### PR TITLE
Allow a thread handle to be passed to HWBreakPointHook's hook/unHook

### DIFF
--- a/polyhook2/Exceptions/HWBreakPointHook.hpp
+++ b/polyhook2/Exceptions/HWBreakPointHook.hpp
@@ -14,6 +14,9 @@ public:
 	HWBreakPointHook(const char* fnAddress, const char* fnCallback);
 	~HWBreakPointHook();
 
+	bool hook(HANDLE hThread);
+	bool unHook(HANDLE hThread);
+
 	virtual bool hook() override;
 	virtual bool unHook() override;
 	auto getProtectionObject() {


### PR DESCRIPTION
Adds an overload of hook/unHook that takes a HANDLE as a parameter. 

This could be used to apply the hook to all active threads or a specific thread you aren't currently on.