### PR TITLE
Fixed jmp opcode (0x25) which should not be the call opcode (0x15)

### DIFF
--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -151,7 +151,7 @@ void PLH::ZydisDisassembler::setDisplacementFields(PLH::Instruction& inst, const
 				if ((zydisInst->mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_JMP && inst.size() >= 2 && inst.getBytes().at(0) == 0xff && inst.getBytes().at(1) == 0x25) ||
 					(zydisInst->mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_CALL && inst.size() >= 2 && inst.getBytes().at(0) == 0xff && inst.getBytes().at(1) == 0x15) ||
 					(zydisInst->mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_CALL && inst.size() >= 3 && inst.getBytes().at(1) == 0xff && inst.getBytes().at(2) == 0x15) ||
-					(zydisInst->mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_JMP && inst.size() >= 3 && inst.getBytes().at(1) == 0xff && inst.getBytes().at(2) == 0x15)
+					(zydisInst->mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_JMP && inst.size() >= 3 && inst.getBytes().at(1) == 0xff && inst.getBytes().at(2) == 0x25)
 					) {
 
 					// is displacement set earlier already?


### PR DESCRIPTION
Fix to #180.
I was also having trouble hooking some WinAPI functions in my system. After some debugging, I found out **Detour::followJmp** was not following the jump because **Instruction::m_isIndirect** was not being correctly set to true, so **Instruction::getDestination()** failed. The jmp opcode is 0x25 and not 0x15, as shown by x64dbg's disassembler:
![image](https://github.com/stevemk14ebr/PolyHook_2_0/assets/5056011/3296b83e-fc91-40d1-91ef-edef7469283c)
![image](https://github.com/stevemk14ebr/PolyHook_2_0/assets/5056011/18b92e74-598c-4299-b629-695013ccb072)
