### PR TITLE
Removed incorrect check for BUILD_DLL in loading of ASMJIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,16 +159,12 @@ if(FEATURE_INLINENTD MATCHES ON)
 endif()
 
 if(DEP_ASMJIT_NEED MATCHES ON)
-	
-	# only build tests if making exe
-	if(BUILD_DLL MATCHES OFF)
-		# AsmJit is a dep iff inlinetd is on
-		set(ASMJIT_DIR ${PROJECT_SOURCE_DIR}/asmjit)
-		set(ASMJIT_EMBED TRUE)
-	
-		include("${ASMJIT_DIR}/CMakeLists.txt")
-		include_directories(${ASMJIT_DIR}/src)
-	endif()
+	# AsmJit is a dep iff inlinetd is on
+	set(ASMJIT_DIR ${PROJECT_SOURCE_DIR}/asmjit)
+	set(ASMJIT_EMBED TRUE)
+
+	include("${ASMJIT_DIR}/CMakeLists.txt")
+	include_directories(${ASMJIT_DIR}/src)
 endif()
 
 include_directories(${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
ASMJIT should load if FEATURE_INLINENTD is set, the comments incorrectly labeled the ASMJIT loading as test code and so it didn't run if BUILD_DLL was set. This caused the build to fail when FEATURE_INLINENTD and BUILD_DLL were set. I simply removed this check as I believe it was accidently added when duplicating existing code.