### PR TITLE
cmake and linux specific bugfixes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	${PROJECT_SOURCE_DIR}/sources/UID.cpp
 	${PROJECT_SOURCE_DIR}/sources/Misc.cpp
 	${PROJECT_SOURCE_DIR}/sources/PolyHookOs.cpp
-	 "Examples/VCPKG_StaticLink/VCPKG_StaticLink/main.cpp")
+	)
 
 if(NOT POLYHOOK_BUILD_DLL)
 	target_compile_options(${PROJECT_NAME} PRIVATE

--- a/polyhook2/PolyHookOs.hpp
+++ b/polyhook2/PolyHookOs.hpp
@@ -39,7 +39,7 @@
 #if defined(_MSC_VER)
 #define PLH_INLINE __forceinline
 #elif defined(__GNUC__)
-#define PLH_INLINE __attribute__((always_inline))
+#define PLH_INLINE inline __attribute__((always_inline))
 #else
 #define PLH_INLINE inline
 #endif

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -52,7 +52,7 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 	if (!accessor.safe_mem_read(firstInstruction, (uint64_t)buf, size, read)) {
 		goto exit;
 	}
-	{
+
 	ZydisDecodedInstruction insInfo;
 	uint64_t offset = 0;
 	bool endHit = false;
@@ -101,7 +101,7 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 
 		offset += insInfo.length;
 	}
-}
+
 exit:
 	delete[] buf;
 	return insVec;

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -53,55 +53,55 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 		goto exit;
 	}
 	{
-		ZydisDecodedInstruction insInfo;
-		uint64_t offset = 0;
-		bool endHit = false;
-		while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(m_decoder, (char*) (buf + offset), (ZyanUSize) (read - offset), &insInfo))) {
-		Instruction::Displacement displacement = {};
-			displacement.Absolute = 0;
+	ZydisDecodedInstruction insInfo;
+	uint64_t offset = 0;
+	bool endHit = false;
+	while (ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(m_decoder, (char*) (buf + offset), (ZyanUSize) (read - offset), &insInfo))) {
+        Instruction::Displacement displacement = {};
+		displacement.Absolute = 0;
 
-			uint64_t address = start + offset;
+		uint64_t address = start + offset;
 
-			std::string opstr;
-			if (!getOpStr(&insInfo, address, &opstr)){
-				break;
-		}
+		std::string opstr;
+		if (!getOpStr(&insInfo, address, &opstr)){
+			break;
+        }
 
 
-			Instruction inst(address,
-							 displacement,
-							 0,
-							 false,
-							 false,
-							 (uint8_t*) ((unsigned char*) buf + offset),
-							 insInfo.length,
-							 ZydisMnemonicGetString(insInfo.mnemonic),
-							 opstr,
-							 m_mode);
+		Instruction inst(address,
+						 displacement,
+						 0,
+						 false,
+						 false,
+						 (uint8_t*) ((unsigned char*) buf + offset),
+						 insInfo.length,
+						 ZydisMnemonicGetString(insInfo.mnemonic),
+						 opstr,
+						 m_mode);
 
-			setDisplacementFields(inst, &insInfo);
-			if (endHit && !isPadBytes(inst)) {
-				break;
-		}
+		setDisplacementFields(inst, &insInfo);
+		if (endHit && !isPadBytes(inst)) {
+			break;
+        }
 
-			for (int i = 0; i < insInfo.operand_count; i++) {
-				auto op = insInfo.operands[i];
-				if (op.type == ZYDIS_OPERAND_TYPE_MEMORY && op.mem.type == ZYDIS_MEMOP_TYPE_MEM && op.mem.disp.has_displacement && op.mem.base == ZYDIS_REGISTER_NONE && op.mem.segment != ZYDIS_REGISTER_DS && inst.isIndirect()) {
-					inst.setIndirect(false);
-				}
+		for (int i = 0; i < insInfo.operand_count; i++) {
+			auto op = insInfo.operands[i];
+			if (op.type == ZYDIS_OPERAND_TYPE_MEMORY && op.mem.type == ZYDIS_MEMOP_TYPE_MEM && op.mem.disp.has_displacement && op.mem.base == ZYDIS_REGISTER_NONE && op.mem.segment != ZYDIS_REGISTER_DS && inst.isIndirect()) {
+				inst.setIndirect(false);
 			}
-
-			insVec.push_back(inst);
-
-			// searches instruction vector and updates references
-			addToBranchMap(insVec, inst);
-			if (isFuncEnd(inst, start == address)){
-				endHit = true;
 		}
 
-			offset += insInfo.length;
-		}
+		insVec.push_back(inst);
+
+		// searches instruction vector and updates references
+		addToBranchMap(insVec, inst);
+		if (isFuncEnd(inst, start == address)){
+			endHit = true;
+        }
+
+		offset += insInfo.length;
 	}
+}
 exit:
 	delete[] buf;
 	return insVec;

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -50,7 +50,8 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 	size_t read = 0;
 	auto* buf = new uint8_t[(uint32_t)size];
 	if (!accessor.safe_mem_read(firstInstruction, (uint64_t)buf, size, read)) {
-		goto exit;
+		delete[] buf;
+		return insVec;
 	}
 
 	ZydisDecodedInstruction insInfo;
@@ -102,7 +103,6 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 		offset += insInfo.length;
 	}
 
-exit:
 	delete[] buf;
 	return insVec;
 }


### PR DESCRIPTION
Removes missplaced source path which breaks cmake build in CMakeLists.txt.

"__attribute__((always_inline))" needs an additional "inline" to build correctly.

gcc does not like the goto statement without the curly brackets. 

With these changes polyhook should build fine on linux. 
