### PR TITLE
Fixed warning in FBAllocator.cpp

### DIFF
--- a/sources/FBAllocator.cpp
+++ b/sources/FBAllocator.cpp
@@ -73,8 +73,7 @@ void* ALLOC_Alloc(ALLOC_HANDLE hAlloc, size_t size)
     // Convert handle to an ALLOC_Allocator instance
     self = (ALLOC_Allocator*)hAlloc;
 
-    // Ensure requested size fits within memory block 
-    (size);
+    // Ensure requested size fits within memory block
     assert(size <= self->blockSize);
 
     // Get a block from the free-list


### PR DESCRIPTION
The expression '(size)' is unused and generates a warning [-Wunused-value] in FBAllocator.cpp at line 77, column 6.

This line is very irritating, especially with -Werror, so it is better to delete it.
It did not appear to have much logic anyway.
