### PR TITLE
Allow clients to provide their own logging callback.

### DIFF
--- a/MainTests.cpp
+++ b/MainTests.cpp
@@ -5,7 +5,9 @@
 #include "polyhook2/ErrorLog.hpp"
 int main(int argc, char* const argv[]) {
 	std::cout << "Welcome to PolyHook -By- Stevemk14ebr" << std::endl;
-	PLH::ErrorLog::singleton().setLogLevel(PLH::ErrorLevel::INFO);
+	auto logger = std::make_shared<PLH::ErrorLog>();
+	logger->setLogLevel(PLH::ErrorLevel::INFO);
+	PLH::Log::registerLogger(logger);
 	int result = Catch::Session().run(argc, argv);
 
 	getchar();

--- a/polyhook2/ErrorLog.hpp
+++ b/polyhook2/ErrorLog.hpp
@@ -8,14 +8,35 @@
 
 namespace PLH {
 
+// abstract base class for logging, clients should subclass this to intercept log messages
+class Logger
+{
+public:
+	virtual void log(std::string msg, ErrorLevel level) = 0;
+	virtual ~Logger() {};
+};
+
+// class for registering client loggers
+class Log
+{
+private:
+	static std::shared_ptr<Logger> m_logger;
+public:
+	static void registerLogger(std::shared_ptr<Logger> logger);
+	static void log(std::string msg, ErrorLevel level);
+};
+
+// simple logger implementation
+
 struct Error {
 	std::string msg;
 	ErrorLevel lvl;
 };
 
-class ErrorLog {
+class ErrorLog : public Logger {
 public:
 	void setLogLevel(ErrorLevel level);
+	void log(std::string msg, ErrorLevel level);
 	void push(std::string msg, ErrorLevel level);
 	void push(Error err);
 	Error pop();
@@ -24,6 +45,7 @@ private:
 	std::vector<Error> m_log;
 	ErrorLevel m_logLevel = ErrorLevel::INFO;
 };
+
 }
 
 #endif

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -35,12 +35,12 @@ std::optional<PLH::insts_t> PLH::Detour::calcNearestSz(const PLH::insts_t& funct
 
 bool PLH::Detour::followJmp(PLH::insts_t& functionInsts, const uint8_t curDepth, const uint8_t depth) {
 	if (functionInsts.size() <= 0) {
-		ErrorLog::singleton().push("Couldn't decompile instructions at followed jmp", ErrorLevel::WARN);
+		Log::log("Couldn't decompile instructions at followed jmp", ErrorLevel::WARN);
 		return false;
 	}
 
 	if (curDepth >= depth) {
-		ErrorLog::singleton().push("Prologue jmp resolution hit max depth, prologue too deep", ErrorLevel::WARN);
+		Log::log("Prologue jmp resolution hit max depth, prologue too deep", ErrorLevel::WARN);
 		return false;
 	}
 
@@ -51,7 +51,7 @@ bool PLH::Detour::followJmp(PLH::insts_t& functionInsts, const uint8_t curDepth,
 
 	// might be a mem type like jmp rax, not supported
 	if (!functionInsts.front().hasDisplacement()) {
-		ErrorLog::singleton().push("Branching instruction without displacement encountered", ErrorLevel::WARN);
+		Log::log("Branching instruction without displacement encountered", ErrorLevel::WARN);
 		return false;
 	}
 
@@ -163,7 +163,7 @@ bool PLH::Detour::buildRelocationList(insts_t& prologue, const uint64_t roundPro
 				*/
 				std::string err = "Cannot fixup IP relative data operation, needed disp. beyond max disp range: " + inst.getFullName() +
 					" needed: " + int_to_hex((uint64_t)std::llabs(delta)) + " raw: " + int_to_hex(delta) +  " max: " + int_to_hex(maxInstDisp);
-				ErrorLog::singleton().push(err, ErrorLevel::SEV);
+				Log::log(err, ErrorLevel::SEV);
 				return false;
 			}else {
 				instsNeedingReloc.push_back(inst);

--- a/sources/AVehHook.cpp
+++ b/sources/AVehHook.cpp
@@ -11,7 +11,7 @@ PLH::AVehHook::AVehHook() {
 	if (m_refCount.m_count == 0) {
 		m_hHandler = AddVectoredExceptionHandler(1, &AVehHook::Handler);
 		if (m_hHandler == NULL) {
-			ErrorLog::singleton().push("Failed to add VEH", ErrorLevel::SEV);
+			Log::log("Failed to add VEH", ErrorLevel::SEV);
 		}
 	}
 
@@ -27,7 +27,7 @@ PLH::AVehHook::~AVehHook() {
 		ULONG status = RemoveVectoredExceptionHandler(m_hHandler);
 		m_hHandler = nullptr;
 		if (status == 0) {
-			ErrorLog::singleton().push("Failed to remove VEH", ErrorLevel::SEV);
+			Log::log("Failed to remove VEH", ErrorLevel::SEV);
 		}
 	}
 }

--- a/sources/CapstoneDisassembler.cpp
+++ b/sources/CapstoneDisassembler.cpp
@@ -7,7 +7,7 @@ PLH::CapstoneDisassembler::CapstoneDisassembler(const PLH::Mode mode) : ADisasse
 	const cs_mode csMode = (mode == PLH::Mode::x64 ? CS_MODE_64 : CS_MODE_32);
 	if (cs_open(CS_ARCH_X86, csMode, &m_capHandle) != CS_ERR_OK) {
 		m_capHandle = NULL;
-		ErrorLog::singleton().push("Failed to initialize capstone", ErrorLevel::SEV);
+		Log::log("Failed to initialize capstone", ErrorLevel::SEV);
 	}
 
 	cs_option(m_capHandle, CS_OPT_DETAIL, CS_OPT_ON);

--- a/sources/EatHook.cpp
+++ b/sources/EatHook.cpp
@@ -36,14 +36,14 @@ bool PLH::EatHook::hook() {
 		m_allocator = new PageAllocator(m_moduleBase, 0x80000000);
 		m_trampoline = m_allocator->getBlock(m_trampolineSize);
 		if (m_trampoline == 0) {
-			ErrorLog::singleton().push("EAT hook offset is > 32bit's. Allocation of trampoline necessary and failed to find free page within range", ErrorLevel::INFO);
+			Log::log("EAT hook offset is > 32bit's. Allocation of trampoline necessary and failed to find free page within range", ErrorLevel::INFO);
 			return false;
 		}
 
 		PLH::ADisassembler::writeEncoding(makeAgnosticJmp(m_trampoline, m_fnCallback), *this);
 		offset = m_trampoline - m_moduleBase;
 
-		ErrorLog::singleton().push("EAT hook offset is > 32bit's. Allocation of trampoline necessary", ErrorLevel::INFO);
+		Log::log("EAT hook offset is > 32bit's. Allocation of trampoline necessary", ErrorLevel::INFO);
 	}
 
 	// Just like IAT, EAT is by default a writeable section
@@ -103,7 +103,7 @@ uint32_t* PLH::EatHook::FindEatFunction(const std::string& apiName, const std::w
 	}
 
 	if (pExportAddress == nullptr) {
-		ErrorLog::singleton().push("Failed to find export address from requested dll", ErrorLevel::SEV);
+		Log::log("Failed to find export address from requested dll", ErrorLevel::SEV);
 	}
 	return pExportAddress;
 }
@@ -118,7 +118,7 @@ uint32_t* PLH::EatHook::FindEatFunctionInModule(const std::string& apiName) {
 	auto* pDataDir = (IMAGE_DATA_DIRECTORY*)pNT->OptionalHeader.DataDirectory;
 
 	if (pDataDir[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress == NULL) {
-		ErrorLog::singleton().push("PEs without export tables are unsupported", ErrorLevel::SEV);
+		Log::log("PEs without export tables are unsupported", ErrorLevel::SEV);
 		return NULL;
 	}
 
@@ -141,6 +141,6 @@ uint32_t* PLH::EatHook::FindEatFunctionInModule(const std::string& apiName) {
 		return pExportAddress;
 	}
 
-	ErrorLog::singleton().push("API not found before end of EAT", ErrorLevel::SEV);
+	Log::log("API not found before end of EAT", ErrorLevel::SEV);
 	return nullptr;
 }

--- a/sources/ErrorLog.cpp
+++ b/sources/ErrorLog.cpp
@@ -1,10 +1,26 @@
 #include "polyhook2/ErrorLog.hpp"
 
+std::shared_ptr<PLH::Logger> PLH::Log::m_logger = nullptr;
+
+void PLH::Log::registerLogger(std::shared_ptr<Logger> logger) {
+	m_logger = logger;
+}
+
+void PLH::Log::log(std::string msg, ErrorLevel level) {
+	if (m_logger) m_logger->log(std::move(msg), level);
+}
+
 void PLH::ErrorLog::setLogLevel(PLH::ErrorLevel level) {
 	m_logLevel = level;
 }
 
-void PLH::ErrorLog::push(std::string msg, PLH::ErrorLevel level) {
+void PLH::ErrorLog::log(std::string msg, ErrorLevel level)
+{
+	push({ std::move(msg), level });
+}
+
+void PLH::ErrorLog::push(std::string msg, ErrorLevel level)
+{
 	push({ std::move(msg), level });
 }
 

--- a/sources/HWBreakPointHook.cpp
+++ b/sources/HWBreakPointHook.cpp
@@ -32,7 +32,7 @@ bool PLH::HWBreakPointHook::hook()
 	ZeroMemory(&ctx, sizeof(ctx));
 	ctx.ContextFlags = CONTEXT_DEBUG_REGISTERS;
 	if (!GetThreadContext(m_hThread, &ctx)) {
-		ErrorLog::singleton().push("Failed to get thread context", ErrorLevel::SEV);
+		Log::log("Failed to get thread context", ErrorLevel::SEV);
 		return false;
 	}
 
@@ -45,7 +45,7 @@ bool PLH::HWBreakPointHook::hook()
 	}
 
 	if (!freeReg) {
-		ErrorLog::singleton().push("All HW BP's are used", ErrorLevel::SEV);
+		Log::log("All HW BP's are used", ErrorLevel::SEV);
 		return false;
 	}
 
@@ -72,7 +72,7 @@ bool PLH::HWBreakPointHook::hook()
 
 	// undefined, suspendthread needed
 	if (!SetThreadContext(m_hThread, &ctx)) {
-		ErrorLog::singleton().push("Failed to set thread context", ErrorLevel::SEV);
+		Log::log("Failed to set thread context", ErrorLevel::SEV);
 	}
 
 	return true;
@@ -83,7 +83,7 @@ bool PLH::HWBreakPointHook::unHook() {
 	ZeroMemory(&ctx, sizeof(ctx));
 	ctx.ContextFlags = CONTEXT_DEBUG_REGISTERS;
 	if (!GetThreadContext(m_hThread, &ctx)) {
-		ErrorLog::singleton().push("Failed to get thread context", ErrorLevel::SEV);
+		Log::log("Failed to get thread context", ErrorLevel::SEV);
 		return false;
 	}
 
@@ -91,7 +91,7 @@ bool PLH::HWBreakPointHook::unHook() {
 
 	//Still need to call suspend thread
 	if (!SetThreadContext(m_hThread, &ctx)) {
-		ErrorLog::singleton().push("Failed to set thread context", ErrorLevel::SEV);
+		Log::log("Failed to set thread context", ErrorLevel::SEV);
 		return false;
 	}
 	return true;

--- a/sources/ILCallback.cpp
+++ b/sources/ILCallback.cpp
@@ -102,7 +102,7 @@ uint64_t PLH::ILCallback::getJitFunc(const asmjit::FuncSignature& sig, const asm
 		} else if (isXmmReg(argType)) {
 			arg = cc.newXmm();
 		} else {
-			ErrorLog::singleton().push("Parameters wider than 64bits not supported", ErrorLevel::SEV);
+			Log::log("Parameters wider than 64bits not supported", ErrorLevel::SEV);
 			return 0;
 		}
 
@@ -136,7 +136,7 @@ uint64_t PLH::ILCallback::getJitFunc(const asmjit::FuncSignature& sig, const asm
 		} else if(isXmmReg(argType)) {
 			cc.movq(argsStackIdx, argRegisters.at(argIdx).as<asmjit::x86::Xmm>());
 		} else {
-			ErrorLog::singleton().push("Parameters wider than 64bits not supported", ErrorLevel::SEV);
+			Log::log("Parameters wider than 64bits not supported", ErrorLevel::SEV);
 			return 0;
 		}
 
@@ -173,7 +173,7 @@ uint64_t PLH::ILCallback::getJitFunc(const asmjit::FuncSignature& sig, const asm
 		}else if (isXmmReg(argType)) {
 			cc.movq(argRegisters.at(arg_idx).as<asmjit::x86::Xmm>(), argsStackIdx);
 		}else {
-			ErrorLog::singleton().push("Parameters wider than 64bits not supported", ErrorLevel::SEV);
+			Log::log("Parameters wider than 64bits not supported", ErrorLevel::SEV);
 			return 0;
 		}
 
@@ -248,7 +248,7 @@ uint64_t PLH::ILCallback::getJitFunc(const asmjit::FuncSignature& sig, const asm
 	code.relocateToBase(m_callbackBuf);
 	code.copyFlattenedData((unsigned char*)m_callbackBuf, size);
 
-	ErrorLog::singleton().push("JIT Stub:\n" + std::string(log.data()), ErrorLevel::INFO);
+	Log::log("JIT Stub:\n" + std::string(log.data()), ErrorLevel::INFO);
 	return m_callbackBuf;
 }
 

--- a/sources/IatHook.cpp
+++ b/sources/IatHook.cpp
@@ -74,7 +74,7 @@ IMAGE_THUNK_DATA* PLH::IatHook::FindIatThunk(const std::string& dllName, const s
 	}
 
 	if (pThunk == nullptr) {
-		ErrorLog::singleton().push("Failed to find thunk for api from requested dll", ErrorLevel::SEV);
+		Log::log("Failed to find thunk for api from requested dll", ErrorLevel::SEV);
 	}
 	return pThunk;
 }
@@ -89,7 +89,7 @@ IMAGE_THUNK_DATA* PLH::IatHook::FindIatThunkInModule(void* moduleBase, const std
 	auto* pDataDir = (IMAGE_DATA_DIRECTORY*)pNT->OptionalHeader.DataDirectory;
 
 	if (pDataDir[IMAGE_DIRECTORY_ENTRY_IMPORT].VirtualAddress == NULL) {
-		ErrorLog::singleton().push("PEs without import tables are unsupported", ErrorLevel::SEV);
+		Log::log("PEs without import tables are unsupported", ErrorLevel::SEV);
 		return nullptr;
 	}
 
@@ -110,7 +110,7 @@ IMAGE_THUNK_DATA* PLH::IatHook::FindIatThunkInModule(void* moduleBase, const std
 			RVA2VA(uintptr_t, moduleBase, pImports[i].FirstThunk);
 
 		if (!pOriginalThunk) {
-			ErrorLog::singleton().push("IAT's without valid original thunk are un-supported", ErrorLevel::SEV);
+			Log::log("IAT's without valid original thunk are un-supported", ErrorLevel::SEV);
 			return nullptr;
 		}
 
@@ -131,6 +131,6 @@ IMAGE_THUNK_DATA* PLH::IatHook::FindIatThunkInModule(void* moduleBase, const std
 		}
 	}
 
-	ErrorLog::singleton().push("Thunk not found before end of IAT", ErrorLevel::SEV);
+	Log::log("Thunk not found before end of IAT", ErrorLevel::SEV);
 	return nullptr;
 }

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -7,13 +7,13 @@ PLH::ZydisDisassembler::ZydisDisassembler(PLH::Mode mode) : ADisassembler(mode),
 		(mode == PLH::Mode::x64) ? ZYDIS_MACHINE_MODE_LONG_64 : ZYDIS_MACHINE_MODE_LONG_COMPAT_32,
 		(mode == PLH::Mode::x64) ? ZYDIS_ADDRESS_WIDTH_64 : ZYDIS_ADDRESS_WIDTH_32)))
 	{
-		ErrorLog::singleton().push("Failed to initialize zydis decoder", ErrorLevel::SEV);
+		Log::log("Failed to initialize zydis decoder", ErrorLevel::SEV);
 		return;
 	}
 
 	if (ZYAN_FAILED(ZydisFormatterInit(m_formatter, ZYDIS_FORMATTER_STYLE_INTEL)))
 	{
-		ErrorLog::singleton().push("Failed to initialize zydis formatter", ErrorLevel::SEV);
+		Log::log("Failed to initialize zydis formatter", ErrorLevel::SEV);
 		return;
 	}
 


### PR DESCRIPTION
To intercept the polyhook log, clients have to periodically call PLH::ErrorLog::singleton().pop() until the log queue is empty, which is somewhat inconvenient. This patch allows clients to register their own logging callback, ensuring that log messages can be captured by the client instantly, allowing different logging systems from the default, and also allowing the client to simply disable logging if so desired.

I've chosen not to register any logger by default, since I imagine most applications will want to implement their own logging callback. The default logger can be enabled with (also see MainTests.cpp):

```cpp
auto logger = std::make_shared<PLH::ErrorLog>();
PLH::Log::registerLogger(logger);
```

It might make sense to eventually deprecate PLH::ErrorLog from the main API and move it to MainTests.cpp to serve as an example. I've left it in the main API as for now.

Implementation based on https://stackoverflow.com/a/1136971