### PR TITLE
m_hooked interactions

### DIFF
--- a/polyhook2/IHook.hpp
+++ b/polyhook2/IHook.hpp
@@ -52,6 +52,17 @@ public:
 		return true;
 	}
 
+	virtual bool setHooked(const bool state) {
+		if (m_hooked == state)
+			return true;
+
+		return state ? hook() : unHook();
+	}
+
+	virtual bool isHooked() {
+		return m_hooked;
+	}
+
 	virtual HookType getType() const = 0;
 
 	virtual void setDebug(const bool state) {


### PR DESCRIPTION
Adds more interactions regarding a hook's hooked state, now allowing for retrieval of current state and state attribution through a boolean.

resolves #155