### PR TITLE
Various fixes to allow compilation with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,15 @@ set(HEADER_IMP_SOURCES
 		${PROJECT_SOURCE_DIR}/sources/TestEffectTracker.cpp
 		${PROJECT_SOURCE_DIR}/sources/PageAllocator.cpp)
 
-set(UNIT_TEST_SOURCES 
-		${PROJECT_SOURCE_DIR}/MainTests.cpp
-        ${PROJECT_SOURCE_DIR}/UnitTests/TestDisassembler.cpp
-		${PROJECT_SOURCE_DIR}/UnitTests/TestMemProtector.cpp)
+# only build tests if making exe
+if(BUILD_DLL MATCHES OFF)	
+	set(UNIT_TEST_SOURCES 
+			${PROJECT_SOURCE_DIR}/MainTests.cpp
+			${PROJECT_SOURCE_DIR}/UnitTests/TestDisassembler.cpp
+			${PROJECT_SOURCE_DIR}/UnitTests/TestMemProtector.cpp)
+else()
+	set(UNIT_TEST_SOURCES)
+endif()
 
 # Headers, Sources, and Test for detours
 if(FEATURE_DETOURS MATCHES ON) 

--- a/UnitTests/TestDetourNoTDx64.cpp
+++ b/UnitTests/TestDetourNoTDx64.cpp
@@ -46,7 +46,16 @@ TEST_CASE("Minimal Example", "[AsmJit]") {
 NOINLINE void hookMeInt(int a) {
 	volatile int var = 1;
 	int var2 = var + a;
-	printf("%d %d %I64X\n", var, var2, (uint64_t)_ReturnAddress());
+
+#ifdef _MSC_VER
+	uint64_t retAddress = (uint64_t)_ReturnAddress();
+#elif __GNUC__
+	uint64_t retAddress = (uint64_t)__builtin_return_address(0);
+#else
+	#error "Please implement this for your compiler."
+#endif
+
+	printf("%d %d %I64X\n", var, var2, retAddress);
 }
 
 NOINLINE void hookMeFloat(float a) {

--- a/UnitTests/TestDetourNoTDx64.cpp
+++ b/UnitTests/TestDetourNoTDx64.cpp
@@ -3,7 +3,7 @@
 #include "headers/Detour/ILCallback.hpp"
 #pragma warning( disable : 4244)
 
-#include "headers/tests/TestEffectTracker.hpp"
+#include "headers/Tests/TestEffectTracker.hpp"
 
 /**These tests can spontaneously fail if the compiler desides to optimize away
 the handler or inline the function. NOINLINE attempts to fix the latter, the former
@@ -40,7 +40,7 @@ TEST_CASE("Minimal Example", "[AsmJit]") {
 	rt.release(fn);
 }
 
-#include "headers/Detour/X64Detour.hpp"
+#include "headers/Detour/x64Detour.hpp"
 #include "headers/CapstoneDisassembler.hpp"
 
 NOINLINE void hookMeInt(int a) {

--- a/UnitTests/TestDetourNoTDx86.cpp
+++ b/UnitTests/TestDetourNoTDx86.cpp
@@ -3,7 +3,7 @@
 #include "headers/Detour/ILCallback.hpp"
 #pragma warning( disable : 4244)
 
-#include "headers/tests/TestEffectTracker.hpp"
+#include "headers/Tests/TestEffectTracker.hpp"
 
 /**These tests can spontaneously fail if the compiler desides to optimize away
 the handler or inline the function. NOINLINE attempts to fix the latter, the former
@@ -40,7 +40,7 @@ TEST_CASE("Minimal Asmjit Example", "[AsmJit]") {
 	rt.release(fn);
 }
 
-#include "headers/Detour/X86Detour.hpp"
+#include "headers/Detour/x86Detour.hpp"
 #include "headers/CapstoneDisassembler.hpp"
 
 NOINLINE void hookMeInt(int a) {

--- a/UnitTests/TestDetourNoTDx86.cpp
+++ b/UnitTests/TestDetourNoTDx86.cpp
@@ -76,7 +76,16 @@ NOINLINE void __fastcall hookMeIntFloatDoubleFst(int a, float b, double c) {
 	ans += (float)a;
 	ans += c;
 	ans += b;
-	printf("%d %f %f %f retAddr:%x\n", a, b, c, ans, (uint32_t)_ReturnAddress());
+
+#ifdef _MSC_VER
+	uint32_t retAddress = (uint32_t)_ReturnAddress();
+#elif __GNUC__
+	uint32_t retAddress = (uint32_t)__builtin_return_address(0);
+#else
+	#error "Please implement this for your compiler."
+#endif
+
+	printf("%d %f %f %f retAddr:%x\n", a, b, c, ans, retAddress);
 }
 
 NOINLINE void myCallback(const PLH::ILCallback::Parameters* p, const uint8_t count, const PLH::ILCallback::ReturnValue* retVal) {

--- a/UnitTests/TestDetourx64.cpp
+++ b/UnitTests/TestDetourx64.cpp
@@ -2,10 +2,10 @@
 // Created by steve on 7/9/18.
 //
 #include <Catch.hpp>
-#include "headers/Detour/X64Detour.hpp"
+#include "headers/Detour/x64Detour.hpp"
 #include "headers/CapstoneDisassembler.hpp"
 
-#include "headers/tests/TestEffectTracker.hpp"
+#include "headers/Tests/TestEffectTracker.hpp"
 
 EffectTracker effects;
 

--- a/UnitTests/TestDetourx86.cpp
+++ b/UnitTests/TestDetourx86.cpp
@@ -64,7 +64,8 @@ b:  7f f4                   jg     0x1
 */
 unsigned char hookMe3[] = {0x55, 0x89, 0xE5, 0x89, 0xE5, 0x89, 0xE5, 0x89, 0xE5, 0x90, 0x90, 0x7F, 0xF4};
 
-NOINLINE void __declspec(naked) hookMeLoop() {
+NOINLINE void PH_ATTR_NAKED hookMeLoop() {
+#ifdef _MSC_VER
 	__asm {
 		xor eax, eax
 		start :
@@ -73,6 +74,17 @@ NOINLINE void __declspec(naked) hookMeLoop() {
 			jle start
 			ret
 	}
+#elif __GNUC__
+	asm(
+		"xor %eax, %eax;\n\t"
+		"START: inc %eax;\n\t"
+		"cmp $5, %eax;\n\t"
+		"jle START;\n\t"
+		"ret;"
+	);
+#else
+#error "Please implement this for your compiler!"
+#endif
 }
 
 uint64_t hookMeLoopTramp = NULL;

--- a/UnitTests/TestDetourx86.cpp
+++ b/UnitTests/TestDetourx86.cpp
@@ -5,7 +5,7 @@
 #include "headers/Detour/x86Detour.hpp"
 #include "headers/CapstoneDisassembler.hpp"
 
-#include "headers/tests/TestEffectTracker.hpp"
+#include "headers/Tests/TestEffectTracker.hpp"
 
 /**These tests can spontaneously fail if the compiler desides to optimize away
 the handler or inline the function. NOINLINE attempts to fix the latter, the former

--- a/headers/Detour/ILCallback.hpp
+++ b/headers/Detour/ILCallback.hpp
@@ -21,7 +21,7 @@ namespace PLH {
 			}
 
 			// asm depends on this specific type
-			uint64_t m_arguments[];
+			uint64_t m_arguments[1];
 		};
 
 		struct ReturnValue {

--- a/headers/IHook.hpp
+++ b/headers/IHook.hpp
@@ -13,11 +13,13 @@
 
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define NOINLINE __attribute__((noinline))
+#define PH_ATTR_NAKED __attribute__((naked))
 #define OPTS_OFF _Pragma("GCC push_options") \
 _Pragma("GCC optimize (\"O0\")")
 #define OPTS_ON #pragma GCC pop_options
 #elif defined(_MSC_VER)
 #define NOINLINE __declspec(noinline)
+#define PH_ATTR_NAKED __declspec(naked)
 #define OPTS_OFF __pragma(optimize("", off))
 #define OPTS_ON __pragma(optimize("", on))
 #endif

--- a/headers/Instruction.hpp
+++ b/headers/Instruction.hpp
@@ -6,6 +6,7 @@
 #define POLYHOOK_2_0_INSTRUCTION_HPP
 
 #include <cassert>
+#include <cstring>
 #include <string>
 #include <vector>
 #include <sstream>

--- a/headers/MemProtector.hpp
+++ b/headers/MemProtector.hpp
@@ -12,7 +12,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 #include <iostream>
 
 PLH::ProtFlag operator|(PLH::ProtFlag lhs, PLH::ProtFlag rhs);

--- a/headers/PageAllocator.hpp
+++ b/headers/PageAllocator.hpp
@@ -13,7 +13,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace PLH {
 

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -1,5 +1,7 @@
 #include "headers/Detour/ADetour.hpp"
 
+#include <cmath>
+
 std::optional<PLH::insts_t> PLH::Detour::calcNearestSz(const PLH::insts_t& functionInsts, const uint64_t prolOvrwStartOffset,
 													   uint64_t& prolOvrwEndOffset) {
 

--- a/sources/ILCallback.cpp
+++ b/sources/ILCallback.cpp
@@ -125,8 +125,7 @@ uint64_t PLH::ILCallback::getJitFunc(const asmjit::FuncSignature& sig, const PLH
 	argsStackIdx.setSize(sizeof(uint64_t));
 	
 	// set i = 0
-	cc.mov(i, 0);  
-	UNREFERENCED_PARAMETER(callback);
+	cc.mov(i, 0);
 	//// mov from arguments registers into the stack structure
 	for (uint8_t arg_idx = 0; arg_idx < sig.argCount(); arg_idx++) {
 		const uint8_t argType = sig.args()[arg_idx];

--- a/sources/MemProtector.cpp
+++ b/sources/MemProtector.cpp
@@ -1,7 +1,7 @@
 #include "headers/MemProtector.hpp"
 #include "headers/Enums.hpp"
 
-#include <Windows.h>
+#include <windows.h>
 
 PLH::ProtFlag operator|(PLH::ProtFlag lhs, PLH::ProtFlag rhs) {
 	return static_cast<PLH::ProtFlag>(


### PR DESCRIPTION
These changes allow PolyHook 2 to be built successfully with the MinGW toolchain.

MSVC also builds PH2 successfully with the patches.

Below are tests results with MSVC and MinGW, targeting both 32 and 64 bit, on Release mode:
- MSVC
  - 32: everything passed.
  - 64: 1 test failed on `UnitTests/TestDetourNoTDx64.cpp` in line 114 with: `[!] Error: Cannot fixup IP relative data operation, relocation beyond displacement size`.
- MinGW:
  - 32: 1 test failed on `UnitTests/TestDetourx86.cpp` in line 191.
  - 64: 1 test failed on `UnitTests/TestDetourx64.cpp` in line 120 with: `[!] Error: Function too small to hook safely!`.

The tests were ran with MinGW version 9.2.0 and MSVC 2017 version 15.9.8, on a Windows 10 Pro version 1809 virtual machine.
