### PR TITLE
Prioritizes writing the jump target address before the actual hook

### DIFF
--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -462,7 +462,7 @@ inline PLH::insts_t makex64MinimumJump(const uint64_t address, const uint64_t de
 	std::stringstream ss;
 	ss << std::hex << "[" << destHolder << "] ->" << destination;
 
-	return { Instruction(address, disp, 2, true, true, bytes, "jmp", ss.str(), Mode::x64),  specialDest };
+	return { specialDest, Instruction(address, disp, 2, true, true, bytes, "jmp", ss.str(), Mode::x64) };
 }
 
 inline PLH::insts_t makex86Jmp(const uint64_t address, const uint64_t destination) {


### PR DESCRIPTION
This reduces the possibility of crashes when hooking without suspendthreads.
The best option may be to stop the entire execution, because even change the order there is a possibility that is hooking while executing at the target address, thus leading to uncontrollable results. But at least doing so does not expose the target to a jump to an uncontrolled address.