### PR TITLE
Displacement size fix

### DIFF
--- a/UnitTests/windows/TestDisassembler.cpp
+++ b/UnitTests/windows/TestDisassembler.cpp
@@ -134,9 +134,9 @@ TEST_CASE("Test Instruction UUID generator", "[Instruction],[UID]") {
 	}
 }
 
-TEMPLATE_TEST_CASE("Test Disassemblers x64", "[ZydisDisassembler]", PLH::ZydisDisassembler) {
+TEST_CASE("Test Disassemblers x64", "[ZydisDisassembler]") {
 	PLH::StackCanary canaryg;
-	TestType disasm(PLH::Mode::x64);
+    PLH::ZydisDisassembler disasm(PLH::Mode::x64);
 	auto                      Instructions = disasm.disassemble((uint64_t)&x64ASM.front(), (uint64_t)&x64ASM.front(),
 		(uint64_t)&x64ASM.front() + x64ASM.size(), PLH::MemAccessor());
 
@@ -245,7 +245,7 @@ TEMPLATE_TEST_CASE("Test Disassemblers x64", "[ZydisDisassembler]", PLH::ZydisDi
 	}
 }
 
-TEMPLATE_TEST_CASE("Test Disassemblers x86 FF25", "[ZydisDisassembler]", PLH::ZydisDisassembler) {
+TEST_CASE("Test Disassemblers x86 FF25", "[ZydisDisassembler]") {
 #ifdef POLYHOOK2_ARCH_X64
 	// this test is not suitable for x64 due to ff 25 not being re-written
 	return;
@@ -255,7 +255,7 @@ TEMPLATE_TEST_CASE("Test Disassemblers x86 FF25", "[ZydisDisassembler]", PLH::Zy
 	*(uint32_t*)(x86ASM_FF25.data() + 2) = (uint32_t)(x86ASM_FF25.data() + 6); // 0xFF25 <pMem> = &mem; (just fyi *mem == 0xAA0000AB)
 
 	PLH::StackCanary canaryg;
-	TestType disasm(PLH::Mode::x86);
+    PLH::ZydisDisassembler disasm(PLH::Mode::x86);
 	auto                      Instructions = disasm.disassemble((uint64_t)&x86ASM_FF25.front(), (uint64_t)&x86ASM_FF25.front(),
 		(uint64_t)&x86ASM_FF25.front() + x86ASM_FF25.size(), PLH::MemAccessor());
 
@@ -276,9 +276,9 @@ TEMPLATE_TEST_CASE("Test Disassemblers x86 FF25", "[ZydisDisassembler]", PLH::Zy
 	REQUIRE(Instructions.at(0).hasDisplacement());
 }
 
-TEMPLATE_TEST_CASE("Test Disassemblers x86", "[ZydisDisassembler]", PLH::ZydisDisassembler) {
+TEST_CASE("Test Disassemblers x86", "[ZydisDisassembler]") {
 	PLH::StackCanary canaryg;
-	TestType disasm(PLH::Mode::x86);
+    PLH::ZydisDisassembler disasm(PLH::Mode::x86);
 	auto                      Instructions = disasm.disassemble((uint64_t)&x86ASM.front(), (uint64_t)&x86ASM.front(),
 		(uint64_t)&x86ASM.front() + x86ASM.size(), PLH::MemAccessor());
 
@@ -381,9 +381,9 @@ TEMPLATE_TEST_CASE("Test Disassemblers x86", "[ZydisDisassembler]", PLH::ZydisDi
 	}
 }
 
-TEMPLATE_TEST_CASE("Test Disassemblers x64 Two", "[ZydisDisassembler]", PLH::ZydisDisassembler) {
+TEST_CASE("Test Disassemblers x64 Two", "[ZydisDisassembler]") {
 	PLH::StackCanary canaryg;
-	TestType disasm(PLH::Mode::x64);
+    PLH::ZydisDisassembler disasm(PLH::Mode::x64);
 	PLH::insts_t Instructions = disasm.disassemble((uint64_t)&x64ASM2.front(), (uint64_t)&x64ASM2.front(),
 		(uint64_t)&x64ASM2.front() + x64ASM2.size(), PLH::MemAccessor());
 
@@ -405,27 +405,27 @@ TEMPLATE_TEST_CASE("Test Disassemblers x64 Two", "[ZydisDisassembler]", PLH::Zyd
 	}
 }
 
-TEMPLATE_TEST_CASE("Test Disassemblers NOPS", "[ZydisDisassembler]",PLH::ZydisDisassembler) {
+TEST_CASE("Test Disassemblers NOPS", "[ZydisDisassembler]") {
 	PLH::StackCanary canaryg;
-	TestType disasm(PLH::Mode::x64);
+    PLH::ZydisDisassembler disasm(PLH::Mode::x64);
 	PLH::insts_t Instructions = disasm.disassemble((uint64_t)&x86x64Nops.front(), (uint64_t)&x86x64Nops.front(),
 		(uint64_t)&x86x64Nops.front() + x86x64Nops.size(), PLH::MemAccessor());
 
-	TestType disasmx86(PLH::Mode::x86);
+    PLH::ZydisDisassembler disasmx86(PLH::Mode::x86);
 	PLH::insts_t Instructionsx86 = disasmx86.disassemble((uint64_t)&x86x64Nops.front(), (uint64_t)&x86x64Nops.front(),
 		(uint64_t)&x86x64Nops.front() + x86x64Nops.size(), PLH::MemAccessor());
 
 	SECTION("Verify multi-byte nops decodings x64") {
 		for (auto& ins : Instructions) {
 			REQUIRE(ins.getMnemonic() == "nop");
-			REQUIRE(TestType::isPadBytes(ins));
+			REQUIRE(PLH::ZydisDisassembler::isPadBytes(ins));
 		}
 	}
 
 	SECTION("Verify multi-byte nops decodings x86") {
 		for (auto& ins : Instructionsx86) {
 			REQUIRE(ins.getMnemonic() == "nop");
-			REQUIRE(TestType::isPadBytes(ins));			
+			REQUIRE(PLH::ZydisDisassembler::isPadBytes(ins));
 		}
 	}
 }

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -160,7 +160,7 @@ bool PLH::Detour::buildRelocationList(insts_t& prologue, const uint64_t roundPro
 		// data operations (duplicated because clearer)
 		if (!inst.isBranching() && inst.hasDisplacement()) {
 			const uint8_t dispSzBits = (uint8_t)inst.getDispSize() * 8;
-			const uint64_t maxInstDisp = (uint64_t)(std::pow(2, dispSzBits) / 2.0 - 1.0); 
+			const uint64_t maxInstDisp = (uint64_t)(std::pow(2, dispSzBits - 1) - 1.0);
 			if ((uint64_t)std::llabs(delta) > maxInstDisp) {
 				/*EX: 48 8d 0d 96 79 07 00    lea rcx, [rip + 0x77996]
 				If instruction is moved beyond displacement field width

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -158,6 +158,8 @@ void PLH::ZydisDisassembler::setDisplacementFields(PLH::Instruction& inst, const
 				inst.setDisplacementOffset(zydisInst->raw.imm->offset);
 				inst.setRelativeDisplacement(zydisInst->raw.imm->value.s);
 				return;
+			} else {
+                inst.setImmediateOffset(zydisInst->raw.imm->offset);
 			}
             break;
 		}

--- a/sources/x64Detour.cpp
+++ b/sources/x64Detour.cpp
@@ -237,7 +237,7 @@ bool PLH::x64Detour::hook() {
 	Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
 
 	
-	uint64_t minProlSz = _detourScheme != detour_scheme_t::INPLACE ? getMinJmpSize() : INPLACE_DETOUR_SIZE; // min size of patches that may split instructions
+	uint64_t minProlSz = (_detourScheme != detour_scheme_t::INPLACE) ? getMinJmpSize() : INPLACE_DETOUR_SIZE; // min size of patches that may split instructions
 	uint64_t roundProlSz = minProlSz; // nearest size to min that doesn't split any instructions
 
 	std::optional<PLH::insts_t> prologueOpt;


### PR DESCRIPTION
This PR fixes displacement size calculation when instructions contain both IP-relative displacement and immediate values. I think this case warrants a new unit test that covers this scenario. Perhaps it can be added once the RIP-relative hooking feature is complete.

It also raises visibility of `m_displacement` member so that it is in line with member usages. However, I do believe that class members need to be revisited at some point because some public members (e.g. `m_isIndirect`) are public, but nevertheless have getters, which are used sometimes but not always, leading to inconsistencies. I believe a classical OOP encapsulation is warranted once main work has been done.

Finally, a new unit test is introduced that targets RIP-relative hooking. Naturally it fails for now, but it is useful to keep it around during development. Additionally, `TEMPLATE_TEST_CASE` have been converted to `TEST_CASE` because there are no longer multiple `TestType`s being tested, hence the code can be simplified.