### PR TITLE
Linux and 32 bit compile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+
 project(PolyHook_2)
 string(TOLOWER ${PROJECT_NAME} LOWERCASE_PROJECT_NAME)
 include(CMakePackageConfigHelpers)
@@ -40,6 +43,23 @@ endif()
 option(POLYHOOK_FEATURE_DETOURS "Implement detour functionality" ON)
 option(POLYHOOK_FEATURE_INLINENTD "Support inline hooks without specifying typedefs by generating callback stubs at runtime with AsmJit" ON)
 option(POLYHOOK_FEATURE_VIRTUALS "Implement all virtual table hooking functionality" ON)
+
+option(POLYHOOK_COMPILE_32 "Force 32 bit compile" OFF)
+option(POLYHOOK_DISABLE_IOSTREAM "Replace iostream debug routines with more Cish versions for stability" OFF)
+option(POLYHOOK_DISABLE_INSTRUCTION_PRINTING "Disable instruction debug printing for more speed" OFF)
+
+if(POLYHOOK_COMPILE_32)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+endif()
+
+if(POLYHOOK_DISABLE_IOSTREAM)
+	add_compile_definitions(POLYHOOK_DISABLE_IOSTREAM=1)
+endif()
+
+if(POLYHOOK_DISABLE_INSTRUCTION_PRINTING)
+	add_compile_definitions(POLYHOOK_DISABLE_INSTRUCTION_PRINTING=1)
+endif()
 
 #
 # ASMTK

