### PR TITLE
Increased IHook descendants' member accessibility

### DIFF
--- a/polyhook2/Detour/x64Detour.hpp
+++ b/polyhook2/Detour/x64Detour.hpp
@@ -43,7 +43,7 @@ public:
 	detour_scheme_t getDetourScheme() const;
 	void setDetourScheme(detour_scheme_t scheme);
 
-private:
+protected:
 	bool makeTrampoline(insts_t& prologue, insts_t& trampolineOut);
 
 	// assumes we are looking within a +-2GB window

--- a/polyhook2/Detour/x86Detour.hpp
+++ b/polyhook2/Detour/x86Detour.hpp
@@ -28,7 +28,7 @@ public:
 	Mode getArchType() const override;
 
 	uint8_t getJmpSize() const;
-private:
+protected:
 	bool makeTrampoline(insts_t& prologue, insts_t& trampolineOut);
 };
 }

--- a/polyhook2/Exceptions/BreakPointHook.hpp
+++ b/polyhook2/Exceptions/BreakPointHook.hpp
@@ -25,7 +25,7 @@ public:
 			hook();
 		});
 	}
-private:
+protected:
 	uint64_t m_fnCallback;
 	uint64_t m_fnAddress;
 	uint8_t m_origByte;

--- a/polyhook2/Exceptions/HWBreakPointHook.hpp
+++ b/polyhook2/Exceptions/HWBreakPointHook.hpp
@@ -25,7 +25,7 @@ public:
 			hook();
 		});
 	}
-private:
+protected:
 	uint64_t m_fnCallback;
 	uint64_t m_fnAddress;
 	uint8_t m_regIdx;

--- a/polyhook2/PE/EatHook.hpp
+++ b/polyhook2/PE/EatHook.hpp
@@ -33,7 +33,6 @@ public:
 	virtual HookType getType() const override {
 		return HookType::EAT;
 	}
-
 protected:
     EatHook(std::string apiName, std::wstring moduleName, HMODULE moduleHandle, uint64_t fnCallback, uint64_t* userOrigVar);
 

--- a/polyhook2/PE/IatHook.hpp
+++ b/polyhook2/PE/IatHook.hpp
@@ -26,7 +26,7 @@ public:
 	virtual HookType getType() const override {
 		return HookType::IAT;
 	}
-private:
+protected:
 	IMAGE_THUNK_DATA* FindIatThunk(const std::string& dllName, const std::string& apiName, const std::wstring moduleName = L"");
 	IMAGE_THUNK_DATA* FindIatThunkInModule(void* moduleBase, const std::string& dllName, const std::string& apiName);
 

--- a/polyhook2/Virtuals/VFuncSwapHook.hpp
+++ b/polyhook2/Virtuals/VFuncSwapHook.hpp
@@ -24,7 +24,7 @@ public:
 	virtual HookType getType() const override {
 		return HookType::VTableSwap;
 	}
-private:
+protected:
 	uint16_t countVFuncs();
 	uint64_t  m_class;
 	uintptr_t* m_vtable;

--- a/polyhook2/Virtuals/VTableSwapHook.hpp
+++ b/polyhook2/Virtuals/VTableSwapHook.hpp
@@ -58,7 +58,7 @@ public:
 	virtual HookType getType() const override {
 		return HookType::VTableSwap;
 	}
-private:
+protected:
 	uint16_t countVFuncs();
 
 	std::unique_ptr<uintptr_t[]> m_newVtable;


### PR DESCRIPTION
This PR changes the accessibility modifier of `IHook` descendants from `private` to `protected`. This leave the door open to useful inheritance for unforeseen use cases (if we could foresee them, we would implement public interfaces for that). It also partially facilities quick testing of new features/bug-fixes via inheritance, which can be easier than having to clone and setup the library from sources.

Other classes that have `private` members have not been modified in a similar fashion. But should they?