### PR TITLE
Fixes PolyHook2Alloca not being inlined

### DIFF
--- a/polyhook2/PolyHookOs.hpp
+++ b/polyhook2/PolyHookOs.hpp
@@ -36,6 +36,14 @@
     #endif
 #endif
 
+#if defined(_MSC_VER)
+    #define PLH_INLINE __forceinline
+#elif defined(__GNUC__)
+    #define PLH_INLINE __attribute__((always_inline))
+#else
+    #define PLH_INLINE inline
+#endif
+
 #include <iostream> //for debug printing
 #include <sstream>
 #include <iomanip> //setw
@@ -72,7 +80,7 @@
 void PolyHook2DebugBreak();
 
 // Methods using stack allocation need to be inlined
-__forceinline void* PolyHook2Alloca(size_t size)
+PLH_INLINE void* PolyHook2Alloca(size_t size)
 {
 #if defined(POLYHOOK2_OS_WINDOWS)
     return _alloca(size);

--- a/polyhook2/PolyHookOs.hpp
+++ b/polyhook2/PolyHookOs.hpp
@@ -70,6 +70,15 @@
 #include <inttypes.h>
 
 void PolyHook2DebugBreak();
-void* PolyHook2Alloca(size_t size);
+
+// Methods using stack allocation need to be inlined
+__forceinline void* PolyHook2Alloca(size_t size)
+{
+#if defined(POLYHOOK2_OS_WINDOWS)
+    return _alloca(size);
+#else
+    return alloca(size);
+#endif
+}
 
 #endif

--- a/polyhook2/PolyHookOs.hpp
+++ b/polyhook2/PolyHookOs.hpp
@@ -2,46 +2,46 @@
 #define POLYHOOK_2_OS_HPP
 
 #if defined(WIN64) || defined(_WIN64) || defined(__MINGW64__)
-    #define POLYHOOK2_OS_WINDOWS
-    #define POLYHOOK2_ARCH_X64
+#define POLYHOOK2_OS_WINDOWS
+#define POLYHOOK2_ARCH_X64
 
-    #ifdef __GNUC__
-    
-    // VirtualAlloc2 requires NTDII_WIN10_RS4 on my distrubition of mingw
-    #define NTDDI_VERSION NTDDI_WIN10_RS4 
+#ifdef __GNUC__
 
-    // This was taken from Microsofts Detours library 
-    #define ERROR_DYNAMIC_CODE_BLOCKED 1655L
+// VirtualAlloc2 requires NTDII_WIN10_RS4 on my distrubition of mingw
+#define NTDDI_VERSION NTDDI_WIN10_RS4 
 
-    #endif
+// This was taken from Microsofts Detours library 
+#define ERROR_DYNAMIC_CODE_BLOCKED 1655L
+
+#endif
 
 #elif defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
-    #define POLYHOOK2_OS_WINDOWS
-    #define POLYHOOK2_ARCH_X86
+#define POLYHOOK2_OS_WINDOWS
+#define POLYHOOK2_ARCH_X86
 #elif defined(__linux__) || defined(linux)
-    #if defined(__x86_64__)
-        #define POLYHOOK2_OS_LINUX
-        #define POLYHOOK2_ARCH_X64
-    #else
-        #define POLYHOOK2_OS_LINUX
-        #define POLYHOOK2_ARCH_X86
-    #endif
+#if defined(__x86_64__)
+#define POLYHOOK2_OS_LINUX
+#define POLYHOOK2_ARCH_X64
+#else
+#define POLYHOOK2_OS_LINUX
+#define POLYHOOK2_ARCH_X86
+#endif
 #elif defined(__APPLE__)
-    #if defined(__x86_64__)
-        #define POLYHOOK2_OS_APPLE
-        #define POLYHOOK2_ARCH_X64
-    #else
-        #define POLYHOOK2_OS_APPLE
-        #define POLYHOOK2_ARCH_X86
-    #endif
+#if defined(__x86_64__)
+#define POLYHOOK2_OS_APPLE
+#define POLYHOOK2_ARCH_X64
+#else
+#define POLYHOOK2_OS_APPLE
+#define POLYHOOK2_ARCH_X86
+#endif
 #endif
 
 #if defined(_MSC_VER)
-    #define PLH_INLINE __forceinline
+#define PLH_INLINE __forceinline
 #elif defined(__GNUC__)
-    #define PLH_INLINE __attribute__((always_inline))
+#define PLH_INLINE __attribute__((always_inline))
 #else
-    #define PLH_INLINE inline
+#define PLH_INLINE inline
 #endif
 
 #include <iostream> //for debug printing

--- a/sources/PolyHookOs.cpp
+++ b/sources/PolyHookOs.cpp
@@ -8,11 +8,6 @@ void PolyHook2DebugBreak()
     __debugbreak();
 }
 
-void* PolyHook2Alloca(size_t size)
-{
-    return _alloca(size);
-}
-
 #elif defined(POLYHOOK2_OS_LINUX)
 
 void PolyHook2DebugBreak()
@@ -20,21 +15,11 @@ void PolyHook2DebugBreak()
     __asm__("int3");
 }
 
-void* PolyHook2Alloca(size_t size)
-{
-    return alloca(size);
-}
-
 #elif defined(POLYHOOK2_OS_APPLE)
 
 void PolyHook2DebugBreak()
 {
     __asm__("int3");
-}
-
-void* PolyHook2Alloca(size_t size)
-{
-    return alloca(size);
 }
 
 #endif


### PR DESCRIPTION
PolyHook2Alloca allocates memory dynamically on the stack but it wasn't being inline, causing the memory to be deallocated after it returned.

resolve #149 
Tested only on Windows MSVC.