### PR TITLE
Safe in-place scheme

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -12,6 +12,9 @@
       <option name="SPACE_BEFORE_REFERENCE_IN_DECLARATION" value="false" />
       <option name="SPACE_AFTER_REFERENCE_IN_DECLARATION" value="true" />
     </Objective-C>
+    <editorconfig>
+      <option name="ENABLED" value="false" />
+    </editorconfig>
     <codeStyleSettings language="CMake">
       <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
     </codeStyleSettings>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,8 +270,10 @@ if(POLYHOOK_FEATURE_DETOURS)
 	# only build tests if making exe
 	if(NOT POLYHOOK_BUILD_DLL)
 		if(CMAKE_SIZEOF_VOID_P EQUAL 8) #64-bit
-			target_sources(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourx64.cpp
-			 ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourTranslationx64.cpp)
+			target_sources(${PROJECT_NAME} PRIVATE
+			    ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourx64.cpp
+			    ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourTranslationx64.cpp
+				${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourSchemex64.cpp)
 		elseif(CMAKE_SIZEOF_VOID_P EQUAL 4) #32-bit
 			target_sources(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourx86.cpp)
 		endif()

--- a/UnitTests/windows/TestDetourSchemex64.cpp
+++ b/UnitTests/windows/TestDetourSchemex64.cpp
@@ -1,0 +1,121 @@
+#include <Catch.hpp>
+#include "polyhook2/Detour/x64Detour.hpp"
+
+#include "polyhook2/Tests/StackCanary.hpp"
+#include "polyhook2/Tests/TestEffectTracker.hpp"
+
+#include "polyhook2/PolyHookOsIncludes.hpp"
+
+EffectTracker schemeEffects;
+
+TEST_CASE("Testing detour schemes", "[DetourScheme][ADetour]") {
+    typedef int (* IntFn)();
+
+    asmjit::JitRuntime rt;
+
+    auto make_func = [&](const std::function<void(asmjit::x86::Assembler&)>& builder) {
+        asmjit::CodeHolder code;
+        code.init(rt.environment());
+        asmjit::x86::Assembler a(&code);
+        builder(a);
+
+        IntFn fn;
+        auto error = rt.add(&fn, &code);
+
+        if (error) {
+            const auto message = std::string("Error generating function: ") + asmjit::DebugUtils::errorAsString(error);
+            PLH::Log::log(message, PLH::ErrorLevel::SEV);
+        }
+
+        return fn;
+    };
+
+    SECTION("Validate in-place detour scheme in large function") {
+        PLH::StackCanary canary;
+
+        auto large_function = make_func([](auto& a) {
+            a.mov(asmjit::x86::rax, 0x1234567890123456);
+            a.mov(asmjit::x86::rbx, 0x6543210987654321);
+            a.mov(asmjit::x86::rcx, 0x1234567890ABCDEF);
+            a.mov(asmjit::x86::rcx, 0xFEDCBA0987654321);
+            a.ret();
+        });
+
+        static uint64_t tramp_large_function;
+        IntFn hook_large_function = []() {
+            PLH::StackCanary canary;
+            schemeEffects.PeakEffect().trigger();
+            printf("hook_large_function called");
+            return ((IntFn) (tramp_large_function))();
+        };
+
+        PLH::x64Detour detour((uint64_t) large_function, (uint64_t) hook_large_function, &tramp_large_function);
+        detour.setDetourScheme(PLH::x64Detour::detour_scheme_t::INPLACE);
+        REQUIRE(detour.hook() == true);
+        schemeEffects.PushEffect();
+        large_function();
+        REQUIRE(schemeEffects.PopEffect().didExecute());
+        REQUIRE(detour.unHook() == true);
+    }
+
+    SECTION("Validate in-place detour scheme in medium function") {
+        PLH::StackCanary canary;
+
+        auto medium_function = make_func([](auto& a) {
+            a.mov(asmjit::x86::rax, 0x1234567890123456);
+            a.mov(asmjit::x86::rcx, 0x1234567890ABCDEF);
+            a.ret();
+        });
+
+        static uint64_t tramp_medium_function;
+        IntFn hook_medium_function = []() {
+            PLH::StackCanary canary;
+            schemeEffects.PeakEffect().trigger();
+            printf("hook_medium_function called");
+            return ((IntFn) (tramp_medium_function))();
+        };
+
+        PLH::x64Detour detour1((uint64_t) medium_function, (uint64_t) hook_medium_function, &tramp_medium_function);
+        detour1.setDetourScheme(PLH::x64Detour::detour_scheme_t::INPLACE);
+        REQUIRE(detour1.hook() == false);
+
+        PLH::x64Detour detour2((uint64_t) medium_function, (uint64_t) hook_medium_function, &tramp_medium_function);
+        detour2.setDetourScheme(PLH::x64Detour::detour_scheme_t::INPLACE_SHORT);
+        REQUIRE(detour2.hook() == true);
+        schemeEffects.PushEffect();
+        medium_function();
+        REQUIRE(schemeEffects.PopEffect().didExecute());
+        REQUIRE(detour2.unHook() == true);
+    }
+
+    SECTION("Validate code-cave detour scheme in small function") {
+        PLH::StackCanary canary;
+
+        auto small_function = make_func([](auto& a) {
+            a.mov(asmjit::x86::rax, 0x1234567890123456);
+            a.ret();
+        });
+
+        static uint64_t tramp_small_function;
+        IntFn hook_small_function = []() {
+            PLH::StackCanary canary;
+            schemeEffects.PeakEffect().trigger();
+            printf("tramp_small_function called");
+            return ((IntFn) (tramp_small_function))();
+        };
+
+        PLH::x64Detour detour1((uint64_t) small_function, (uint64_t) hook_small_function, &tramp_small_function);
+        detour1.setDetourScheme(PLH::x64Detour::detour_scheme_t::INPLACE_SHORT);
+        REQUIRE(detour1.hook() == false);
+
+
+        // FIXME: Is not guaranteed to find a cave
+        PLH::x64Detour detour2((uint64_t) small_function, (uint64_t) hook_small_function, &tramp_small_function);
+        detour2.setDetourScheme(PLH::x64Detour::detour_scheme_t::CODE_CAVE);
+        REQUIRE(detour2.hook() == true);
+        schemeEffects.PushEffect();
+        small_function();
+        REQUIRE(schemeEffects.PopEffect().didExecute());
+        REQUIRE(detour2.unHook() == true);
+    }
+}

--- a/UnitTests/windows/TestDetourTranslationx64.cpp
+++ b/UnitTests/windows/TestDetourTranslationx64.cpp
@@ -1,6 +1,5 @@
 #include <Catch.hpp>
 #include "polyhook2/Detour/x64Detour.hpp"
-#include "polyhook2/ZydisDisassembler.hpp"
 
 #include "polyhook2/Tests/StackCanary.hpp"
 #include "polyhook2/Tests/TestEffectTracker.hpp"

--- a/UnitTests/windows/TestDetourx64.cpp
+++ b/UnitTests/windows/TestDetourx64.cpp
@@ -3,12 +3,13 @@
 //
 #include <Catch.hpp>
 #include "polyhook2/Detour/x64Detour.hpp"
-#include "polyhook2/ZydisDisassembler.hpp"
 
 #include "polyhook2/Tests/StackCanary.hpp"
 #include "polyhook2/Tests/TestEffectTracker.hpp"
 
 #include "polyhook2/PolyHookOsIncludes.hpp"
+
+#include <asmjit/asmjit.h>
 
 EffectTracker effects;
 

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -31,12 +31,16 @@ PLH::ZydisDisassembler::~ZydisDisassembler() {
 	}
 }
 
