### PR TITLE
VTableSwapHook2 template class for simpler API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,3 +335,4 @@ CMakeCache.txt
 cmake-*
 _build/
 _install/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	${PROJECT_SOURCE_DIR}/sources/StackCanary.cpp
 	${PROJECT_SOURCE_DIR}/sources/PageAllocator.cpp
 	${PROJECT_SOURCE_DIR}/sources/ErrorLog.cpp
-	${PROJECT_SOURCE_DIR}/sources/UID.cpp )
+	${PROJECT_SOURCE_DIR}/sources/UID.cpp)
 
 #DisAsm/Capstone
 if(POLYHOOK_DISASM_CAPSTONE)
@@ -346,6 +346,7 @@ if(POLYHOOK_FEATURE_VIRTUALS)
 	if(NOT POLYHOOK_BUILD_DLL)
 		target_sources(${PROJECT_NAME} PRIVATE
 			${PROJECT_SOURCE_DIR}/UnitTests/TestVTableSwapHook.cpp
+			${PROJECT_SOURCE_DIR}/UnitTests/TestVTableSwapHook2.cpp
 			${PROJECT_SOURCE_DIR}/UnitTests/TestVFuncSwapHook.cpp)
 	endif()
 endif()

--- a/UnitTests/TestVTableSwapHook2.cpp
+++ b/UnitTests/TestVTableSwapHook2.cpp
@@ -1,0 +1,66 @@
+#include <memory>
+#include <stdexcept>
+
+#include <Catch.hpp>
+
+#include "polyhook2/Virtuals/VTableSwapHook.hpp"
+#include "polyhook2/Tests/StackCanary.hpp"
+
+// original class
+
+class MyClass {
+public:
+	virtual ~MyClass() {}
+
+	virtual int method1(int x) {
+		return 2 * x;
+	}
+
+	virtual int method2(int x, int y) {
+		return x + y;
+	}
+};
+
+// virtual function hooks
+
+int myclass_method1(MyClass* pThis, int x);
+int myclass_method2(MyClass* pThis, int x, int y);
+
+// helper typedefs, and unique_ptr for storing the hook
+
+typedef PLH::VFunc<1, decltype(&myclass_method1)> VMethod1;
+typedef PLH::VFunc<2, decltype(&myclass_method2)> VMethod2;
+typedef PLH::VTableSwapHook2<MyClass, VMethod1, VMethod2> VTableMyClass;
+std::unique_ptr<VTableMyClass> hook = nullptr;
+
+// hook implementations
+
+NOINLINE int myclass_method1(MyClass* pThis, int x) {
+	if (!hook)
+		throw std::runtime_error("original function not hooked");
+	return hook->origFunc<VMethod1>(pThis, x) + 1;
+}
+
+NOINLINE int myclass_method2(MyClass* pThis, int x, int y) {
+	if (!hook)
+		throw std::runtime_error("original function not hooked");
+	return hook->origFunc<VMethod2>(pThis, x, y) + 2;
+}
+
+// test case
+
+TEST_CASE("VTableSwap2 tests", "[VTableSwap2]") {
+	std::shared_ptr<MyClass> pClass(new MyClass); 
+
+	SECTION("Verify vtable redirected") {
+		PLH::StackCanary canary;
+		REQUIRE(pClass->method1(3) == 6);
+		REQUIRE(pClass->method2(13, 9) == 22);
+		hook = std::make_unique<VTableMyClass>(pClass.get(), VMethod1(&myclass_method1), VMethod2(&myclass_method2));
+		REQUIRE(pClass->method1(3) == 7);
+		REQUIRE(pClass->method2(13, 9) == 24);
+		hook = nullptr;
+		REQUIRE(pClass->method1(3) == 6);
+		REQUIRE(pClass->method2(13, 9) == 22);
+	}
+}

