### PR TITLE
Improve logging

### DIFF
--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -194,7 +194,7 @@ public:
 		m_isRelative = true;
 		m_hasDisplacement = true;
 
-		assert(m_dispOffset + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
+		assert(static_cast<size_t>(m_dispOffset) + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
 		std::memcpy(&m_bytes[getDisplacementOffset()], &m_displacement.Relative, m_dispSize);
 	}
 

--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -194,7 +194,7 @@ public:
 		m_isRelative = true;
 		m_hasDisplacement = true;
 
-		assert(static_cast<size_t>(m_dispOffset) + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
+		assert((size_t)m_dispOffset + m_dispSize <= m_bytes.size() && m_dispSize <= sizeof(m_displacement.Relative));
 		std::memcpy(&m_bytes[getDisplacementOffset()], &m_displacement.Relative, m_dispSize);
 	}
 

--- a/sources/x64Detour.cpp
+++ b/sources/x64Detour.cpp
@@ -60,9 +60,9 @@ const char* x64Detour::printDetourScheme(detour_scheme_t scheme)
 
 template<uint16_t SIZE>
 optional<uint64_t> x64Detour::findNearestCodeCave(uint64_t address) {
-	static_assert(SIZE + 1 < FINDPATTERN_SCRATCH_SIZE);
     static_assert(SIZE + 1 < FINDPATTERN_SCRATCH_SIZE);
-	
+    static_assert(SIZE + 1 < FINDPATTERN_SCRATCH_SIZE);
+
     const uint64_t chunkSize = 64000;
     auto* data = new unsigned char[chunkSize];
     auto delete_data = finally([=]() {
@@ -320,9 +320,8 @@ bool x64Detour::allocate_jump_to_callback() {
 
 bool x64Detour::hook() {
     Log::log("m_fnAddress: " + int_to_hex(m_fnAddress) + "\n", ErrorLevel::INFO);
-
     insts_t insts = m_disasm.disassemble(m_fnAddress, m_fnAddress, m_fnAddress + 100, *this);
-	Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
+    Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
 
     if (insts.empty()) {
         Log::log("Disassembler unable to decode any valid instructions", ErrorLevel::SEV);
@@ -341,6 +340,12 @@ bool x64Detour::hook() {
         return false;
     }
 
+    {
+        std::stringstream ss;
+        ss << printDetourScheme(m_chosen_scheme);
+        Log::log("Chosen detour scheme: " + ss.str() + "\n", ErrorLevel::INFO);
+    }
+
     // min size of patches that may split instructions
     // For valloc & code cave, we insert the jump, hence we take only size of the 1st instruction.
     // For detours, we calculate the size of the generated code.
@@ -355,12 +360,6 @@ bool x64Detour::hook() {
     if (!prologueOpt) {
         Log::log("Function too small to hook safely!", ErrorLevel::SEV);
         return false;
-    }
-	
-	{
-        std::stringstream ss;
-        ss << printDetourScheme(m_chosen_scheme);
-        Log::log("Chosen detour scheme: " + ss.str() + "\n", ErrorLevel::INFO);
     }
 
     assert(roundProlSz >= minProlSz);

--- a/sources/x64Detour.cpp
+++ b/sources/x64Detour.cpp
@@ -45,8 +45,24 @@ void x64Detour::setDetourScheme(detour_scheme_t scheme) {
     m_detourScheme = scheme;
 }
 
+const char* x64Detour::printDetourScheme(detour_scheme_t scheme)
+{
+        switch (scheme) {
+        case VALLOC2: return "VALLOC2";
+        case INPLACE: return "INPLACE";
+        case CODE_CAVE: return "CODE_CAVE";
+        case INPLACE_SHORT: return "INPLACE_SHORT";
+        case RECOMMENDED: return "RECOMMENDED";
+        case ALL: return "ALL";
+        default: return "UNKNOWN";
+        }
+}
+
 template<uint16_t SIZE>
 optional<uint64_t> x64Detour::findNearestCodeCave(uint64_t address) {
+	static_assert(SIZE + 1 < FINDPATTERN_SCRATCH_SIZE);
+    static_assert(SIZE + 1 < FINDPATTERN_SCRATCH_SIZE);
+	
     const uint64_t chunkSize = 64000;
     auto* data = new unsigned char[chunkSize];
     auto delete_data = finally([=]() {
@@ -339,6 +355,12 @@ bool x64Detour::hook() {
     if (!prologueOpt) {
         Log::log("Function too small to hook safely!", ErrorLevel::SEV);
         return false;
+    }
+	
+	{
+        std::stringstream ss;
+        ss << printDetourScheme(m_chosen_scheme);
+        Log::log("Chosen detour scheme: " + ss.str() + "\n", ErrorLevel::INFO);
     }
 
     assert(roundProlSz >= minProlSz);

--- a/sources/x64Detour.cpp
+++ b/sources/x64Detour.cpp
@@ -320,6 +320,7 @@ bool x64Detour::allocate_jump_to_callback() {
 
 bool x64Detour::hook() {
     Log::log("m_fnAddress: " + int_to_hex(m_fnAddress) + "\n", ErrorLevel::INFO);
+
     insts_t insts = m_disasm.disassemble(m_fnAddress, m_fnAddress, m_fnAddress + 100, *this);
     Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
 

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -17,10 +17,10 @@ uint8_t getJmpSize() {
 }
 
 bool x86Detour::hook() {
-	Log::log("m_fnAddress: " + int_to_hex(m_fnAddress) + "\n", ErrorLevel::INFO);
+    Log::log("m_fnAddress: " + int_to_hex(m_fnAddress) + "\n", ErrorLevel::INFO);
 	
     insts_t insts = m_disasm.disassemble(m_fnAddress, m_fnAddress, m_fnAddress + 100, *this);
-	Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
+    Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
 	
     if (insts.empty()) {
         Log::log("Disassembler unable to decode any valid instructions", ErrorLevel::SEV);

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -17,7 +17,11 @@ uint8_t getJmpSize() {
 }
 
 bool x86Detour::hook() {
+	Log::log("m_fnAddress: " + int_to_hex(m_fnAddress) + "\n", ErrorLevel::INFO);
+	
     insts_t insts = m_disasm.disassemble(m_fnAddress, m_fnAddress, m_fnAddress + 100, *this);
+	Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
+	
     if (insts.empty()) {
         Log::log("Disassembler unable to decode any valid instructions", ErrorLevel::SEV);
         return false;
@@ -32,8 +36,6 @@ bool x86Detour::hook() {
     m_fnAddress = insts.front().getAddress();
 
     // --------------- END RECURSIVE JMP RESOLUTION ---------------------
-
-    Log::log("Original function:\n" + instsToStr(insts) + "\n", ErrorLevel::INFO);
 
     uint64_t minProlSz = getJmpSize(); // min size of patches that may split instructions
     uint64_t roundProlSz = minProlSz; // nearest size to min that doesn't split any instructions


### PR DESCRIPTION
* Print the `m_fnAddress` address at the beginning: If disassembling yields an empty instructions list, it will still log out the address
* Print the instructions directly after disassembling: If any error occurred shortly afterwards (e.g. in `followJmp`), we still get logging output of the instructions