### PR TITLE
Bugfixes

### DIFF
--- a/UnitTests/windows/TestDetourTranslationx64.cpp
+++ b/UnitTests/windows/TestDetourTranslationx64.cpp
@@ -59,6 +59,8 @@ unsigned char cmpR15bByte[] = {
     0xC3                                      // ret
 };
 
+// TODO: Translation + INPLACE scheme
+
 uint64_t oCmpQwordImm = NULL;
 
 uint64_t hookCmpQwordImm() {

--- a/UnitTests/windows/TestDetourx64.cpp
+++ b/UnitTests/windows/TestDetourx64.cpp
@@ -111,7 +111,7 @@ HOOK_CALLBACK(&CreateMutexExA, hCreateMutexExA, { // NOLINT(cert-err58-cpp)
 });
 
 
-TEST_CASE("Testing 64 detours", "[x64Detour][ADetour]") {
+TEST_CASE("Testing x64 detours", "[x64Detour][ADetour]") {
     SECTION("Normal function") {
         PLH::StackCanary canary;
         PLH::x64Detour detour((uint64_t) &hookMe1, (uint64_t) h_hookMe1, &hookMe1Tramp);
@@ -192,9 +192,8 @@ TEST_CASE("Testing 64 detours", "[x64Detour][ADetour]") {
         PLH::StackCanary canary;
         PLH::x64Detour detour((uint64_t) &malloc, (uint64_t) h_hookMalloc, &hookMallocTramp);
         effects.PushEffect(); // catch does some allocations, push effect first so peak works
-        bool result = detour.hook();
 
-        REQUIRE(result == true);
+        REQUIRE(detour.hook());
 
         void* pMem = malloc(16);
         free(pMem);

--- a/polyhook2/Detour/x64Detour.hpp
+++ b/polyhook2/Detour/x64Detour.hpp
@@ -53,6 +53,7 @@ protected:
     optional<uint64_t> m_valloc2_region;
     RangeAllocator m_allocator;
     asmjit::JitRuntime m_asmjit_rt;
+    detour_scheme_t m_chosen_scheme = detour_scheme_t::VALLOC2;
 
     bool makeTrampoline(insts_t& prologue, insts_t& outJmpTable);
 
@@ -64,7 +65,7 @@ protected:
 
     bool make_inplace_trampoline(uint64_t base_address, const std::function<void(asmjit::x86::Assembler&)>& builder);
 
-    bool allocate_trampoline();
+    bool allocate_jump_to_callback();
 };
 
 }

--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -283,6 +283,14 @@ public:
 		return Instruction(address, {0}, 0, false, false, bytes, "nop", "", Mode::x64);
 	}
 
+    bool startsWithDisplacement() const {
+        if(getOperandTypes().empty()){
+            return false;
+        }
+
+        return getOperandTypes()[0] == Instruction::OperandType::Displacement;
+    }
+
 private:
 	void Init(const uint64_t address,
 			  const Displacement& displacement,

--- a/polyhook2/ZydisDisassembler.hpp
+++ b/polyhook2/ZydisDisassembler.hpp
@@ -94,7 +94,7 @@ public:
 			// search back, check if new instruction points to older ones (one to one)
 			auto destInst = std::find_if(insVec.begin(), insVec.end(), [&](const Instruction& oldIns) {
 				return oldIns.getAddress() == inst.getDestination();
-				});
+			});
 
 			if (destInst != insVec.end()) {
 				updateBranchMap(destInst->getAddress(), inst);
@@ -119,7 +119,7 @@ protected:
 	void setDisplacementFields(PLH::Instruction& inst, const ZydisDecodedInstruction* zydisInst) const;
 
 	typename branch_map_t::mapped_type& updateBranchMap(uint64_t key, const Instruction& new_val) {
-		branch_map_t::iterator it = m_branchMap.find(key);
+		auto it = m_branchMap.find(key);
 		if (it != m_branchMap.end()) {
 			it->second.push_back(new_val);
 		} else {

--- a/polyhook2/ZydisDisassembler.hpp
+++ b/polyhook2/ZydisDisassembler.hpp
@@ -57,7 +57,7 @@ public:
 		return false;
 	}
 
-	static bool isFuncEnd(const PLH::Instruction& instruction) {
+	static bool isFuncEnd(const PLH::Instruction& instruction, const bool firstFunc = false) {
 		// TODO: more?
 		/*
 		* 0xABABABAB : Used by Microsoft's HeapAlloc() to mark "no man's land" guard bytes after allocated heap memory
@@ -73,10 +73,11 @@ public:
 		* 0xFEEEFEEE : Used by Microsoft's HeapFree() to mark freed heap memory
 		*/
 		std::string mnemonic = instruction.getMnemonic();
-		auto byts = instruction.getBytes();
-		return (instruction.size() == 1 && byts[0] == 0xCC) ||
-			(instruction.size() >= 2 && byts[0] == 0xf3 && byts[1] == 0xc3) ||
-			mnemonic == "ret" || mnemonic == "jmp" || mnemonic.find("iret") == 0;
+		auto bytes = instruction.getBytes();
+		return (instruction.size() == 1 && bytes[0] == 0xCC) ||
+			(instruction.size() >= 2 && bytes[0] == 0xf3 && bytes[1] == 0xc3) ||
+            (mnemonic == "jmp" && !firstFunc) || // Jump to tranlslation
+			mnemonic == "ret" || mnemonic.find("iret") == 0;
 	}
 
 	static bool isPadBytes(const PLH::Instruction& instruction) {

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -152,7 +152,7 @@ void Detour::buildRelocationList(
                 /*
                  * EX: 48 8d 0d 96 79 07 00    lea rcx, [rip + 0x77996]
                  * If instruction is moved beyond displacement field width
-                 * we can't fix the load. Hence, we add it to the list of
+                 * we can't fix the displacement. Hence, we add it to the list of
                  * instructions that need to be translated to equivalent ones.
                  */
                 instsNeedingTranslation.push_back(inst);

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -38,7 +38,7 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
     const MemAccessor& accessor
 ) {
 	insts_t insVec;
-	m_branchMap.clear();
+//	m_branchMap.clear();
 
 	uint64_t size = end - start;
 	assert(size > 0);
@@ -131,7 +131,8 @@ void PLH::ZydisDisassembler::setDisplacementFields(PLH::Instruction& inst, const
 
 				if (zydisInst->attributes & ZYDIS_ATTRIB_IS_RELATIVE) {
 					inst.setDisplacementOffset(zydisInst->raw.disp.offset);
-					inst.setRelativeDisplacement(operand->mem.disp.value, true);
+					inst.setDisplacementSize((uint8_t)(zydisInst->raw.disp.size / 8));
+					inst.setRelativeDisplacement(operand->mem.disp.value);
 				}
 
 				if ((zydisInst->mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_JMP && inst.size() >= 2 && inst.getBytes().at(0) == 0xff && inst.getBytes().at(1) == 0x25) ||
@@ -162,7 +163,6 @@ void PLH::ZydisDisassembler::setDisplacementFields(PLH::Instruction& inst, const
 					inst.setRelativeDisplacement(zydisInst->raw.imm->value.s);
 					return;
 				} else {
-					inst.setImmediateOffset(zydisInst->raw.imm->offset);
 					inst.setImmediate(zydisInst->raw.imm->value.s);
 					inst.setImmediateSize(zydisInst->raw.imm->size);
 				}

--- a/sources/x64Detour.cpp
+++ b/sources/x64Detour.cpp
@@ -502,10 +502,8 @@ optional<TranslationResult> translate_instruction(const Instruction& instruction
         return {};
     }
 
-    const auto startsWithDisplacement = instruction.getOperandTypes()[0] == Instruction::OperandType::Displacement;
-
-    const auto operand1 = startsWithDisplacement ? scratch_register_string : second_operand_string;
-    const auto operand2 = startsWithDisplacement ? second_operand_string : scratch_register_string;
+    const auto operand1 = instruction.startsWithDisplacement() ? scratch_register_string : second_operand_string;
+    const auto operand2 = instruction.startsWithDisplacement() ? second_operand_string : scratch_register_string;
 
     TranslationResult result;
     result.instruction = mnemonic + " " + operand1 + ", " + operand2;
@@ -579,7 +577,7 @@ optional<uint64_t> x64Detour::generateTranslationRoutine(const Instruction& inst
     translation.emplace_back(translated_instruction);
 
     // Store the scratch register content into the destination, if necessary
-    if (instructions_to_store.count(instruction.getMnemonic())) {
+    if (instruction.startsWithDisplacement() && instructions_to_store.count(instruction.getMnemonic())) {
         translation.emplace_back("mov [" + address_register + "], " + scratch_register_64);
     }
 


### PR DESCRIPTION
This PR fixes various critical bugs. Mostly they are related to the translation routine, e.g. in-place & translation combo, back-references & translation combo, etc. The displacement size is now taken from disassembler, rather than computed, which makes it always accurate. The jump-to-trampoline allocation is now done before trampoline allocation, because minProlSize can not be known until we have chosen a supported detour scheme. Translation write-back is also fixed, so that it does not write back result if rip-relative address is in a source operand.