### PR TITLE
Variable initialisation fix.

### DIFF
--- a/UnitTests/TestVTableSwapHook.cpp
+++ b/UnitTests/TestVTableSwapHook.cpp
@@ -70,4 +70,18 @@ TEST_CASE("VTableSwap tests", "[VTableSwap]") {
 		REQUIRE(vTblSwapEffects.PopEffect().didExecute());
 		REQUIRE(hook.unHook());
 	}
+
+	SECTION("Verify invalid virtual function behaviour") {
+		PLH::StackCanary canary;
+		PLH::VFuncMap redirect = { {(uint16_t)10000, (uint64_t)&hkVirtNoParams} };
+		PLH::VTableSwapHook hook((char*)ClassToHook.get(), redirect);
+		REQUIRE(!hook.hook());
+		origVFuncs = hook.getOriginals();
+		REQUIRE(origVFuncs.size() == 0);
+
+		vTblSwapEffects.PushEffect();
+		ClassToHook->NoParamVirt();
+		REQUIRE(!vTblSwapEffects.PopEffect().didExecute());
+		REQUIRE(!hook.unHook());
+	}
 }

--- a/sources/VFuncSwapHook.cpp
+++ b/sources/VFuncSwapHook.cpp
@@ -6,8 +6,12 @@ PLH::VFuncSwapHook::VFuncSwapHook(const char* Class, const VFuncMap& redirectMap
 
 PLH::VFuncSwapHook::VFuncSwapHook(const uint64_t Class, const VFuncMap& redirectMap, VFuncMap* userOrigMap) 
 	: m_class(Class)
+	, m_vtable(nullptr)
+	, m_vFuncCount(0)
 	, m_redirectMap(redirectMap)
+	, m_origVFuncs()
 	, m_userOrigMap(userOrigMap)
+	, m_Hooked(false)
 {}
 
 bool PLH::VFuncSwapHook::hook() {

--- a/sources/VTableSwapHook.cpp
+++ b/sources/VTableSwapHook.cpp
@@ -9,8 +9,13 @@ PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class)
 {}
 
 PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, const VFuncMap& redirectMap) 
-	: m_class(Class)
+	: m_newVtable(nullptr)
+	, m_origVtable(nullptr)
+	, m_class(Class)
+	, m_vFuncCount(0)
 	, m_redirectMap(redirectMap)
+	, m_origVFuncs()
+	, m_Hooked(false)
 {}
 
 bool PLH::VTableSwapHook::hook() {


### PR DESCRIPTION
I ran into a rather subtle bug when attempting to hook a VTableSwapHook with an invalid virtual function index. For some reason, m_Hooked was set to true even if the hook failed. It turns out this can happen simply because m_Hooked is never initialised in this case. This patch fixes this by fully initialising all member variables of VTableSwapHook and VFuncSwapHook, and also adds a test case.