### PR TITLE
detour: fix compilation of x64detour

### DIFF
--- a/polyhook2/Detour/x64Detour.hpp
+++ b/polyhook2/Detour/x64Detour.hpp
@@ -5,6 +5,7 @@
 #ifndef POLYHOOK_2_X64DETOUR_HPP
 #define POLYHOOK_2_X64DETOUR_HPP
 
+#include <functional>
 #include <optional>
 using namespace std::placeholders;
 


### PR DESCRIPTION
std::placeholders is part of functional header

fixes #87 