### PR TITLE
Support for absolute paths & module handles in EAT hooks

### DIFF
--- a/UnitTests/windows/TestEatHook.cpp
+++ b/UnitTests/windows/TestEatHook.cpp
@@ -11,7 +11,7 @@ EffectTracker eatEffectTracker;
 typedef void(* tEatTestExport)();
 uint64_t oEatTestExport;
 
-extern "C" [[maybe_unused]] __declspec(dllexport) NOINLINE void EatTestExport()
+extern "C" __declspec(dllexport) NOINLINE void EatTestExport()
 {
 	PLH::StackCanary canary;
 }

--- a/UnitTests/windows/TestEatHook.cpp
+++ b/UnitTests/windows/TestEatHook.cpp
@@ -4,44 +4,45 @@
 #include "polyhook2/Tests/StackCanary.hpp"
 #include "polyhook2/Tests/TestEffectTracker.hpp"
 #include "polyhook2/PolyHookOsIncludes.hpp"
+#include "polyhook2/Detour/ADetour.hpp"
 
 EffectTracker eatEffectTracker;
 
 typedef void(* tEatTestExport)();
 uint64_t oEatTestExport;
 
-extern "C" __declspec(dllexport) NOINLINE void EatTestExport()
+extern "C" [[maybe_unused]] __declspec(dllexport) NOINLINE void EatTestExport()
 {
 	PLH::StackCanary canary;
 }
 
 NOINLINE void hkEatTestExport()