-PLH::insts_t
-PLH::ZydisDisassembler::disassemble(uint64_t firstInstruction, uint64_t start, uint64_t End, const MemAccessor& accessor) {
+PLH::insts_t PLH::ZydisDisassembler::disassemble(
+    uint64_t firstInstruction,
+    uint64_t start,
+    uint64_t end,
+    const MemAccessor& accessor
+) {
 	insts_t insVec;
 	m_branchMap.clear();
 
-	uint64_t size = End - start;
+	uint64_t size = end - start;
 	assert(size > 0);
 	if (size <= 0) {
 		return insVec;

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -60,8 +60,9 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 		uint64_t address = start + offset;
 
 		std::string opstr;
-		if (!getOpStr(&insInfo, address, &opstr))
+		if (!getOpStr(&insInfo, address, &opstr)){
 			break;
+        }
 
 		Instruction inst(address,
 						 displacement,
@@ -75,8 +76,9 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 						 m_mode);
 
 		setDisplacementFields(inst, &insInfo);
-		if (endHit && !isPadBytes(inst))
+		if (endHit && !isPadBytes(inst)) {
 			break;
+        }
 
 		insVec.push_back(inst);
 

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -75,6 +75,7 @@ bool x86Detour::hook() {
     MemoryProtector prot(m_fnAddress, m_hookSize, ProtFlag::RWX, *this);
 
     m_hookInsts = makex86Jmp(m_fnAddress, m_fnCallback);
+    Log::log("Hook instructions:\n" + instsToStr(m_hookInsts) + "\n", ErrorLevel::INFO);
     ZydisDisassembler::writeEncoding(m_hookInsts, *this);
 
     // Nop the space between jmp and end of prologue


### PR DESCRIPTION
This PR makes changes to the x64 detour scheme. The old INPLACE scheme is now INPLACE_SHORT, and uses rax register. The new INPLACE scheme now creates a non-spoiling trampoline, but at the expense of larger size. New `TestDetourSchemex64.cpp` unit tests are targeting those schemes (except Valloc2, which is tested in every other detour unit test anyway).

All tests pass except the last code-cave one. It always fails with
> No code caves found near function

Any ideas how we could ensure code cave allocation that will be found during a hook?