### PR TITLE
Allow errors below logging threshold to pushed onto the error log so …

### DIFF
--- a/polyhook2/ErrorLog.hpp
+++ b/polyhook2/ErrorLog.hpp
@@ -20,7 +20,6 @@ public:
 	}
 	
 	void push(std::string msg, ErrorLevel level) {
-		if (level >= m_logLevel)
 			push({ std::move(msg), level });
 	}
 


### PR DESCRIPTION
…they can be retrieved manually