### PR TITLE
- fix vc2019 compiler error for unit-tests;

### DIFF
--- a/UnitTests/TestDisassembler.cpp
+++ b/UnitTests/TestDisassembler.cpp
@@ -144,7 +144,7 @@ TEMPLATE_TEST_CASE("Test Disassemblers x64", "[ADisassembler],[CapstoneDisassemb
 	uint64_t PrevInstAddress = (uint64_t)&x64ASM.front();
 	size_t   PrevInstSize = 0;
 
-	std::vector<char*> CorrectMnemonic = {"mov", "mov", "push", "sub", "mov", "mov", "mov", "cmp", "jne", "call", "jmp"};
+	std::vector<const char*> CorrectMnemonic = {"mov", "mov", "push", "sub", "mov", "mov", "mov", "cmp", "jne", "call", "jmp"};
 	std::vector<uint8_t> CorrectSizes = {5, 5, 1, 4, 3, 2, 3, 3, 2, 5, 6};
 
 	SECTION("Check disassembler integrity") {
@@ -286,7 +286,7 @@ TEMPLATE_TEST_CASE("Test Disassemblers x86", "[ADisassembler],[CapstoneDisassemb
 	// TODO: full buffer isn't disassembled
 	//Instructions.erase(Instructions.begin() + 0x9, Instructions.end());
 	std::vector<uint8_t> CorrectSizes = {2, 6, 5, 6, 2, 6, 2};
-	std::vector<char*> CorrectMnemonic = {"add", "add", "add", "jne", "je", "lea", "jmp"};
+	std::vector<const char*> CorrectMnemonic = {"add", "add", "add", "jne", "je", "lea", "jmp"};
 
 	uint64_t PrevInstAddress = (uint64_t)&x86ASM.front();
 	size_t   PrevInstSize = 0;

--- a/UnitTests/TestEatHook.cpp
+++ b/UnitTests/TestEatHook.cpp
@@ -67,14 +67,14 @@ int __stdcall hkEatMessageBox(HWND    hWnd,
 	UNREFERENCED_PARAMETER(hWnd);
 	PLH::StackCanary canary;
 	tEatMessageBox MsgBox = (tEatMessageBox)oEatMessageBox;
-	MsgBox(0, "My Hook", "text", 0);
+	MsgBox(0, TEXT("My Hook"), TEXT("text"), 0);
 	eatEffectTracker.PeakEffect().trigger();
 	return 1;
 }
 
 TEST_CASE("Eat winapi tests", "[EatHook]") {
 	PLH::StackCanary canary;
-	LoadLibrary("User32.dll");
+	LoadLibrary(TEXT("User32.dll"));
 
 	PLH::EatHook hook("MessageBoxA", L"User32.dll", (char*)&hkEatMessageBox, (uint64_t*)&oEatMessageBox);
 	REQUIRE(hook.hook());
@@ -83,7 +83,7 @@ TEST_CASE("Eat winapi tests", "[EatHook]") {
 
 	// force walk of EAT
 	tEatMessageBox MsgBox = (tEatMessageBox)GetProcAddress(GetModuleHandleA("User32.dll"), "MessageBoxA");
-	MsgBox(0, "test", "test", 0);
+	MsgBox(0, TEXT("test"), TEXT("test"), 0);
 	REQUIRE(eatEffectTracker.PopEffect().didExecute());
 	hook.unHook();
 }

--- a/polyhook2/PE/PEB.hpp
+++ b/polyhook2/PE/PEB.hpp
@@ -26,7 +26,6 @@
 #endif /* !_IA64_ */
 #endif
 
-#define NOMINMAX
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/polyhook2/PageAllocator.hpp
+++ b/polyhook2/PageAllocator.hpp
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <cassert>
 #include <limits>
-#define NOMINMAX
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif


### PR DESCRIPTION
The vc2019 cannot compile the code (UnitTests\TestDisassembler.cpp) with error C2440:

```
error C2440: 'initializing': cannot convert from 'initializer list' to 'std::vector<char *,std::allocator<char *>>'
note: No constructor could take the source type, or constructor overload resolution was ambiguous
```