-{	
+{
 	PLH::StackCanary canary;
 	eatEffectTracker.PeakEffect().trigger();
 }
 
-TEST_CASE("Eat Hook Tests", "[EatHook]") {
-	SECTION("Verify if export is found and hooked") {
+TEST_CASE("Hook internal test export", "[EatHook]") {
+	SECTION("Verify if export is found and hooked when module name is empty") {
 		PLH::StackCanary canary;
 		PLH::EatHook hook("EatTestExport", L"", (char*)&hkEatTestExport, (uint64_t*)&oEatTestExport);
 		REQUIRE(hook.hook());
 
-		tEatTestExport pExport = (tEatTestExport)GetProcAddress(GetModuleHandle(nullptr), "EatTestExport");
-		REQUIRE(pExport);  
+		auto pExport = (tEatTestExport)GetProcAddress(GetModuleHandle(nullptr), "EatTestExport");
+		REQUIRE(pExport);
 
 		eatEffectTracker.PushEffect();
-		pExport();	
+		pExport();
 		REQUIRE(eatEffectTracker.PopEffect().didExecute());
 		REQUIRE(hook.unHook());
 	}
 
-	SECTION("Verify if export is found and hooked when module explicitly named") {
+	SECTION("Verify if export is found and hooked when module name is explicitly given") {
 		PLH::StackCanary canary;
 		PLH::EatHook hook("EatTestExport", L"Polyhook_2.exe", (char*)&hkEatTestExport, (uint64_t*)&oEatTestExport);
 		REQUIRE(hook.hook());
 
-		tEatTestExport pExport = (tEatTestExport)GetProcAddress(GetModuleHandle(nullptr), "EatTestExport");
+		auto pExport = (tEatTestExport)GetProcAddress(GetModuleHandle(nullptr), "EatTestExport");
 		REQUIRE(pExport);
 
 		eatEffectTracker.PushEffect();
@@ -51,29 +52,17 @@ TEST_CASE("Eat Hook Tests", "[EatHook]") {
 	}
 }
 
-typedef  int(__stdcall* tEatMessageBox)(HWND    hWnd,
-	LPCTSTR lpText,
-	LPCTSTR lpCaption,
-	UINT    uType);
-uint64_t  oEatMessageBox;
-
-int __stdcall hkEatMessageBox(HWND    hWnd,
-	LPCTSTR lpText,
-	LPCTSTR lpCaption,
-	UINT    uType)
-{
-	UNREFERENCED_PARAMETER(lpText);
-	UNREFERENCED_PARAMETER(lpCaption);
-	UNREFERENCED_PARAMETER(uType);
-	UNREFERENCED_PARAMETER(hWnd);
+typedef int(__stdcall* tEatMessageBox)(HWND, LPCTSTR, LPCTSTR, UINT);
+uint64_t oEatMessageBox;
+int __stdcall hkEatMessageBox(HWND, LPCTSTR, LPCTSTR, UINT) {
 	PLH::StackCanary canary;
-	tEatMessageBox MsgBox = (tEatMessageBox)oEatMessageBox;
-	MsgBox(0, TEXT("My Hook"), TEXT("text"), 0);
+	auto MsgBox = (tEatMessageBox)oEatMessageBox;
+	MsgBox(nullptr, TEXT("My Hook"), TEXT("text"), 0);
 	eatEffectTracker.PeakEffect().trigger();
 	return 1;
 }
 
-TEST_CASE("Eat winapi tests", "[EatHook]") {
+TEST_CASE("Hook User32.MessageBoxA using module name", "[EatHook]") {
 	PLH::StackCanary canary;
 	LoadLibrary(TEXT("User32.dll"));
 
@@ -88,13 +77,82 @@ TEST_CASE("Eat winapi tests", "[EatHook]") {
 	eatEffectTracker.PushEffect();
 
 	// force walk of EAT
-	tEatMessageBox MsgBox = (tEatMessageBox)GetProcAddress(GetModuleHandleA("User32.dll"), apiName.c_str());
-	MsgBox(0, TEXT("test"), TEXT("test"), 0);
+	auto MsgBox = (tEatMessageBox)GetProcAddress(GetModuleHandleA("User32.dll"), apiName.c_str());
+	MsgBox(nullptr, TEXT("test"), TEXT("test"), 0);
 	REQUIRE(eatEffectTracker.PopEffect().didExecute());
 	hook.unHook();
 }
 
-typedef  void(__stdcall* tEatGetSystemTime)(PSYSTEMTIME systemTime);
+
+typedef DWORD(__stdcall* tGetTickCount)();
+uint64_t oGetTickCount = 0;
+DWORD WINAPI hkGetTickCount()
+{
+	PLH::StackCanary canary;
+	eatEffectTracker.PeakEffect().trigger();
+
+	auto result = ((tGetTickCount)oGetTickCount)();
+	PLH::Log::log("Original GetTickCount: " + std::to_string(result), PLH::ErrorLevel::INFO);
+
+	return 0x1337;
+}
+
+TEST_CASE("Hook Kernel32.GetTickCount using module path", "[EatHook]") {
+	PLH::StackCanary canary;
+
+	const auto libHandle = LoadLibrary(TEXT("Kernel32.dll"));
+	WCHAR libPath[MAX_PATH];
+	GetModuleFileNameW(libHandle, libPath, MAX_PATH);
+
+	constexpr auto apiName = "GetTickCount";
+
+	PLH::EatHook hook(apiName, libPath, (char*) hkGetTickCount, &oGetTickCount);
+	REQUIRE(hook.hook());
+
+	eatEffectTracker.PushEffect();
+
+	auto address = (void*) GetProcAddress(libHandle, apiName);
+	auto result = ((tGetTickCount) address)();
+
+	REQUIRE(eatEffectTracker.PopEffect().didExecute());
+	REQUIRE(result == 0x1337);
+	hook.unHook();
+}
+
+typedef ULONGLONG(__stdcall* tGetTickCount64)();
+uint64_t oGetTickCount64 = 0;
+ULONGLONG WINAPI hkGetTickCount64()
+{
+	PLH::StackCanary canary;
+	eatEffectTracker.PeakEffect().trigger();
+
+	auto result = ((tGetTickCount)oGetTickCount64)();
+	PLH::Log::log("Original GetTickCount64: " + std::to_string(result), PLH::ErrorLevel::INFO);
+
+	return 0xDEADBEEF;
+}
+
+TEST_CASE("Hook Kernel32.GetTickCount64 using module handle", "[EatHook]") {
+	PLH::StackCanary canary;
+
+	const auto libHandle = LoadLibrary(TEXT("Kernel32.dll"));
+
+	constexpr auto apiName = "GetTickCount64";
+
+	PLH::EatHook hook(apiName, libHandle, (uint64_t) hkGetTickCount64, &oGetTickCount64);
+	REQUIRE(hook.hook());
+
+	eatEffectTracker.PushEffect();
+
+	auto address = (void*) GetProcAddress(libHandle, apiName);
+	auto result = ((tGetTickCount64) address)();
+
+	REQUIRE(eatEffectTracker.PopEffect().didExecute());
+	REQUIRE(result == 0xDEADBEEF);
+	hook.unHook();
+}
+
+typedef void(__stdcall* tEatGetSystemTime)(PSYSTEMTIME systemTime);
 uint64_t oEatGetSystemTime;
 void WINAPI hkGetSystemTime(PSYSTEMTIME systemTime)
 {
@@ -112,16 +170,16 @@ void WINAPI hkGetLocalTime(PSYSTEMTIME systemTime)
 	((tEatGetLocalTime)oEatGetLocalTime)(systemTime);
 }
 
-TEST_CASE("Eat winapi multiple hook", "[EatHook]") {
+TEST_CASE("Hook Kernel32.[GetSystemTime,GetLocalTime]", "[EatHook]") {
 	// These are out of module hooks that require a trampoline stub.
-	// Multiple hooks can fail if the trampoline region isn't re-used 
+	// Multiple hooks can fail if the trampoline region isn't re-used
 	// across multiple calls. Or if no free block is found at all
 	PLH::StackCanary canary;
 	PLH::EatHook hook_GST("GetSystemTime", L"kernel32.dll", (char*)&hkGetSystemTime, (uint64_t*)&oEatGetSystemTime);
 	REQUIRE(hook_GST.hook());
 	eatEffectTracker.PushEffect();
 
-	tEatGetSystemTime GST = (tEatGetSystemTime)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetSystemTime");
+	auto GST = (tEatGetSystemTime)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetSystemTime");
 	SYSTEMTIME t;
 	memset(&t, 0, sizeof(t));
 	GST(&t);
@@ -131,7 +189,7 @@ TEST_CASE("Eat winapi multiple hook", "[EatHook]") {
 	REQUIRE(hook_GLT.hook());
 	eatEffectTracker.PushEffect();
 
-	tEatGetLocalTime GLT = (tEatGetLocalTime)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetLocalTime");
+	auto GLT = (tEatGetLocalTime)GetProcAddress(GetModuleHandleA("kernel32.dll"), "GetLocalTime");
 	memset(&t, 0, sizeof(t));
 	GLT(&t);
 

--- a/polyhook2/PE/EatHook.hpp
+++ b/polyhook2/PE/EatHook.hpp
@@ -16,7 +16,9 @@ namespace PLH {
 class EatHook : public IHook {
 public:
 	EatHook(const std::string& apiName, const std::wstring& moduleName, const char* fnCallback, uint64_t* userOrigVar);
-	EatHook(const std::string& apiName, const std::wstring& moduleName, const uint64_t fnCallback, uint64_t* userOrigVar);
+	EatHook(const std::string& apiName, const std::wstring& moduleName, uint64_t fnCallback, uint64_t* userOrigVar);
+	EatHook(const std::string& apiName, HMODULE moduleHandle, const char* fnCallback, uint64_t* userOrigVar);
+	EatHook(const std::string& apiName, HMODULE moduleHandle, uint64_t fnCallback, uint64_t* userOrigVar);
 	virtual ~EatHook()
 	{
 		if (m_trampoline) {
@@ -31,10 +33,15 @@ public:
 	virtual HookType getType() const override {
 		return HookType::EAT;
 	}
-private:
+
+protected:
+    EatHook(std::string apiName, std::wstring moduleName, HMODULE moduleHandle, uint64_t fnCallback, uint64_t* userOrigVar);
+
+	uint32_t* FindEatFunction();
+	uint32_t* FindEatFunctionInModule() const;
+	uint64_t FindModule();
+
 	const uint16_t m_trampolineSize = 32;
-	uint32_t* FindEatFunction(const std::string& apiName, const std::wstring& moduleName = L"");
-	uint32_t* FindEatFunctionInModule(const std::string& apiName);
 
 	std::wstring m_moduleName;
 	std::string m_apiName;

--- a/polyhook2/PE/EatHook.hpp
+++ b/polyhook2/PE/EatHook.hpp
@@ -16,9 +16,9 @@ namespace PLH {
 class EatHook : public IHook {
 public:
 	EatHook(const std::string& apiName, const std::wstring& moduleName, const char* fnCallback, uint64_t* userOrigVar);
-	EatHook(const std::string& apiName, const std::wstring& moduleName, uint64_t fnCallback, uint64_t* userOrigVar);
-	EatHook(const std::string& apiName, HMODULE moduleHandle, const char* fnCallback, uint64_t* userOrigVar);
-	EatHook(const std::string& apiName, HMODULE moduleHandle, uint64_t fnCallback, uint64_t* userOrigVar);
+	EatHook(const std::string& apiName, const std::wstring& moduleName, const uint64_t fnCallback, uint64_t* userOrigVar);
+	EatHook(const std::string& apiName, const HMODULE moduleHandle, const char* fnCallback, uint64_t* userOrigVar);
+	EatHook(const std::string& apiName, const HMODULE moduleHandle, const uint64_t fnCallback, uint64_t* userOrigVar);
 	virtual ~EatHook()
 	{
 		if (m_trampoline) {

--- a/polyhook2/PolyHookOs.hpp
+++ b/polyhook2/PolyHookOs.hpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
+#include <filesystem>
 
 #include <mutex>
 #include <atomic>

--- a/sources/EatHook.cpp
+++ b/sources/EatHook.cpp
@@ -5,23 +5,35 @@ PLH::EatHook::EatHook(const std::string& apiName, const std::wstring& moduleName
 {}
 
 PLH::EatHook::EatHook(const std::string& apiName, const std::wstring& moduleName, const uint64_t fnCallback, uint64_t* userOrigVar)
-	: m_moduleName(moduleName)
-	, m_apiName(apiName)
-    , m_fnCallback(fnCallback)
-    , m_userOrigVar(userOrigVar)
+    : EatHook(apiName, moduleName, nullptr, fnCallback, userOrigVar)
+{}
+
+PLH::EatHook::EatHook(const std::string& apiName, HMODULE moduleHandle, const char* fnCallback, uint64_t* userOrigVar)
+    : EatHook(apiName, moduleHandle, (uint64_t)fnCallback, userOrigVar)
+{}
+
+PLH::EatHook::EatHook(const std::string& apiName, HMODULE moduleHandle, const uint64_t fnCallback, uint64_t* userOrigVar)
+    : EatHook(apiName, L"", moduleHandle, fnCallback, userOrigVar)
+{}
+
+PLH::EatHook::EatHook(std::string apiName, std::wstring moduleName, const  HMODULE moduleHandle, const uint64_t fnCallback, uint64_t* userOrigVar)
+	: m_moduleName(std::move(moduleName))
+	, m_apiName(std::move(apiName))
+	, m_fnCallback(fnCallback)
+	, m_userOrigVar(userOrigVar)
 	, m_allocator(64, 64) // arbitrary, size is big enough but an overshoot
 	, m_trampoline(0)
-	, m_moduleBase(0)
+	, m_moduleBase(reinterpret_cast<uint64_t>(moduleHandle))
 	, m_origFunc(0)
 {}
 
 bool PLH::EatHook::hook() {
 	assert(m_userOrigVar != nullptr);
-	uint32_t* pExport = FindEatFunction(m_apiName, m_moduleName);
+	uint32_t* pExport = FindEatFunction();
 	if (pExport == nullptr)
 		return false;
 
-	size_t offset = static_cast<size_t>(m_fnCallback - m_moduleBase);
+	auto offset = static_cast<size_t>(m_fnCallback - m_moduleBase);
 
 	/* account for when offset to our function is beyond EAT slots size. We
 	instead allocate a small trampoline within +- 2GB which will do the full
@@ -59,7 +71,7 @@ bool PLH::EatHook::unHook() {
 		return false;
 	}
 
-	uint32_t* pExport = FindEatFunction(m_apiName, m_moduleName);
+	uint32_t* pExport = FindEatFunction();
 	if (pExport == nullptr)
 		return false;
 
@@ -76,45 +88,61 @@ bool PLH::EatHook::unHook() {
 	return true;
 }
 
-uint32_t* PLH::EatHook::FindEatFunction(const std::string& apiName, const std::wstring& moduleName) {
+uint32_t* PLH::EatHook::FindEatFunction() {
+	if(!m_moduleBase){
+		m_moduleBase = FindModule();
+	}
+
+	if(!m_moduleBase){
+		Log::log("EAT | Failed to module base", ErrorLevel::SEV);
+		return nullptr;
+	}
+
+	return FindEatFunctionInModule();
+}
+
+uint64_t PLH::EatHook::FindModule() {
 #if defined(_WIN64)
 	PEB* peb = (PPEB)__readgsqword(0x60);
 #else
 	PEB* peb = (PPEB)__readfsdword(0x30);
 #endif
 
-	uint32_t* pExportAddress = nullptr;
-	PEB_LDR_DATA* ldr = (PPEB_LDR_DATA)peb->Ldr;
+	auto* ldr = (PPEB_LDR_DATA)peb->Ldr;
+	auto* dte = (LDR_DATA_TABLE_ENTRY*)ldr->InLoadOrderModuleList.Flink;
 
-	// find loaded module from peb
-	for (auto* dte = (LDR_DATA_TABLE_ENTRY*)ldr->InLoadOrderModuleList.Flink;
-        dte->DllBase != NULL;
-        dte = (LDR_DATA_TABLE_ENTRY*)dte->InLoadOrderLinks.Flink) {
-
-		// try all modules if none given, otherwise only try specified
-		const ci_wstring_view baseModuleName{dte->BaseDllName.Buffer, dte->BaseDllName.Length / sizeof(wchar_t)};
-		if (!moduleName.empty() && baseModuleName.compare(moduleName.data()) != 0)
-		    continue;
-
-		//std::wcout << moduleName << L" Found module" << std::endl;
-
-		m_moduleBase = (uint64_t)dte->DllBase;
-
-		pExportAddress = FindEatFunctionInModule(apiName);
-		if (pExportAddress != nullptr)
-			return pExportAddress;
+	// Empty module name implies current process
+	if(m_moduleName.empty()){
+		return reinterpret_cast<uint64_t>(dte->DllBase);
 	}
 
-	if (pExportAddress == nullptr) {
-		Log::log("Failed to find export address from requested dll", ErrorLevel::SEV);
+	const auto useFullPath = std::filesystem::path(m_moduleName).is_absolute();
+
+	// iterate over loaded modules to find the target module
+	while (dte->DllBase != nullptr) {
+		const auto peb_module = useFullPath ? dte->FullDllName: dte->BaseDllName;
+
+		const ci_wstring_view pebModuleName{peb_module.Buffer, peb_module.Length / sizeof(wchar_t)};
+
+		// Perform case-insensitive comparison
+		const auto maxCharCount = std::min(pebModuleName.length(), m_moduleName.length());
+		if(_wcsnicmp(pebModuleName.data(), m_moduleName.c_str(), maxCharCount) == 0){
+			// std::wcout << L"Found module: " << path_or_name << std::endl;
+			return reinterpret_cast<uint64_t>(dte->DllBase);
+		}
+
+		dte = (LDR_DATA_TABLE_ENTRY*)dte->InLoadOrderLinks.Flink;
 	}
-	return pExportAddress;
+
+    Log::log("EAT | Failed to automatically find module", ErrorLevel::SEV);
+
+	return 0;
 }
 
-uint32_t* PLH::EatHook::FindEatFunctionInModule(const std::string& apiName) {
-	assert(m_moduleBase != NULL);
-	if (m_moduleBase == NULL)
-		return NULL;
+uint32_t* PLH::EatHook::FindEatFunctionInModule() const {
+    if (m_moduleBase == NULL) {
+        return nullptr;
+    }
 
 	auto* pDos = (IMAGE_DOS_HEADER*)m_moduleBase;
 	auto* pNT = RVA2VA(IMAGE_NT_HEADERS*, m_moduleBase, pDos->e_lfanew);
@@ -122,7 +150,7 @@ uint32_t* PLH::EatHook::FindEatFunctionInModule(const std::string& apiName) {
 
 	if (pDataDir[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress == NULL) {
 		Log::log("PEs without export tables are unsupported", ErrorLevel::SEV);
-		return NULL;
+		return nullptr;
 	}
 
 	auto* pExports = RVA2VA(IMAGE_EXPORT_DIRECTORY*, m_moduleBase, pDataDir[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress);
@@ -131,16 +159,15 @@ uint32_t* PLH::EatHook::FindEatFunctionInModule(const std::string& apiName) {
 	auto* pAddressOfNames = RVA2VA(uint32_t*, m_moduleBase, pExports->AddressOfNames);
 	auto* pAddressOfNameOrdinals = RVA2VA(uint16_t*, m_moduleBase, pExports->AddressOfNameOrdinals);
 
-	for (uint32_t i = 0; i < pExports->NumberOfNames; i++)
-	{
-        	if(my_narrow_stricmp(RVA2VA(char*, m_moduleBase, pAddressOfNames[i]), apiName.c_str()) != 0)
+	for (uint32_t i = 0; i < pExports->NumberOfNames; i++) {
+        if(my_narrow_stricmp(RVA2VA(char*, m_moduleBase, pAddressOfNames[i]), m_apiName.c_str()) != 0){
 			continue;
+		}
 
 		// std::cout << RVA2VA(char*, m_moduleBase, pAddressOfNames[i]) << std::endl;
 		const uint16_t iExportOrdinal = pAddressOfNameOrdinals[i];
-		uint32_t* pExportAddress = &pAddressOfFunctions[iExportOrdinal];
 
-		return pExportAddress;
+		return &pAddressOfFunctions[iExportOrdinal];
 	}
 
 	Log::log("API not found before end of EAT", ErrorLevel::SEV);


### PR DESCRIPTION
This PR implements support for absolute module paths & module handles for EAT Hooks as discussed in #114.

Some miscellaneous optimizations suggested by Clang-tidy have also been applied.

New tests have been added that cover the new use cases, and test names have been rephrased to reflect that change.