### PR TITLE
Fix crash on ErrorLog::pop()

### DIFF
--- a/headers/ErrorLog.hpp
+++ b/headers/ErrorLog.hpp
@@ -41,8 +41,11 @@ public:
 	}
 
 	Error pop() {
-		Error err = m_log.back();
-		m_log.pop_back();
+		Error err = {};
+		if (!m_log.empty()) {
+			err = m_log.back();
+			m_log.pop_back();
+		}
 		return err;
 	}
 


### PR DESCRIPTION
Calling back() on an empty vector results in an assertion.