### PR TITLE
Fix asmjit lib when internal asmtk is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,11 @@ if(POLYHOOK_FEATURE_DETOURS AND NOT POLYHOOK_USE_EXTERNAL_ASMTK)
 
 	if(POLYHOOK_BUILD_SHARED_ASMTK)
 		set(ASMTK_STATIC OFF CACHE BOOL "")
-	else()
+        set(ASMJIT_STATIC OFF CACHE BOOL "")
+    else()
 		set(ASMTK_STATIC ON CACHE BOOL "")
-	endif()
+        set(ASMJIT_STATIC ON CACHE BOOL "")
+    endif()
 
 	add_subdirectory(asmtk)
     add_asmjit_properties()


### PR DESCRIPTION
This PR fixes a static vs shared issue when Detour feature is enabled. Right now there is a bug where asmjit will be included as a shared lib even if asmtk is configured as static lib. It's important that asmjit follows asmtk's linkage, otherwise it leads to a mess. 