### PR TITLE
Correct toupper -> towupper

### DIFF
--- a/headers/Misc.hpp
+++ b/headers/Misc.hpp
@@ -118,7 +118,7 @@ struct ci_wchar_traits : public std::char_traits<wchar_t> {
     static int compare(const wchar_t* s1, const wchar_t* s2, size_t n) {
         while (n-- != 0) {
             if (towupper(*s1) < towupper(*s2)) return -1;
-            if (toupper(*s1) > towupper(*s2)) return 1;
+            if (towupper(*s1) > towupper(*s2)) return 1;
             ++s1; ++s2;
         }
         return 0;


### PR DESCRIPTION
Just noticed this after you merged the PR.
Sorry about that.

Signed-off-by: Randshot <randshot@norealm.xyz>
