### PR TITLE
Fix debug test failure.

### DIFF
--- a/UnitTests/TestVTableSwapHook.cpp
+++ b/UnitTests/TestVTableSwapHook.cpp
@@ -70,18 +70,4 @@ TEST_CASE("VTableSwap tests", "[VTableSwap]") {
 		REQUIRE(vTblSwapEffects.PopEffect().didExecute());
 		REQUIRE(hook.unHook());
 	}
-
-	SECTION("Verify invalid virtual function behaviour") {
-		PLH::StackCanary canary;
-		PLH::VFuncMap redirect = { {(uint16_t)10000, (uint64_t)&hkVirtNoParams} };
-		PLH::VTableSwapHook hook((char*)ClassToHook.get(), redirect);
-		REQUIRE(!hook.hook());
-		origVFuncs = hook.getOriginals();
-		REQUIRE(origVFuncs.size() == 0);
-
-		vTblSwapEffects.PushEffect();
-		ClassToHook->NoParamVirt();
-		REQUIRE(!vTblSwapEffects.PopEffect().didExecute());
-		REQUIRE(!hook.unHook());
-	}
 }


### PR DESCRIPTION
Unfortunately in my previous patch in #75, the newly added test fails under the debug build. It's entirely my fault for not testing the debug build separately. Attached is a possible fix but I have some design questions, and so maybe a different fix is needed depending what you want.

1. Is the logging as in the patch appropriate? If so, what is the precise convention for the different levels? I've assumed INFO is for purely informative messages, WARN is for warning messages that are not going to crash the application (any recoverable error, e.g. failing to hook), and SEV is for severe errors that are likely going to cause crashes. See for instance https://stackoverflow.com/a/2031209 for a classical interpretation. Is that correct?

2. The debug build test suite failure in question was caused by an assert statement (vtable index exceeding number of virtual functions to be precise; ``assert(p.first < m_vFuncCount);``, and also ``assert(m_Hooked);`` in the unHook method): this caused the debug build to crash, whilst the release build successfully recovered from it. I noticed in quite a few places in the library the following pattern:

    ```cpp
    assert(condition);
    if (!condition) { /* recovery code, log... */ return false; }
    /* some stuff requiring condition to be true */
    return true;
    ```

    I find this a bit confusing, i.e. the debug builds will terminate on the assert, whilst the release builds will "just work", since there is a recovery in place. Is this design intentional? If so then probably the patch as I have it is not acceptable, but then we'll have to exclude certain tests from the debug build, which I personally would rather not do unless there's a good reason. The asserts are not consistently used, e.g. there may be an ``assert(m_Hooked);`` in the unhook method, but no corresponding ``assert(!m_Hooked);`` in the hook method. I would propose to simply get rid of them since the return value of these methods already indicates failure, and the failures appear to be often recoverable (certainly for VTableSwapHook, haven't checked the others in detail).

I'd welcome your thoughts on this.