### PR TITLE
Native Detour typedef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ if(POLYHOOK_FEATURE_DETOURS)
 
 	set(POLYHOOK_DETOUR_HEADERS
 		${PROJECT_SOURCE_DIR}/polyhook2/Detour/ADetour.hpp
+		${PROJECT_SOURCE_DIR}/polyhook2/Detour/NatDetour.hpp
 		${PROJECT_SOURCE_DIR}/polyhook2/Detour/x64Detour.hpp
 		${PROJECT_SOURCE_DIR}/polyhook2/Detour/x86Detour.hpp)
 

--- a/polyhook2/Detour/NatDetour.hpp
+++ b/polyhook2/Detour/NatDetour.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "polyhook2/PolyHookOs.hpp"
+
+#ifdef POLYHOOK2_ARCH_X64
+#include "polyhook2/Detour/x64Detour.hpp"
+#else
+#include "polyhook2/Detour/x86Detour.hpp"
+#endif
+
+namespace PLH {
+#ifdef POLYHOOK2_ARCH_X64
+	using NatDetour = x64Detour;
+#else
+	using NatDetour = x86Detour;
+#endif
+}


### PR DESCRIPTION
Created because I found myself having to do this on every project of mine which used Polyhook2.

Adds a typedef to whichever detour works with the current compilation environment, be it x64Detour or x86Detour. The typedef is named NatDetour, it also includes the proper header.

