### PR TITLE
User-configurable max recursion depth in Detour::followJmp for x86Detour and x64Detour

### DIFF
--- a/polyhook2/Detour/x64Detour.hpp
+++ b/polyhook2/Detour/x64Detour.hpp
@@ -27,9 +27,9 @@ public:
 	    ALL =  CODE_CAVE | INPLACE | VALLOC2, // first try to allocate, then fallback to code cave if not supported (will not fallback on failure of allocation)
     };
 
-	x64Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis);
+	x64Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth = c_maxDepth);
 
-	x64Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis);
+	x64Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth = c_maxDepth);
 	virtual ~x64Detour() override;
 	virtual bool hook() override;
 	virtual bool unHook() override;

--- a/polyhook2/Detour/x86Detour.hpp
+++ b/polyhook2/Detour/x86Detour.hpp
@@ -19,9 +19,9 @@ namespace PLH {
 
 class x86Detour : public Detour {
 public:
-	x86Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis);
+	x86Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth = c_maxDepth);
 
-	x86Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis);
+	x86Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth = c_maxDepth);
 	virtual ~x86Detour() = default;
 	virtual bool hook() override;
 

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -33,13 +33,13 @@ std::optional<PLH::insts_t> PLH::Detour::calcNearestSz(const PLH::insts_t& funct
 	return std::nullopt;
 }
 
-bool PLH::Detour::followJmp(PLH::insts_t& functionInsts, const uint8_t curDepth, const uint8_t depth) {
+bool PLH::Detour::followJmp(PLH::insts_t& functionInsts, const uint8_t curDepth, const uint8_t maxDepth) {
 	if (functionInsts.size() <= 0) {
 		Log::log("Couldn't decompile instructions at followed jmp", ErrorLevel::WARN);
 		return false;
 	}
 
-	if (curDepth >= depth) {
+	if (curDepth >= maxDepth) {
 		Log::log("Prologue jmp resolution hit max depth, prologue too deep", ErrorLevel::WARN);
 		return false;
 	}
@@ -57,7 +57,7 @@ bool PLH::Detour::followJmp(PLH::insts_t& functionInsts, const uint8_t curDepth,
 
 	uint64_t dest = functionInsts.front().getDestination();
 	functionInsts = m_disasm.disassemble(dest, dest, dest + 100, *this);
-	return followJmp(functionInsts, curDepth + 1); // recurse
+	return followJmp(functionInsts, curDepth + 1, maxDepth); // recurse
 }
 
 void PLH::Detour::writeNop(uint64_t base, uint32_t size) {

--- a/sources/x64Detour.cpp
+++ b/sources/x64Detour.cpp
@@ -9,11 +9,11 @@
 #include "polyhook2/Misc.hpp"
 #include "polyhook2/MemProtector.hpp"
 
-PLH::x64Detour::x64Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis), m_allocator(8, 100) {
+PLH::x64Detour::x64Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis, maxDepth), m_allocator(8, 100) {
 
 }
 
-PLH::x64Detour::x64Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis), m_allocator(8, 100) {
+PLH::x64Detour::x64Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis, maxDepth), m_allocator(8, 100) {
 
 }
 
@@ -225,7 +225,7 @@ bool PLH::x64Detour::hook() {
 		return false;
 	}
 
-	if (!followJmp(insts)) {
+	if (!followJmp(insts, 0, m_maxDepth)) {
 		Log::log("Prologue jmp resolution failed", ErrorLevel::SEV);
 		return false;
 	}

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -3,11 +3,11 @@
 //
 #include "polyhook2/Detour/x86Detour.hpp"
 
-PLH::x86Detour::x86Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis) {
+PLH::x86Detour::x86Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis, maxDepth) {
 
 }
 
-PLH::x86Detour::x86Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis) {
+PLH::x86Detour::x86Detour(const char* fnAddress, const char* fnCallback, uint64_t* userTrampVar, PLH::ADisassembler& dis, const uint8_t maxDepth) : PLH::Detour(fnAddress, fnCallback, userTrampVar, dis, maxDepth) {
 
 }
 
@@ -26,7 +26,7 @@ bool PLH::x86Detour::hook() {
 		return false;
 	}
 
-	if (!followJmp(insts)) {
+	if (!followJmp(insts, 0, m_maxDepth)) {
 		Log::log("Prologue jmp resolution failed", ErrorLevel::SEV);
 		return false;
 	}


### PR DESCRIPTION
Currently Detour::followJmp() is hardcoded to max recursion depth of 5. In some use cases this limit is not sufficient (example: several hooks placed on the same function by multiple independent programs) and changes to it require recompiling the library.
This PR allows max recursion depth to be specified per x86Detour / x64Detour.