### PR TITLE
Fix compile warning in x86

### DIFF
--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -194,7 +194,7 @@ public:
 		m_isRelative = true;
 		m_hasDisplacement = true;
 
-		assert(m_dispOffset + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
+		assert(static_cast<size_t>(m_dispOffset) + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
 		std::memcpy(&m_bytes[getDisplacementOffset()], &m_displacement.Relative, m_dispSize);
 	}
 

--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -194,7 +194,7 @@ public:
 		m_isRelative = true;
 		m_hasDisplacement = true;
 
-		assert(static_cast<size_t>(m_dispOffset) + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
+		assert((size_t)m_dispOffset + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
 		std::memcpy(&m_bytes[getDisplacementOffset()], &m_displacement.Relative, m_dispSize);
 	}
 


### PR DESCRIPTION
When compiling my x86 hooking code, I was getting the following warning in MSVC:

`1>C:\vcpkg\installed\x86-windows\include\polyhook2\Instruction.hpp(198,3): warning C4018: '<=': signed/unsigned mismatch`