### PR TITLE
cmake: fix Zycore missing headers on installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if(POLYHOOK_DISASM_ZYDIS)
 	set(ZYDIS_BUILD_TOOLS OFF CACHE BOOL "")
 	set(ZYDIS_BUILD_EXAMPLES OFF CACHE BOOL "")
 
+	add_subdirectory(zydis/dependencies/zycore)
 	add_subdirectory(zydis)
 
 	if(MSVC)


### PR DESCRIPTION
fixes regression from e2e2c56a9bc23aa4c45ad3dfdb067b1a629962e2

It copies zycore headers to the installation prefix.

Without it you will get error that `Zycore/Defines.h` is not found.