### PR TITLE
Fixed warning C4005 macro redefinition

### DIFF
--- a/headers/MemProtector.hpp
+++ b/headers/MemProtector.hpp
@@ -6,8 +6,12 @@
 #define POLYHOOK_2_MEMORYPROTECTOR_HPP
 
 #include "headers/Enums.hpp"
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <Windows.h>
 #include <iostream>
 


### PR DESCRIPTION
Fixed warning C4005 macro redefintion caused by MemProtector.hpp not checking if the macro is already defined.