--- a/polyhook2/Detour/x86Detour.hpp
+++ b/polyhook2/Detour/x86Detour.hpp
@@ -17,6 +17,7 @@ namespace PLH {
 
 class x86Detour : public Detour {
 public:
+    x86Detour(const uint32_t fnAddress, const uint32_t fnCallback, uint32_t* userTrampVar);
     x86Detour(uint64_t fnAddress, uint64_t fnCallback, uint64_t* userTrampVar);
 
     virtual ~x86Detour() = default;

--- a/polyhook2/IHook.hpp
+++ b/polyhook2/IHook.hpp
@@ -12,7 +12,9 @@
 #include <functional>
 
 #if defined(__clang__)
+#ifndef NOINLINE
 #define NOINLINE __attribute__((noinline))
+#endif
 #define PH_ATTR_NAKED __attribute__((naked))
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define NOINLINE __attribute__((noinline))
@@ -25,6 +27,10 @@ _Pragma("GCC optimize (\"O0\")")
 #define PH_ATTR_NAKED __declspec(naked)
 #define OPTS_OFF __pragma(optimize("", off))
 #define OPTS_ON __pragma(optimize("", on))
+#endif
+
+#ifdef __linux__
+#define __thiscall
 #endif
 
 #define PH_UNUSED(a) (void)a
@@ -119,9 +125,17 @@ struct callback_type<Ret(CCFROM Class::*)(Args...), void> \
 };
 
 #ifndef _MSC_VER
+#ifndef __cdecl
 #define __cdecl __attribute__((__cdecl__))
+#endif
+
+#ifndef __fastcall
 #define __fastcall __attribute__((__fastcall__))
+#endif
+
+#ifndef __stdcall
 #define __stdcall __attribute__((__stdcall__))
+#endif
 #endif
 
 #ifndef POLYHOOK2_ARCH_X64
@@ -131,12 +145,17 @@ MAKE_CALLBACK_CLASS_IMPL(__stdcall, __stdcall)
 MAKE_CALLBACK_IMPL(__cdecl, __cdecl)
 MAKE_CALLBACK_CLASS_IMPL(__cdecl, __cdecl)
 
+#ifndef __linux__
 MAKE_CALLBACK_IMPL(__thiscall, __thiscall)
 MAKE_CALLBACK_CLASS_IMPL(__thiscall, __fastcall, char*)
 #endif
 
+#endif
+
+#if defined(__linux__) && defined(__i386__)
 MAKE_CALLBACK_IMPL(__fastcall, __fastcall)
 MAKE_CALLBACK_CLASS_IMPL(__fastcall, __fastcall)
+#endif
 
 template <int I, class... Ts>
 decltype(auto) get_pack_idx(Ts&&... ts) {

--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -508,7 +508,7 @@ inline PLH::insts_t makex64MinimumJump(const uint64_t address, const uint64_t de
 	bytes[1] = 0x25;
 	memcpy(&bytes[2], &disp.Relative, 4);
 
-#ifndef __linux__
+#ifndef POLYHOOK_DISABLE_IOSTREAM
 	std::stringstream ss;
 	ss << std::hex << "[" << destHolder << "] ->" << destination;
 	return { specialDest, Instruction(address, disp, 2, true, true, bytes, "jmp", ss.str(), Mode::x64) };

--- a/polyhook2/Misc.hpp
+++ b/polyhook2/Misc.hpp
@@ -191,11 +191,21 @@ using ci_wstring_view = std::basic_string_view<wchar_t, ci_wchar_traits>;
 template< typename T >
 std::string int_to_hex(T i)
 {
+#ifndef POLYHOOK_DISABLE_IOSTREAM
 	std::stringstream stream;
 	stream << "0x" << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex
 		<< (uint64_t) i; // We cast to the highest possible int because uint8_t will be printed as char
 
 	return stream.str();
+#else
+	char buffer[32];
+#ifdef __i386__
+	sprintf(buffer, "0x%0*x", (int)sizeof(T) * 2, (uintptr_t)i);
+#else
+	sprintf(buffer, "0x%0*lx", (int)sizeof(T) * 2, (uintptr_t)i);
+#endif
+	return std::string(buffer);
+#endif
 }
 
 template< typename T >

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -5,6 +5,10 @@
 
 namespace PLH {
 
+x86Detour::x86Detour(const uint32_t fnAddress, const uint32_t fnCallback, uint32_t* userTrampVar)
+    : Detour(static_cast<uint64_t>(fnAddress), static_cast<uint64_t>(fnCallback), reinterpret_cast<uint64_t*>(userTrampVar), getArchType()) {}
+
+
 x86Detour::x86Detour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar)
     : Detour(fnAddress, fnCallback, userTrampVar, getArchType()) {}
 


### PR DESCRIPTION
While attempting to use this library in Linux and 32bit, I ran into a quite a few issues. My build environment is Ubuntu 22.04 x64 which I would guess is probably the most common Linux build environment so I was rather surprised.

For some reason anything using ostream would segfault, so I have written alternatives which can be enabled with a cmake

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f1db217b09b in char32_t std::(anonymous namespace)::read_utf8_code_point<char>(std::(anonymous namespace)::range<char const, true>&, unsigned long)
#1  0x00007f1db217cf3f in std::codecvt_base::result std::(anonymous namespace)::utf16_in<char, char16_t>(std::(anonymous namespace)::range<char const, true>&, std::(anonymous namespace)::range<char16_t, true>&, unsigned long, std::codecvt_mode, std::(anonymous namespace)::surrogates) ()
#2  0x00007f1db217d0a4 in std::codecvt<char16_t, char, __mbstate_t>::do_in(__mbstate_t&, char const*, char const*, char const*&, char16_t*, char16_t*, char16_t*&) const ()
#3  0x00007f1db21df14a in std::ostream& std::ostream::_M_insert<unsigned long>(unsigned long) ()
#4  0x00007f1db2107c1d in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > PLH::int_to_hex<unsigned long>(unsigned long) ()
#5  0x00007f1db20fff0e in PLH::x64Detour::hook()
```

Added some cmake options.

POLYHOOK_COMPILE_32 = add C and C++ flags to compile for 32 bits 
POLYHOOK_DISABLE_IOSTREAM = Replace iostream with alternative. It was crashing on my linux build for some reason. 
POLYHOOK_DISABLE_INSTRUCTION_PRINTING = Disable the printing of instructions in the debug log. Could make a difference when hooking hundreds of functions.

Add a bunch of ifdef in IHook.hpp to prevent linux compile errors.

Add an x86Detour constructor that accepts 32bit ints and upcasts them to 64bit behind the scenes.