--- a/polyhook2/Virtuals/VTableSwapHook.hpp
+++ b/polyhook2/Virtuals/VTableSwapHook.hpp
@@ -10,6 +10,7 @@
 #include "polyhook2/Misc.hpp"
 
 namespace PLH {
+
 typedef std::map<uint16_t, uint64_t> VFuncMap;
 
 class VTableSwapHook : public PLH::IHook {
@@ -40,5 +41,64 @@ private:
 	VFuncMap m_origVFuncs;
 	bool m_Hooked;
 };
+
+
+// storage class for address of a virtual function
+// also stores the function pointer type and index number on the class level
+template<uint16_t I, typename FuncPtr>
+struct VFunc {
+	VFunc() : func(nullptr) {};
+	VFunc(FuncPtr f) : func(f) {};
+	const FuncPtr func;
+	static const uint16_t func_index;
+	typedef FuncPtr func_type;
+};
+
+// definition of constant must reside outside class declaration
+template<uint16_t I, typename FuncPtr> const uint16_t VFunc<I, FuncPtr>::func_index = I;
+
+namespace detail {
+
+	// helper function to convert sequence of VFunc structs into a VFuncMap
+	// using recursive template definition
+	inline PLH::VFuncMap make_vfunc_map()
+	{
+		return PLH::VFuncMap{ };
+	};
+
+	template<uint16_t I, typename FuncPtr, typename ... VFuncTypes>
+	inline PLH::VFuncMap make_vfunc_map(VFunc<I, FuncPtr> vfunc, VFuncTypes ... vfuncs)
+	{
+		PLH::VFuncMap map{ {I, reinterpret_cast<uint64_t>(vfunc.func)} };
+		map.merge(make_vfunc_map(vfuncs ...));
+		return map;
+	};
+
+}
+
+template<class ClassType, typename ... VFuncTypes>
+class VTableSwapHook2 : private VTableSwapHook {
+public:
+	VTableSwapHook2(ClassType* instance, VFuncTypes ... newFuncs)
+		: PLH::VTableSwapHook((char*)instance, detail::make_vfunc_map(newFuncs ...))
+	{
+		if (!hook())
+			throw std::runtime_error(std::string("failed to hook ") + typeid(ClassType).name());
+	};
+
+	template<typename VFuncType, typename ... Args>
+	auto origFunc(Args&& ... args) {
+		auto func = reinterpret_cast<typename VFuncType::func_type>(getOriginals().at(VFuncType::func_index));
+		if (func == nullptr)
+			throw std::runtime_error("original virtual function pointer is null");
+		return func(std::forward<Args>(args) ...);
+	};
+
+	virtual ~VTableSwapHook2()
+	{
+		unHook();
+	}
+};
+
 }
 #endif

--- a/sources/VTableSwapHook.cpp
+++ b/sources/VTableSwapHook.cpp
@@ -4,6 +4,10 @@ PLH::VTableSwapHook::VTableSwapHook(const char* Class, const VFuncMap& redirectM
 	: VTableSwapHook((uint64_t)Class, redirectMap)
 {}
 
+PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class)
+	: VTableSwapHook(Class, PLH::VFuncMap{ })
+{}
+
 PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, const VFuncMap& redirectMap) 
 	: m_class(Class)
 	, m_redirectMap(redirectMap)


### PR DESCRIPTION
As I was migrating some code from the old polyhook to polyhook2, I found myself in need of using the new VTableSwapHook API since the VFuncDetour is no longer part of polyhook2. I found the interface somewhat non-intuitive to use, especially with all the type casts that are required to convert back and forth between integers and function pointers, and therefore I wrote a wrapper template class that is easier to use, with more straightforward boilerplate.

The template does type checking on the function signatures so you cannot accidentally hook a method with the wrong type signature. It also hooks in the constructor (throwing an exception on failure), and unhooks on destruction, following the RAII idiom (when a hook is used as a resource, which would be a common use case). Repeated hooking/unhooking can then be controlled simply by holding a unique_ptr to the wrapper class.

I was wondering if there would be interest from upstream in maintaining such wrapper classes? This one is just for VTableSwapHook but I also have (a much simpler) one for IatHook, and I'm sure it's possible to wrap other classes similarly.

Draft code attached to this pull request, including a test case that demonstrates the use.