### PR TITLE
Add x86HotpatchDetour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,14 +274,16 @@ if(POLYHOOK_FEATURE_DETOURS)
 		${PROJECT_SOURCE_DIR}/polyhook2/Detour/ADetour.hpp
 		${PROJECT_SOURCE_DIR}/polyhook2/Detour/NatDetour.hpp
 		${PROJECT_SOURCE_DIR}/polyhook2/Detour/x64Detour.hpp
-		${PROJECT_SOURCE_DIR}/polyhook2/Detour/x86Detour.hpp)
+		${PROJECT_SOURCE_DIR}/polyhook2/Detour/x86Detour.hpp
+		${PROJECT_SOURCE_DIR}/polyhook2/Detour/x86HotpatchDetour.hpp)
 
 	install(FILES ${POLYHOOK_DETOUR_HEADERS} DESTINATION include/polyhook2/Detour)
 
 	target_sources(${PROJECT_NAME} PRIVATE
 		${PROJECT_SOURCE_DIR}/sources/ADetour.cpp
 		${PROJECT_SOURCE_DIR}/sources/x64Detour.cpp
-		${PROJECT_SOURCE_DIR}/sources/x86Detour.cpp)
+		${PROJECT_SOURCE_DIR}/sources/x86Detour.cpp
+		${PROJECT_SOURCE_DIR}/sources/x86HotpatchDetour.cpp)
 
 	# only build tests if making exe
 	if(NOT POLYHOOK_BUILD_DLL)
@@ -291,7 +293,9 @@ if(POLYHOOK_FEATURE_DETOURS)
 			    ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourTranslationx64.cpp
 				${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourSchemex64.cpp)
 		elseif(CMAKE_SIZEOF_VOID_P EQUAL 4) #32-bit
-			target_sources(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourx86.cpp)
+			target_sources(${PROJECT_NAME} PRIVATE
+			    ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourx86.cpp
+			    ${PROJECT_SOURCE_DIR}/UnitTests/${POLYHOOK_OS}/TestDetourx86hotpatch.cpp)
 		endif()
 	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,13 +59,13 @@ if(POLYHOOK_FEATURE_DETOURS AND NOT POLYHOOK_USE_EXTERNAL_ASMTK)
 	if(NOT POLYHOOK_USE_EXTERNAL_ASMJIT)
 	    set(ASMJIT_DIR "${PROJECT_SOURCE_DIR}/asmjit")
     endif()
-
+	# asmjit and asmtk do not use `option`
 	if(POLYHOOK_BUILD_SHARED_ASMTK)
-		set(ASMTK_STATIC OFF CACHE BOOL "")
-        set(ASMJIT_STATIC OFF CACHE BOOL "")
+		set(ASMTK_STATIC OFF)
+		set(ASMJIT_STATIC OFF)
     else()
-		set(ASMTK_STATIC ON CACHE BOOL "")
-        set(ASMJIT_STATIC ON CACHE BOOL "")
+		set(ASMTK_STATIC ON)
+		set(ASMJIT_STATIC ON)
     endif()
 
     add_subdirectory(asmtk)
@@ -88,10 +88,11 @@ endif()
 if(POLYHOOK_FEATURE_INLINENTD AND NOT POLYHOOK_USE_EXTERNAL_ASMJIT)
     # Avoid including asmjit again if it was already included
     if(NOT TARGET asmjit)
+        # asmjit doesn't use `option`
         if(POLYHOOK_BUILD_SHARED_ASMJIT)
-            set(ASMJIT_STATIC OFF CACHE BOOL "")
+            set(ASMJIT_STATIC OFF)
         else()
-            set(ASMJIT_STATIC ON CACHE BOOL "")
+            set(ASMJIT_STATIC ON)
         endif()
 
 	add_subdirectory(asmjit)
@@ -103,13 +104,23 @@ endif()
 # Zydis
 #
 
-if(NOT POLYHOOK_USE_EXTERNAL_ZYDIS)
-    set(ZYDIS_BUILD_SHARED_LIB ${POLYHOOK_BUILD_SHARED_ZYDIS} CACHE BOOL "")
-	set(ZYCORE_BUILD_SHARED_LIB ${POLYHOOK_BUILD_SHARED_ZYDIS} CACHE BOOL "")
-	set(ZYDIS_BUILD_TOOLS OFF CACHE BOOL "")
-	set(ZYDIS_BUILD_EXAMPLES OFF CACHE BOOL "")
+function(set_zycore_options)
+	set(ZYCORE_BUILD_SHARED_LIB ${POLYHOOK_BUILD_SHARED_ZYDIS} CACHE BOOL "" FORCE)
+	set(ZYCORE_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+	set(ZYCORE_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+endfunction()
 
+function(set_zydis_options)
+	set(ZYDIS_BUILD_SHARED_LIB ${POLYHOOK_BUILD_SHARED_ZYDIS} CACHE BOOL "" FORCE)
+	set(ZYDIS_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
+	set(ZYDIS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+	set(ZYDIS_BUILD_DOXYGEN OFF CACHE BOOL "" FORCE)
+endfunction()
+
+if(NOT POLYHOOK_USE_EXTERNAL_ZYDIS)
+	set_zycore_options()
 	add_subdirectory(zydis/dependencies/zycore)
+	set_zydis_options()
 	add_subdirectory(zydis)
 
 	if(MSVC)

--- a/Catch.hpp
+++ b/Catch.hpp
@@ -1,21 +1,21 @@
 /*
- *  Catch v2.13.3
- *  Generated: 2020-10-31 18:20:31.045274
+ *  Catch v2.13.10
+ *  Generated: 2022-10-16 11:01:23.452308
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
- *  Copyright (c) 2020 Two Blue Cubes Ltd. All rights reserved.
+ *  Copyright (c) 2022 Two Blue Cubes Ltd. All rights reserved.
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 #ifndef TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
 #define TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-// start catch.hpp
+ // start catch.hpp
 
 
 #define CATCH_VERSION_MAJOR 2
 #define CATCH_VERSION_MINOR 13
-#define CATCH_VERSION_PATCH 3
+#define CATCH_VERSION_PATCH 10
 
 #ifdef __clang__
 #    pragma clang system_header
@@ -66,13 +66,16 @@
 #if !defined(CATCH_CONFIG_IMPL_ONLY)
 // start catch_platform.h
 
+// See e.g.:
+// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
-# include <TargetConditionals.h>
-# if TARGET_OS_OSX == 1
-#  define CATCH_PLATFORM_MAC
-# elif TARGET_OS_IPHONE == 1
-#  define CATCH_PLATFORM_IPHONE
-# endif
+#  include <TargetConditionals.h>
+#  if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || \
+      (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)
+#    define CATCH_PLATFORM_MAC
+#  elif (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+#    define CATCH_PLATFORM_IPHONE
+#  endif
 
 #elif defined(linux) || defined(__linux) || defined(__linux__)
 #  define CATCH_PLATFORM_LINUX
@@ -132,9 +135,9 @@ namespace Catch {
 
 #endif
 
-// We have to avoid both ICC and Clang, because they try to mask themselves
-// as gcc, and we want only GCC in this block
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !defined(__CUDACC__)
+// Only GCC compiler should be used in this block, so other compilers trying to
+// mask themselves as GCC should be ignored.
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !defined(__CUDACC__) && !defined(__LCC__)
 #    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic push" )
 #    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "GCC diagnostic pop" )
 
@@ -183,13 +186,13 @@ namespace Catch {
 ////////////////////////////////////////////////////////////////////////////////
 // Assume that non-Windows platforms support posix signals by default
 #if !defined(CATCH_PLATFORM_WINDOWS)
-    #define CATCH_INTERNAL_CONFIG_POSIX_SIGNALS
+#define CATCH_INTERNAL_CONFIG_POSIX_SIGNALS
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // We know some environments not to support full POSIX signals
 #if defined(__CYGWIN__) || defined(__QNX__) || defined(__EMSCRIPTEN__) || defined(__DJGPP__)
-    #define CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS
+#define CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS
 #endif
 
 #ifdef __OS400__
@@ -237,9 +240,6 @@ namespace Catch {
 // Visual C++
 #if defined(_MSC_VER)
 
-#  define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
-#  define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  __pragma( warning(pop) )
-
 // Universal Windows platform does not support SEH
 // Or console colours (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
@@ -248,13 +248,18 @@ namespace Catch {
 #    define CATCH_INTERNAL_CONFIG_WINDOWS_SEH
 #  endif
 
+#  if !defined(__clang__) // Handle Clang masquerading for msvc
+
 // MSVC traditional preprocessor needs some workaround for __VA_ARGS__
 // _MSVC_TRADITIONAL == 0 means new conformant preprocessor
 // _MSVC_TRADITIONAL == 1 means old traditional non-conformant preprocessor
-#  if !defined(__clang__) // Handle Clang masquerading for msvc
 #    if !defined(_MSVC_TRADITIONAL) || (defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL)
 #      define CATCH_INTERNAL_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #    endif // MSVC_TRADITIONAL
+
+// Only do this if we're not using clang on Windows, which uses `diagnostic push` & `diagnostic pop`
+#    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
+#    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  __pragma( warning(pop) )
 #  endif // __clang__
 
 #endif // _MSC_VER
@@ -279,7 +284,7 @@ namespace Catch {
 ////////////////////////////////////////////////////////////////////////////////
 // Embarcadero C++Build
 #if defined(__BORLANDC__)
-    #define CATCH_INTERNAL_CONFIG_POLYFILL_ISNAN
+#define CATCH_INTERNAL_CONFIG_POLYFILL_ISNAN
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -290,7 +295,7 @@ namespace Catch {
 // Otherwise all supported compilers support COUNTER macro,
 // but user still might want to turn it off
 #if ( !defined(__JETBRAINS_IDE__) || __JETBRAINS_IDE__ >= 20170300L )
-    #define CATCH_INTERNAL_CONFIG_COUNTER
+#define CATCH_INTERNAL_CONFIG_COUNTER
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -299,9 +304,9 @@ namespace Catch {
 // This means that it is detected as Windows, but does not provide
 // the same set of capabilities as real Windows does.
 #if defined(UNDER_RTSS) || defined(RTX64_BUILD)
-    #define CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH
-    #define CATCH_INTERNAL_CONFIG_NO_ASYNC
-    #define CATCH_CONFIG_COLOUR_NONE
+#define CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH
+#define CATCH_INTERNAL_CONFIG_NO_ASYNC
+#define CATCH_CONFIG_COLOUR_NONE
 #endif
 
 #if !defined(_GLIBCXX_USE_C99_MATH_TR1)
@@ -311,38 +316,38 @@ namespace Catch {
 // Various stdlib support checks that require __has_include
 #if defined(__has_include)
   // Check if string_view is available and usable
-  #if __has_include(<string_view>) && defined(CATCH_CPP17_OR_GREATER)
-  #    define CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW
-  #endif
+#if __has_include(<string_view>) && defined(CATCH_CPP17_OR_GREATER)
+#    define CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW
+#endif
 
-  // Check if optional is available and usable
-  #  if __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
-  #    define CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL
-  #  endif // __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
+// Check if optional is available and usable
+#  if __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
+#    define CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL
+#  endif // __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
 
-  // Check if byte is available and usable
-  #  if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
-  #    include <cstddef>
-  #    if __cpp_lib_byte > 0
-  #      define CATCH_INTERNAL_CONFIG_CPP17_BYTE
-  #    endif
-  #  endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+// Check if byte is available and usable
+#  if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+#    include <cstddef>
+#    if defined(__cpp_lib_byte) && (__cpp_lib_byte > 0)
+#      define CATCH_INTERNAL_CONFIG_CPP17_BYTE
+#    endif
+#  endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
 
-  // Check if variant is available and usable
-  #  if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
-  #    if defined(__clang__) && (__clang_major__ < 8)
-         // work around clang bug with libstdc++ https://bugs.llvm.org/show_bug.cgi?id=31852
-         // fix should be in clang 8, workaround in libstdc++ 8.2
-  #      include <ciso646>
-  #      if defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
-  #        define CATCH_CONFIG_NO_CPP17_VARIANT
-  #      else
-  #        define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
-  #      endif // defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
-  #    else
-  #      define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
-  #    endif // defined(__clang__) && (__clang_major__ < 8)
-  #  endif // __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
+// Check if variant is available and usable
+#  if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
+#    if defined(__clang__) && (__clang_major__ < 8)
+       // work around clang bug with libstdc++ https://bugs.llvm.org/show_bug.cgi?id=31852
+       // fix should be in clang 8, workaround in libstdc++ 8.2
+#      include <ciso646>
+#      if defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
+#        define CATCH_CONFIG_NO_CPP17_VARIANT
+#      else
+#        define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
+#      endif // defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
+#    else
+#      define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
+#    endif // defined(__clang__) && (__clang_major__ < 8)
+#  endif // __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
 #endif // defined(__has_include)
 
 #if defined(CATCH_INTERNAL_CONFIG_COUNTER) && !defined(CATCH_CONFIG_NO_COUNTER) && !defined(CATCH_CONFIG_COUNTER)
@@ -478,16 +483,18 @@ std::ostream& operator<<(std::ostream&, Catch_global_namespace_dummy);
 
 namespace Catch {
 
-    struct CaseSensitive { enum Choice {
-        Yes,
-        No
-    }; };
+    struct CaseSensitive {
+        enum Choice {
+            Yes,
+            No
+        };
+    };
 
     class NonCopyable {
-        NonCopyable( NonCopyable const& )              = delete;
-        NonCopyable( NonCopyable && )                  = delete;
-        NonCopyable& operator = ( NonCopyable const& ) = delete;
-        NonCopyable& operator = ( NonCopyable && )     = delete;
+        NonCopyable(NonCopyable const&) = delete;
+        NonCopyable(NonCopyable&&) = delete;
+        NonCopyable& operator = (NonCopyable const&) = delete;
+        NonCopyable& operator = (NonCopyable&&) = delete;
 
     protected:
         NonCopyable();
@@ -497,25 +504,25 @@ namespace Catch {
     struct SourceLineInfo {
 
         SourceLineInfo() = delete;
-        SourceLineInfo( char const* _file, std::size_t _line ) noexcept
-        :   file( _file ),
-            line( _line )
+        SourceLineInfo(char const* _file, std::size_t _line) noexcept
+            : file(_file),
+            line(_line)
         {}
 
-        SourceLineInfo( SourceLineInfo const& other )            = default;
-        SourceLineInfo& operator = ( SourceLineInfo const& )     = default;
-        SourceLineInfo( SourceLineInfo&& )              noexcept = default;
-        SourceLineInfo& operator = ( SourceLineInfo&& ) noexcept = default;
+        SourceLineInfo(SourceLineInfo const& other) = default;
+        SourceLineInfo& operator = (SourceLineInfo const&) = default;
+        SourceLineInfo(SourceLineInfo&&)              noexcept = default;
+        SourceLineInfo& operator = (SourceLineInfo&&) noexcept = default;
 
         bool empty() const noexcept { return file[0] == '\0'; }
-        bool operator == ( SourceLineInfo const& other ) const noexcept;
-        bool operator < ( SourceLineInfo const& other ) const noexcept;
+        bool operator == (SourceLineInfo const& other) const noexcept;
+        bool operator < (SourceLineInfo const& other) const noexcept;
 
         char const* file;
         std::size_t line;
     };
 
-    std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
+    std::ostream& operator << (std::ostream& os, SourceLineInfo const& info);
 
     // Bring in operator<< from global namespace into Catch namespace
     // This is necessary because the overload of operator<< above makes
@@ -530,7 +537,7 @@ namespace Catch {
         std::string operator+() const;
     };
     template<typename T>
-    T const& operator + ( T const& value, StreamEndStop ) {
+    T const& operator + (T const& value, StreamEndStop) {
         return value;
     }
 }
@@ -542,7 +549,7 @@ namespace Catch {
 namespace Catch {
 
     struct RegistrarForTagAliases {
-        RegistrarForTagAliases( char const* alias, char const* tag, SourceLineInfo const& lineInfo );
+        RegistrarForTagAliases(char const* alias, char const* tag, SourceLineInfo const& lineInfo);
     };
 
 } // end namespace Catch
@@ -565,7 +572,7 @@ namespace Catch {
     class TestSpec;
 
     struct ITestInvoker {
-        virtual void invoke () const = 0;
+        virtual void invoke() const = 0;
         virtual ~ITestInvoker();
     };
 
@@ -575,13 +582,13 @@ namespace Catch {
     struct ITestCaseRegistry {
         virtual ~ITestCaseRegistry();
         virtual std::vector<TestCase> const& getAllTests() const = 0;
-        virtual std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const = 0;
+        virtual std::vector<TestCase> const& getAllTestsSorted(IConfig const& config) const = 0;
     };
 
-    bool isThrowSafe( TestCase const& testCase, IConfig const& config );
-    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
-    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
-    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+    bool isThrowSafe(TestCase const& testCase, IConfig const& config);
+    bool matchTest(TestCase const& testCase, TestSpec const& testSpec, IConfig const& config);
+    std::vector<TestCase> filterTests(std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config);
+    std::vector<TestCase> const& getAllTestCasesSorted(IConfig const& config);
 
 }
 
@@ -612,16 +619,16 @@ namespace Catch {
     public: // construction
         constexpr StringRef() noexcept = default;
 
-        StringRef( char const* rawChars ) noexcept;
+        StringRef(char const* rawChars) noexcept;
 
-        constexpr StringRef( char const* rawChars, size_type size ) noexcept
-        :   m_start( rawChars ),
-            m_size( size )
+        constexpr StringRef(char const* rawChars, size_type size) noexcept
+            : m_start(rawChars),
+            m_size(size)
         {}
 
-        StringRef( std::string const& stdString ) noexcept
-        :   m_start( stdString.c_str() ),
-            m_size( stdString.size() )
+        StringRef(std::string const& stdString) noexcept
+            : m_start(stdString.c_str()),
+            m_size(stdString.size())
         {}
 
         explicit operator std::string() const {
@@ -629,12 +636,12 @@ namespace Catch {
         }
 
     public: // operators
-        auto operator == ( StringRef const& other ) const noexcept -> bool;
+        auto operator == (StringRef const& other) const noexcept -> bool;
         auto operator != (StringRef const& other) const noexcept -> bool {
             return !(*this == other);
         }
 
-        auto operator[] ( size_type index ) const noexcept -> char {
+        auto operator[] (size_type index) const noexcept -> char {
             assert(index < m_size);
             return m_start[index];
         }
@@ -655,7 +662,7 @@ namespace Catch {
         // Returns a substring of [start, start + length).
         // If start + length > size(), then the substring is [start, size()).
         // If start > size(), then the substring is empty.
-        auto substr( size_type start, size_type length ) const noexcept -> StringRef;
+        auto substr(size_type start, size_type length) const noexcept -> StringRef;
 
         // Returns the current start pointer. May not be null-terminated.
         auto data() const noexcept -> char const*;
@@ -669,16 +676,16 @@ namespace Catch {
         constexpr const_iterator end() const { return m_start + m_size; }
     };
 
-    auto operator += ( std::string& lhs, StringRef const& sr ) -> std::string&;
-    auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
+    auto operator += (std::string& lhs, StringRef const& sr)->std::string&;
+    auto operator << (std::ostream& os, StringRef const& sr)->std::ostream&;
 
-    constexpr auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
-        return StringRef( rawChars, size );
+    constexpr auto operator "" _sr(char const* rawChars, std::size_t size) noexcept -> StringRef {
+        return StringRef(rawChars, size);
     }
 } // namespace Catch
 
-constexpr auto operator "" _catch_sr( char const* rawChars, std::size_t size ) noexcept -> Catch::StringRef {
-    return Catch::StringRef( rawChars, size );
+constexpr auto operator "" _catch_sr(char const* rawChars, std::size_t size) noexcept -> Catch::StringRef {
+    return Catch::StringRef(rawChars, size);
 }
 
 // end catch_stringref.h
@@ -946,58 +953,58 @@ namespace Catch {
 
 } // namespace Catch
 
-namespace mpl_{
+namespace mpl_ {
     struct na;
 }
 
 // end catch_meta.hpp
 namespace Catch {
 
-template<typename C>
-class TestInvokerAsMethod : public ITestInvoker {
-    void (C::*m_testAsMethod)();
-public:
-    TestInvokerAsMethod( void (C::*testAsMethod)() ) noexcept : m_testAsMethod( testAsMethod ) {}
+    template<typename C>
+    class TestInvokerAsMethod : public ITestInvoker {
+        void (C::* m_testAsMethod)();
+    public:
+        TestInvokerAsMethod(void (C::* testAsMethod)()) noexcept : m_testAsMethod(testAsMethod) {}
 
-    void invoke() const override {
-        C obj;
-        (obj.*m_testAsMethod)();
+        void invoke() const override {
+            C obj;
+            (obj.*m_testAsMethod)();
+        }
+    };
+
+    auto makeTestInvoker(void(*testAsFunction)()) noexcept -> ITestInvoker*;
+
+    template<typename C>
+    auto makeTestInvoker(void (C::* testAsMethod)()) noexcept -> ITestInvoker* {
+        return new(std::nothrow) TestInvokerAsMethod<C>(testAsMethod);
     }
-};
 
-auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker*;
+    struct NameAndTags {
+        NameAndTags(StringRef const& name_ = StringRef(), StringRef const& tags_ = StringRef()) noexcept;
+        StringRef name;
+        StringRef tags;
+    };
 
-template<typename C>
-auto makeTestInvoker( void (C::*testAsMethod)() ) noexcept -> ITestInvoker* {
-    return new(std::nothrow) TestInvokerAsMethod<C>( testAsMethod );
-}
-
-struct NameAndTags {
-    NameAndTags( StringRef const& name_ = StringRef(), StringRef const& tags_ = StringRef() ) noexcept;
-    StringRef name;
-    StringRef tags;
-};
-
-struct AutoReg : NonCopyable {
-    AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept;
-    ~AutoReg();
-};
+    struct AutoReg : NonCopyable {
+        AutoReg(ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags) noexcept;
+        ~AutoReg();
+    };
 
 } // end namespace Catch
 
 #if defined(CATCH_CONFIG_DISABLE)
-    #define INTERNAL_CATCH_TESTCASE_NO_REGISTRATION( TestName, ... ) \
+#define INTERNAL_CATCH_TESTCASE_NO_REGISTRATION( TestName, ... ) \
         static void TestName()
-    #define INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION( TestName, ClassName, ... ) \
+#define INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION( TestName, ClassName, ... ) \
         namespace{                        \
             struct TestName : INTERNAL_CATCH_REMOVE_PARENS(ClassName) { \
                 void test();              \
             };                            \
         }                                 \
         void TestName::test()
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( TestName, TestFunc, Name, Tags, Signature, ... )  \
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( TestName, TestFunc, Name, Tags, Signature, ... )  \
         INTERNAL_CATCH_DEFINE_SIG_TEST(TestFunc, INTERNAL_CATCH_REMOVE_PARENS(Signature))
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( TestNameClass, TestName, ClassName, Name, Tags, Signature, ... )    \
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( TestNameClass, TestName, ClassName, Name, Tags, Signature, ... )    \
         namespace{                                                                                  \
             namespace INTERNAL_CATCH_MAKE_NAMESPACE(TestName) {                                      \
             INTERNAL_CATCH_DECLARE_SIG_TEST_METHOD(TestName, ClassName, INTERNAL_CATCH_REMOVE_PARENS(Signature));\
@@ -1005,59 +1012,59 @@ struct AutoReg : NonCopyable {
         }                                                                                           \
         INTERNAL_CATCH_DEFINE_SIG_TEST_METHOD(TestName, INTERNAL_CATCH_REMOVE_PARENS(Signature))
 
-    #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ )
-    #else
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
-    #endif
+#ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...) \
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ )
+#else
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...) \
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
+#endif
 
-    #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ )
-    #else
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ ) )
-    #endif
+#ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...) \
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ )
+#else
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...) \
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ ) )
+#endif
 
-    #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION( ClassName, Name, Tags,... ) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
-    #else
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION( ClassName, Name, Tags,... ) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
-    #endif
+#ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION( ClassName, Name, Tags,... ) \
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
+#else
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION( ClassName, Name, Tags,... ) \
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
+#endif
 
-    #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION( ClassName, Name, Tags, Signature, ... ) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
-    #else
-        #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION( ClassName, Name, Tags, Signature, ... ) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
-    #endif
+#ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION( ClassName, Name, Tags, Signature, ... ) \
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
+#else
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION( ClassName, Name, Tags, Signature, ... ) \
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
+#endif
 #endif
 
     ///////////////////////////////////////////////////////////////////////////////
-    #define INTERNAL_CATCH_TESTCASE2( TestName, ... ) \
+#define INTERNAL_CATCH_TESTCASE2( TestName, ... ) \
         static void TestName(); \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         namespace{ Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( &TestName ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ __VA_ARGS__ } ); } /* NOLINT */ \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         static void TestName()
-    #define INTERNAL_CATCH_TESTCASE( ... ) \
-        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), __VA_ARGS__ )
+#define INTERNAL_CATCH_TESTCASE( ... ) \
+        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), __VA_ARGS__ )
 
     ///////////////////////////////////////////////////////////////////////////////
-    #define INTERNAL_CATCH_METHOD_AS_TEST_CASE( QualifiedMethod, ... ) \
+#define INTERNAL_CATCH_METHOD_AS_TEST_CASE( QualifiedMethod, ... ) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         namespace{ Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( &QualifiedMethod ), CATCH_INTERNAL_LINEINFO, "&" #QualifiedMethod, Catch::NameAndTags{ __VA_ARGS__ } ); } /* NOLINT */ \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
     ///////////////////////////////////////////////////////////////////////////////
-    #define INTERNAL_CATCH_TEST_CASE_METHOD2( TestName, ClassName, ... )\
+#define INTERNAL_CATCH_TEST_CASE_METHOD2( TestName, ClassName, ... )\
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         namespace{ \
@@ -1068,18 +1075,18 @@ struct AutoReg : NonCopyable {
         } \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         void TestName::test()
-    #define INTERNAL_CATCH_TEST_CASE_METHOD( ClassName, ... ) \
-        INTERNAL_CATCH_TEST_CASE_METHOD2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), ClassName, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEST_CASE_METHOD( ClassName, ... ) \
+        INTERNAL_CATCH_TEST_CASE_METHOD2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), ClassName, __VA_ARGS__ )
 
     ///////////////////////////////////////////////////////////////////////////////
-    #define INTERNAL_CATCH_REGISTER_TESTCASE( Function, ... ) \
+#define INTERNAL_CATCH_REGISTER_TESTCASE( Function, ... ) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( Function ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ __VA_ARGS__ } ); /* NOLINT */ \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
     ///////////////////////////////////////////////////////////////////////////////
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(TestName, TestFunc, Name, Tags, Signature, ... )\
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(TestName, TestFunc, Name, Tags, Signature, ... )\
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
@@ -1109,22 +1116,22 @@ struct AutoReg : NonCopyable {
         INTERNAL_CATCH_DEFINE_SIG_TEST(TestFunc,INTERNAL_CATCH_REMOVE_PARENS(Signature))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ )
 #else
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ )
 #else
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ ) )
 #endif
 
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(TestName, TestFuncName, Name, Tags, Signature, TmplTypes, TypesList) \
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(TestName, TestFuncName, Name, Tags, Signature, TmplTypes, TypesList) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                      \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                      \
         CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS                \
@@ -1158,22 +1165,22 @@ struct AutoReg : NonCopyable {
         static void TestFuncName()
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename T,__VA_ARGS__)
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename T,__VA_ARGS__)
 #else
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename T, __VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename T, __VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__)
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__)
 #else
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ ) )
 #endif
 
-    #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2(TestName, TestFunc, Name, Tags, TmplList)\
+#define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2(TestName, TestFunc, Name, Tags, TmplList)\
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS \
@@ -1200,10 +1207,10 @@ struct AutoReg : NonCopyable {
         template<typename TestType>                                   \
         static void TestFunc()
 
-    #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE(Name, Tags, TmplList) \
-        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, TmplList )
+#define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE(Name, Tags, TmplList) \
+        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, TmplList )
 
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( TestNameClass, TestName, ClassName, Name, Tags, Signature, ... ) \
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( TestNameClass, TestName, ClassName, Name, Tags, Signature, ... ) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
@@ -1233,22 +1240,22 @@ struct AutoReg : NonCopyable {
         INTERNAL_CATCH_DEFINE_SIG_TEST_METHOD(TestName, INTERNAL_CATCH_REMOVE_PARENS(Signature))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
 #else
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
 #else
-    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
 #endif
 
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(TestNameClass, TestName, ClassName, Name, Tags, Signature, TmplTypes, TypesList)\
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(TestNameClass, TestName, ClassName, Name, Tags, Signature, TmplTypes, TypesList)\
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS \
@@ -1285,22 +1292,22 @@ struct AutoReg : NonCopyable {
         void TestName<TestType>::test()
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, typename T, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, typename T, __VA_ARGS__ )
 #else
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, typename T,__VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, typename T,__VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, Signature, __VA_ARGS__ )
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, Signature, __VA_ARGS__ )
 #else
-    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, Signature,__VA_ARGS__ ) )
+#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, Signature,__VA_ARGS__ ) )
 #endif
 
-    #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( TestNameClass, TestName, ClassName, Name, Tags, TmplList) \
+#define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( TestNameClass, TestName, ClassName, Name, Tags, TmplList) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS \
@@ -1331,7 +1338,7 @@ struct AutoReg : NonCopyable {
         void TestName<TestType>::test()
 
 #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD(ClassName, Name, Tags, TmplList) \
-        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, TmplList )
+        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, TmplList )
 
 // end catch_test_registry.h
 // start catch_capture.hpp
@@ -1345,43 +1352,47 @@ struct AutoReg : NonCopyable {
 namespace Catch {
 
     // ResultWas::OfType enum
-    struct ResultWas { enum OfType {
-        Unknown = -1,
-        Ok = 0,
-        Info = 1,
-        Warning = 2,
+    struct ResultWas {
+        enum OfType {
+            Unknown = -1,
+            Ok = 0,
+            Info = 1,
+            Warning = 2,
 
-        FailureBit = 0x10,
+            FailureBit = 0x10,
 
-        ExpressionFailed = FailureBit | 1,
-        ExplicitFailure = FailureBit | 2,
+            ExpressionFailed = FailureBit | 1,
+            ExplicitFailure = FailureBit | 2,
 
-        Exception = 0x100 | FailureBit,
+            Exception = 0x100 | FailureBit,
 
-        ThrewException = Exception | 1,
-        DidntThrowException = Exception | 2,
+            ThrewException = Exception | 1,
+            DidntThrowException = Exception | 2,
 
-        FatalErrorCondition = 0x200 | FailureBit
+            FatalErrorCondition = 0x200 | FailureBit
 
-    }; };
+        };
+    };
 
-    bool isOk( ResultWas::OfType resultType );
-    bool isJustInfo( int flags );
+    bool isOk(ResultWas::OfType resultType);
+    bool isJustInfo(int flags);
 
     // ResultDisposition::Flags enum
-    struct ResultDisposition { enum Flags {
-        Normal = 0x01,
+    struct ResultDisposition {
+        enum Flags {
+            Normal = 0x01,
 
-        ContinueOnFailure = 0x02,   // Failures fail test, but execution continues
-        FalseTest = 0x04,           // Prefix expression with !
-        SuppressFail = 0x08         // Failures are reported but do not fail the test
-    }; };
+            ContinueOnFailure = 0x02,   // Failures fail test, but execution continues
+            FalseTest = 0x04,           // Prefix expression with !
+            SuppressFail = 0x08         // Failures are reported but do not fail the test
+        };
+    };
 
-    ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs );
+    ResultDisposition::Flags operator | (ResultDisposition::Flags lhs, ResultDisposition::Flags rhs);
 
-    bool shouldContinueOnFailure( int flags );
-    inline bool isFalseTest( int flags ) { return ( flags & ResultDisposition::FalseTest ) != 0; }
-    bool shouldSuppressFailure( int flags );
+    bool shouldContinueOnFailure(int flags);
+    inline bool isFalseTest(int flags) { return (flags & ResultDisposition::FalseTest) != 0; }
+    bool shouldSuppressFailure(int flags);
 
 } // end namespace Catch
 
@@ -1430,7 +1441,7 @@ namespace Catch {
         virtual std::ostream& stream() const = 0;
     };
 
-    auto makeStream( StringRef const &filename ) -> IStream const*;
+    auto makeStream(StringRef const& filename) -> IStream const*;
 
     class ReusableStringStream : NonCopyable {
         std::size_t m_index;
@@ -1439,10 +1450,10 @@ namespace Catch {
         ReusableStringStream();
         ~ReusableStringStream();
 
-        auto str() const -> std::string;
+        auto str() const->std::string;
 
         template<typename T>
-        auto operator << ( T const& value ) -> ReusableStringStream& {
+        auto operator << (T const& value) -> ReusableStringStream& {
             *m_oss << value;
             return *this;
         }
@@ -1464,23 +1475,23 @@ namespace Catch {
 
             ~EnumInfo();
 
-            StringRef lookup( int value ) const;
+            StringRef lookup(int value) const;
         };
     } // namespace Detail
 
     struct IMutableEnumValuesRegistry {
         virtual ~IMutableEnumValuesRegistry();
 
-        virtual Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values ) = 0;
+        virtual Detail::EnumInfo const& registerEnum(StringRef enumName, StringRef allEnums, std::vector<int> const& values) = 0;
 
         template<typename E>
-        Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::initializer_list<E> values ) {
+        Detail::EnumInfo const& registerEnum(StringRef enumName, StringRef allEnums, std::initializer_list<E> values) {
             static_assert(sizeof(int) >= sizeof(E), "Cannot serialize enum to int");
             std::vector<int> intValues;
-            intValues.reserve( values.size() );
-            for( auto enumValue : values )
-                intValues.push_back( static_cast<int>( enumValue ) );
-            return registerEnum( enumName, allEnums, intValues );
+            intValues.reserve(values.size());
+            for (auto enumValue : values)
+                intValues.push_back(static_cast<int>(enumValue));
+            return registerEnum(enumName, allEnums, intValues);
         }
     };
 
@@ -1503,29 +1514,29 @@ namespace Catch {
 #define CATCH_ARC_ENABLED 0
 #endif
 
-void arcSafeRelease( NSObject* obj );
-id performOptionalSelector( id obj, SEL sel );
+void arcSafeRelease(NSObject* obj);
+id performOptionalSelector(id obj, SEL sel);
 
 #if !CATCH_ARC_ENABLED
-inline void arcSafeRelease( NSObject* obj ) {
-    [obj release];
+inline void arcSafeRelease(NSObject* obj) {
+    [obj release] ;
 }
-inline id performOptionalSelector( id obj, SEL sel ) {
-    if( [obj respondsToSelector: sel] )
-        return [obj performSelector: sel];
+inline id performOptionalSelector(id obj, SEL sel) {
+    if ([obj respondsToSelector : sel])
+        return[obj performSelector : sel];
     return nil;
 }
 #define CATCH_UNSAFE_UNRETAINED
 #define CATCH_ARC_STRONG
 #else
-inline void arcSafeRelease( NSObject* ){}
-inline id performOptionalSelector( id obj, SEL sel ) {
+inline void arcSafeRelease(NSObject*) {}
+inline id performOptionalSelector(id obj, SEL sel) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 #endif
-    if( [obj respondsToSelector: sel] )
-        return [obj performSelector: sel];
+    if ([obj respondsToSelector : sel])
+        return[obj performSelector : sel];
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -1548,11 +1559,11 @@ namespace Catch {
 
         extern const std::string unprintableString;
 
-        std::string rawMemoryToString( const void *object, std::size_t size );
+        std::string rawMemoryToString(const void* object, std::size_t size);
 
         template<typename T>
-        std::string rawMemoryToString( const T& object ) {
-          return rawMemoryToString( &object, sizeof(object) );
+        std::string rawMemoryToString(const T& object) {
+            return rawMemoryToString(&object, sizeof(object));
         }
 
         template<typename T>
@@ -1562,44 +1573,44 @@ namespace Catch {
                 -> decltype(std::declval<Stream&>() << std::declval<U>(), std::true_type());
 
             template<typename, typename>
-            static auto test(...)->std::false_type;
+            static auto test(...) -> std::false_type;
 
         public:
             static const bool value = decltype(test<std::ostream, const T&>(0))::value;
         };
 
         template<typename E>
-        std::string convertUnknownEnumToString( E e );
+        std::string convertUnknownEnumToString(E e);
 
         template<typename T>
         typename std::enable_if<
             !std::is_enum<T>::value && !std::is_base_of<std::exception, T>::value,
-        std::string>::type convertUnstreamable( T const& ) {
+            std::string>::type convertUnstreamable(T const&) {
             return Detail::unprintableString;
         }
         template<typename T>
         typename std::enable_if<
-            !std::is_enum<T>::value && std::is_base_of<std::exception, T>::value,
-         std::string>::type convertUnstreamable(T const& ex) {
+            !std::is_enum<T>::value&& std::is_base_of<std::exception, T>::value,
+            std::string>::type convertUnstreamable(T const& ex) {
             return ex.what();
         }
 
         template<typename T>
         typename std::enable_if<
             std::is_enum<T>::value
-        , std::string>::type convertUnstreamable( T const& value ) {
-            return convertUnknownEnumToString( value );
+            , std::string>::type convertUnstreamable(T const& value) {
+            return convertUnknownEnumToString(value);
         }
 
 #if defined(_MANAGED)
         //! Convert a CLR string to a utf8 std::string
         template<typename T>
-        std::string clrReferenceToString( T^ ref ) {
+        std::string clrReferenceToString(T^ ref) {
             if (ref == nullptr)
                 return std::string("null");
             auto bytes = System::Text::Encoding::UTF8->GetBytes(ref->ToString());
             cli::pin_ptr<System::Byte> p = &bytes[0];
-            return std::string(reinterpret_cast<char const *>(p), bytes->Length);
+            return std::string(reinterpret_cast<char const*>(p), bytes->Length);
         }
 #endif
 
@@ -1610,19 +1621,19 @@ namespace Catch {
     struct StringMaker {
         template <typename Fake = T>
         static
-        typename std::enable_if<::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
+            typename std::enable_if<::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
             convert(const Fake& value) {
-                ReusableStringStream rss;
-                // NB: call using the function-like syntax to avoid ambiguity with
-                // user-defined templated operator<< under clang.
-                rss.operator<<(value);
-                return rss.str();
+            ReusableStringStream rss;
+            // NB: call using the function-like syntax to avoid ambiguity with
+            // user-defined templated operator<< under clang.
+            rss.operator<<(value);
+            return rss.str();
         }
 
         template <typename Fake = T>
         static
-        typename std::enable_if<!::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
-            convert( const Fake& value ) {
+            typename std::enable_if<!::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
+            convert(const Fake& value) {
 #if !defined(CATCH_CONFIG_FALLBACK_STRINGIFIER)
             return Detail::convertUnstreamable(value);
 #else
@@ -1641,13 +1652,13 @@ namespace Catch {
         }
 
         template<typename E>
-        std::string convertUnknownEnumToString( E e ) {
+        std::string convertUnknownEnumToString(E e) {
             return ::Catch::Detail::stringify(static_cast<typename std::underlying_type<E>::type>(e));
         }
 
 #if defined(_MANAGED)
         template <typename T>
-        std::string stringify( T^ e ) {
+        std::string stringify(T^ e) {
             return ::Catch::StringMaker<T^>::convert(e);
         }
 #endif
@@ -1669,12 +1680,12 @@ namespace Catch {
 #endif
 
     template<>
-    struct StringMaker<char const *> {
-        static std::string convert(char const * str);
+    struct StringMaker<char const*> {
+        static std::string convert(char const* str);
     };
     template<>
-    struct StringMaker<char *> {
-        static std::string convert(char * str);
+    struct StringMaker<char*> {
+        static std::string convert(char* str);
     };
 
 #ifdef CATCH_CONFIG_WCHAR
@@ -1691,12 +1702,12 @@ namespace Catch {
 # endif
 
     template<>
-    struct StringMaker<wchar_t const *> {
-        static std::string convert(wchar_t const * str);
+    struct StringMaker<wchar_t const*> {
+        static std::string convert(wchar_t const* str);
     };
     template<>
-    struct StringMaker<wchar_t *> {
-        static std::string convert(wchar_t * str);
+    struct StringMaker<wchar_t*> {
+        static std::string convert(wchar_t* str);
     };
 #endif
 
@@ -1711,13 +1722,13 @@ namespace Catch {
     template<int SZ>
     struct StringMaker<signed char[SZ]> {
         static std::string convert(signed char const* str) {
-            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
+            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const*>(str) });
         }
     };
     template<int SZ>
     struct StringMaker<unsigned char[SZ]> {
         static std::string convert(unsigned char const* str) {
-            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
+            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const*>(str) });
         }
     };
 
@@ -1793,7 +1804,8 @@ namespace Catch {
         static std::string convert(U* p) {
             if (p) {
                 return ::Catch::Detail::rawMemoryToString(p);
-            } else {
+            }
+            else {
                 return "nullptr";
             }
         }
@@ -1804,7 +1816,8 @@ namespace Catch {
         static std::string convert(R C::* p) {
             if (p) {
                 return ::Catch::Detail::rawMemoryToString(p);
-            } else {
+            }
+            else {
                 return "nullptr";
             }
         }
@@ -1813,7 +1826,7 @@ namespace Catch {
 #if defined(_MANAGED)
     template <typename T>
     struct StringMaker<T^> {
-        static std::string convert( T^ ref ) {
+        static std::string convert(T^ ref) {
             return ::Catch::Detail::clrReferenceToString(ref);
         }
     };
@@ -1837,7 +1850,7 @@ namespace Catch {
 #ifdef __OBJC__
     template<>
     struct StringMaker<NSString*> {
-        static std::string convert(NSString * nsstring) {
+        static std::string convert(NSString* nsstring) {
             if (!nsstring)
                 return "nil";
             return std::string("@") + [nsstring UTF8String];
@@ -1851,8 +1864,8 @@ namespace Catch {
 
     };
     namespace Detail {
-        inline std::string stringify( NSString* nsstring ) {
-            return StringMaker<NSString*>::convert( nsstring );
+        inline std::string stringify(NSString* nsstring) {
+            return StringMaker<NSString*>::convert(nsstring);
         }
 
     } // namespace Detail
@@ -1900,7 +1913,8 @@ namespace Catch {
             ReusableStringStream rss;
             if (optional.has_value()) {
                 rss << ::Catch::Detail::stringify(*optional);
-            } else {
+            }
+            else {
                 rss << "{ }";
             }
             return rss.str();
@@ -1931,7 +1945,7 @@ namespace Catch {
             typename Tuple,
             std::size_t N
         >
-            struct TupleElementPrinter<Tuple, N, false> {
+        struct TupleElementPrinter<Tuple, N, false> {
             static void print(const Tuple&, std::ostream&) {}
         };
 
@@ -1965,7 +1979,8 @@ namespace Catch {
         static std::string convert(const std::variant<Elements...>& variant) {
             if (variant.valueless_by_exception()) {
                 return "{valueless variant}";
-            } else {
+            }
+            else {
                 return std::visit(
                     [](const auto& value) {
                         return ::Catch::Detail::stringify(value);
@@ -2010,22 +2025,22 @@ namespace Catch {
 #endif
 
     template<typename Range>
-    std::string rangeToString( Range const& range ) {
-        return ::Catch::Detail::rangeToString( begin( range ), end( range ) );
+    std::string rangeToString(Range const& range) {
+        return ::Catch::Detail::rangeToString(begin(range), end(range));
     }
 
     // Handle vector<bool> specially
     template<typename Allocator>
-    std::string rangeToString( std::vector<bool, Allocator> const& v ) {
+    std::string rangeToString(std::vector<bool, Allocator> const& v) {
         ReusableStringStream rss;
         rss << "{ ";
         bool first = true;
-        for( bool b : v ) {
-            if( first )
+        for (bool b : v) {
+            if (first)
                 first = false;
             else
                 rss << ", ";
-            rss << ::Catch::Detail::stringify( b );
+            rss << ::Catch::Detail::stringify(b);
         }
         rss << " }";
         return rss.str();
@@ -2033,8 +2048,8 @@ namespace Catch {
 
     template<typename R>
     struct StringMaker<R, typename std::enable_if<is_range<R>::value && !::Catch::Detail::IsStreamInsertable<R>::value>::type> {
-        static std::string convert( R const& range ) {
-            return rangeToString( range );
+        static std::string convert(R const& range) {
+            return rangeToString(range);
         }
     };
 
@@ -2055,42 +2070,42 @@ namespace Catch {
 
 namespace Catch {
 
-template <class Ratio>
-struct ratio_string {
-    static std::string symbol();
-};
+    template <class Ratio>
+    struct ratio_string {
+        static std::string symbol();
+    };
 
-template <class Ratio>
-std::string ratio_string<Ratio>::symbol() {
-    Catch::ReusableStringStream rss;
-    rss << '[' << Ratio::num << '/'
-        << Ratio::den << ']';
-    return rss.str();
-}
-template <>
-struct ratio_string<std::atto> {
-    static std::string symbol();
-};
-template <>
-struct ratio_string<std::femto> {
-    static std::string symbol();
-};
-template <>
-struct ratio_string<std::pico> {
-    static std::string symbol();
-};
-template <>
-struct ratio_string<std::nano> {
-    static std::string symbol();
-};
-template <>
-struct ratio_string<std::micro> {
-    static std::string symbol();
-};
-template <>
-struct ratio_string<std::milli> {
-    static std::string symbol();
-};
+    template <class Ratio>
+    std::string ratio_string<Ratio>::symbol() {
+        Catch::ReusableStringStream rss;
+        rss << '[' << Ratio::num << '/'
+            << Ratio::den << ']';
+        return rss.str();
+    }
+    template <>
+    struct ratio_string<std::atto> {
+        static std::string symbol();
+    };
+    template <>
+    struct ratio_string<std::femto> {
+        static std::string symbol();
+    };
+    template <>
+    struct ratio_string<std::pico> {
+        static std::string symbol();
+    };
+    template <>
+    struct ratio_string<std::nano> {
+        static std::string symbol();
+    };
+    template <>
+    struct ratio_string<std::micro> {
+        static std::string symbol();
+    };
+    template <>
+    struct ratio_string<std::milli> {
+        static std::string symbol();
+    };
 
     ////////////
     // std::chrono::duration specializations
@@ -2151,7 +2166,7 @@ struct ratio_string<std::milli> {
 
             auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
             char timeStamp[timeStampSize];
-            const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
+            const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
 #ifdef _MSC_VER
             std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
@@ -2197,11 +2212,11 @@ namespace Catch {
     struct ITransientExpression {
         auto isBinaryExpression() const -> bool { return m_isBinaryExpression; }
         auto getResult() const -> bool { return m_result; }
-        virtual void streamReconstructedExpression( std::ostream &os ) const = 0;
+        virtual void streamReconstructedExpression(std::ostream& os) const = 0;
 
-        ITransientExpression( bool isBinaryExpression, bool result )
-        :   m_isBinaryExpression( isBinaryExpression ),
-            m_result( result )
+        ITransientExpression(bool isBinaryExpression, bool result)
+            : m_isBinaryExpression(isBinaryExpression),
+            m_result(result)
         {}
 
         // We don't actually need a virtual destructor, but many static analysers
@@ -2213,81 +2228,81 @@ namespace Catch {
 
     };
 
-    void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs );
+    void formatReconstructedExpression(std::ostream& os, std::string const& lhs, StringRef op, std::string const& rhs);
 
     template<typename LhsT, typename RhsT>
-    class BinaryExpr  : public ITransientExpression {
+    class BinaryExpr : public ITransientExpression {
         LhsT m_lhs;
         StringRef m_op;
         RhsT m_rhs;
 
-        void streamReconstructedExpression( std::ostream &os ) const override {
+        void streamReconstructedExpression(std::ostream& os) const override {
             formatReconstructedExpression
-                    ( os, Catch::Detail::stringify( m_lhs ), m_op, Catch::Detail::stringify( m_rhs ) );
+            (os, Catch::Detail::stringify(m_lhs), m_op, Catch::Detail::stringify(m_rhs));
         }
 
     public:
-        BinaryExpr( bool comparisonResult, LhsT lhs, StringRef op, RhsT rhs )
-        :   ITransientExpression{ true, comparisonResult },
-            m_lhs( lhs ),
-            m_op( op ),
-            m_rhs( rhs )
+        BinaryExpr(bool comparisonResult, LhsT lhs, StringRef op, RhsT rhs)
+            : ITransientExpression{ true, comparisonResult },
+            m_lhs(lhs),
+            m_op(op),
+            m_rhs(rhs)
         {}
 
         template<typename T>
-        auto operator && ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator && (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator || ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator || (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator == ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator == (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator != ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator != (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator > ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator > (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator < ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator < (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator >= ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator >= (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename T>
-        auto operator <= ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator <= (T) const -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<T>::value,
-            "chained comparisons are not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "chained comparisons are not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
     };
 
@@ -2295,76 +2310,76 @@ namespace Catch {
     class UnaryExpr : public ITransientExpression {
         LhsT m_lhs;
 
-        void streamReconstructedExpression( std::ostream &os ) const override {
-            os << Catch::Detail::stringify( m_lhs );
+        void streamReconstructedExpression(std::ostream& os) const override {
+            os << Catch::Detail::stringify(m_lhs);
         }
 
     public:
-        explicit UnaryExpr( LhsT lhs )
-        :   ITransientExpression{ false, static_cast<bool>(lhs) },
-            m_lhs( lhs )
+        explicit UnaryExpr(LhsT lhs)
+            : ITransientExpression{ false, static_cast<bool>(lhs) },
+            m_lhs(lhs)
         {}
     };
 
     // Specialised comparison functions to handle equality comparisons between ints and pointers (NULL deduces as an int)
     template<typename LhsT, typename RhsT>
-    auto compareEqual( LhsT const& lhs, RhsT const& rhs ) -> bool { return static_cast<bool>(lhs == rhs); }
+    auto compareEqual(LhsT const& lhs, RhsT const& rhs) -> bool { return static_cast<bool>(lhs == rhs); }
     template<typename T>
-    auto compareEqual( T* const& lhs, int rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
+    auto compareEqual(T* const& lhs, int rhs) -> bool { return lhs == reinterpret_cast<void const*>(rhs); }
     template<typename T>
-    auto compareEqual( T* const& lhs, long rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
+    auto compareEqual(T* const& lhs, long rhs) -> bool { return lhs == reinterpret_cast<void const*>(rhs); }
     template<typename T>
-    auto compareEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
+    auto compareEqual(int lhs, T* const& rhs) -> bool { return reinterpret_cast<void const*>(lhs) == rhs; }
     template<typename T>
-    auto compareEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
+    auto compareEqual(long lhs, T* const& rhs) -> bool { return reinterpret_cast<void const*>(lhs) == rhs; }
 
     template<typename LhsT, typename RhsT>
-    auto compareNotEqual( LhsT const& lhs, RhsT&& rhs ) -> bool { return static_cast<bool>(lhs != rhs); }
+    auto compareNotEqual(LhsT const& lhs, RhsT&& rhs) -> bool { return static_cast<bool>(lhs != rhs); }
     template<typename T>
-    auto compareNotEqual( T* const& lhs, int rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
+    auto compareNotEqual(T* const& lhs, int rhs) -> bool { return lhs != reinterpret_cast<void const*>(rhs); }
     template<typename T>
-    auto compareNotEqual( T* const& lhs, long rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
+    auto compareNotEqual(T* const& lhs, long rhs) -> bool { return lhs != reinterpret_cast<void const*>(rhs); }
     template<typename T>
-    auto compareNotEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
+    auto compareNotEqual(int lhs, T* const& rhs) -> bool { return reinterpret_cast<void const*>(lhs) != rhs; }
     template<typename T>
-    auto compareNotEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
+    auto compareNotEqual(long lhs, T* const& rhs) -> bool { return reinterpret_cast<void const*>(lhs) != rhs; }
 
     template<typename LhsT>
     class ExprLhs {
         LhsT m_lhs;
     public:
-        explicit ExprLhs( LhsT lhs ) : m_lhs( lhs ) {}
+        explicit ExprLhs(LhsT lhs) : m_lhs(lhs) {}
 
         template<typename RhsT>
-        auto operator == ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-            return { compareEqual( m_lhs, rhs ), m_lhs, "==", rhs };
+        auto operator == (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { compareEqual(m_lhs, rhs), m_lhs, "==", rhs };
         }
-        auto operator == ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
+        auto operator == (bool rhs) -> BinaryExpr<LhsT, bool> const {
             return { m_lhs == rhs, m_lhs, "==", rhs };
         }
 
         template<typename RhsT>
-        auto operator != ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-            return { compareNotEqual( m_lhs, rhs ), m_lhs, "!=", rhs };
+        auto operator != (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { compareNotEqual(m_lhs, rhs), m_lhs, "!=", rhs };
         }
-        auto operator != ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
+        auto operator != (bool rhs) -> BinaryExpr<LhsT, bool> const {
             return { m_lhs != rhs, m_lhs, "!=", rhs };
         }
 
         template<typename RhsT>
-        auto operator > ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator > (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
             return { static_cast<bool>(m_lhs > rhs), m_lhs, ">", rhs };
         }
         template<typename RhsT>
-        auto operator < ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator < (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
             return { static_cast<bool>(m_lhs < rhs), m_lhs, "<", rhs };
         }
         template<typename RhsT>
-        auto operator >= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator >= (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
             return { static_cast<bool>(m_lhs >= rhs), m_lhs, ">=", rhs };
         }
         template<typename RhsT>
-        auto operator <= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator <= (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
             return { static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs };
         }
         template <typename RhsT>
@@ -2381,17 +2396,17 @@ namespace Catch {
         }
 
         template<typename RhsT>
-        auto operator && ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator && (RhsT const&) -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<RhsT>::value,
-            "operator&& is not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "operator&& is not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         template<typename RhsT>
-        auto operator || ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
+        auto operator || (RhsT const&) -> BinaryExpr<LhsT, RhsT const&> const {
             static_assert(always_false<RhsT>::value,
-            "operator|| is not supported inside assertions, "
-            "wrap the expression inside parentheses, or decompose it");
+                "operator|| is not supported inside assertions, "
+                "wrap the expression inside parentheses, or decompose it");
         }
 
         auto makeUnaryExpr() const -> UnaryExpr<LhsT> {
@@ -2399,20 +2414,20 @@ namespace Catch {
         }
     };
 
-    void handleExpression( ITransientExpression const& expr );
+    void handleExpression(ITransientExpression const& expr);
 
     template<typename T>
-    void handleExpression( ExprLhs<T> const& expr ) {
-        handleExpression( expr.makeUnaryExpr() );
+    void handleExpression(ExprLhs<T> const& expr) {
+        handleExpression(expr.makeUnaryExpr());
     }
 
     struct Decomposer {
         template<typename T>
-        auto operator <= ( T const& lhs ) -> ExprLhs<T const&> {
+        auto operator <= (T const& lhs) -> ExprLhs<T const&> {
             return ExprLhs<T const&>{ lhs };
         }
 
-        auto operator <=( bool value ) -> ExprLhs<bool> {
+        auto operator <=(bool value) -> ExprLhs<bool> {
             return ExprLhs<bool>{ value };
         }
     };
@@ -2454,49 +2469,49 @@ namespace Catch {
 
         virtual ~IResultCapture();
 
-        virtual bool sectionStarted(    SectionInfo const& sectionInfo,
-                                        Counts& assertions ) = 0;
-        virtual void sectionEnded( SectionEndInfo const& endInfo ) = 0;
-        virtual void sectionEndedEarly( SectionEndInfo const& endInfo ) = 0;
+        virtual bool sectionStarted(SectionInfo const& sectionInfo,
+            Counts& assertions) = 0;
+        virtual void sectionEnded(SectionEndInfo const& endInfo) = 0;
+        virtual void sectionEndedEarly(SectionEndInfo const& endInfo) = 0;
 
-        virtual auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& = 0;
+        virtual auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const& lineInfo) -> IGeneratorTracker & = 0;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-        virtual void benchmarkPreparing( std::string const& name ) = 0;
-        virtual void benchmarkStarting( BenchmarkInfo const& info ) = 0;
-        virtual void benchmarkEnded( BenchmarkStats<> const& stats ) = 0;
-        virtual void benchmarkFailed( std::string const& error ) = 0;
+        virtual void benchmarkPreparing(std::string const& name) = 0;
+        virtual void benchmarkStarting(BenchmarkInfo const& info) = 0;
+        virtual void benchmarkEnded(BenchmarkStats<> const& stats) = 0;
+        virtual void benchmarkFailed(std::string const& error) = 0;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-        virtual void pushScopedMessage( MessageInfo const& message ) = 0;
-        virtual void popScopedMessage( MessageInfo const& message ) = 0;
+        virtual void pushScopedMessage(MessageInfo const& message) = 0;
+        virtual void popScopedMessage(MessageInfo const& message) = 0;
 
-        virtual void emplaceUnscopedMessage( MessageBuilder const& builder ) = 0;
+        virtual void emplaceUnscopedMessage(MessageBuilder const& builder) = 0;
 
-        virtual void handleFatalErrorCondition( StringRef message ) = 0;
+        virtual void handleFatalErrorCondition(StringRef message) = 0;
 
         virtual void handleExpr
-                (   AssertionInfo const& info,
-                    ITransientExpression const& expr,
-                    AssertionReaction& reaction ) = 0;
+        (AssertionInfo const& info,
+            ITransientExpression const& expr,
+            AssertionReaction& reaction) = 0;
         virtual void handleMessage
-                (   AssertionInfo const& info,
-                    ResultWas::OfType resultType,
-                    StringRef const& message,
-                    AssertionReaction& reaction ) = 0;
+        (AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            StringRef const& message,
+            AssertionReaction& reaction) = 0;
         virtual void handleUnexpectedExceptionNotThrown
-                (   AssertionInfo const& info,
-                    AssertionReaction& reaction ) = 0;
+        (AssertionInfo const& info,
+            AssertionReaction& reaction) = 0;
         virtual void handleUnexpectedInflightException
-                (   AssertionInfo const& info,
-                    std::string const& message,
-                    AssertionReaction& reaction ) = 0;
+        (AssertionInfo const& info,
+            std::string const& message,
+            AssertionReaction& reaction) = 0;
         virtual void handleIncomplete
-                (   AssertionInfo const& info ) = 0;
+        (AssertionInfo const& info) = 0;
         virtual void handleNonExpr
-                (   AssertionInfo const &info,
-                    ResultWas::OfType resultType,
-                    AssertionReaction &reaction ) = 0;
+        (AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            AssertionReaction& reaction) = 0;
 
         virtual bool lastAssertionPassed() = 0;
         virtual void assertionPassed() = 0;
@@ -2513,7 +2528,7 @@ namespace Catch {
 // end catch_interfaces_capture.h
 namespace Catch {
 
-    struct TestFailureException{};
+    struct TestFailureException {};
     struct AssertionResultData;
     struct IResultCapture;
     class RunContext;
@@ -2526,13 +2541,13 @@ namespace Catch {
         ITransientExpression const* m_transientExpression = nullptr;
         bool m_isNegated;
     public:
-        LazyExpression( bool isNegated );
-        LazyExpression( LazyExpression const& other );
-        LazyExpression& operator = ( LazyExpression const& ) = delete;
+        LazyExpression(bool isNegated);
+        LazyExpression(LazyExpression const& other);
+        LazyExpression& operator = (LazyExpression const&) = delete;
 
         explicit operator bool() const;
 
-        friend auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream&;
+        friend auto operator << (std::ostream& os, LazyExpression const& lazyExpr)->std::ostream&;
     };
 
     struct AssertionReaction {
@@ -2548,21 +2563,21 @@ namespace Catch {
 
     public:
         AssertionHandler
-            (   StringRef const& macroName,
-                SourceLineInfo const& lineInfo,
-                StringRef capturedExpression,
-                ResultDisposition::Flags resultDisposition );
+        (StringRef const& macroName,
+            SourceLineInfo const& lineInfo,
+            StringRef capturedExpression,
+            ResultDisposition::Flags resultDisposition);
         ~AssertionHandler() {
-            if ( !m_completed ) {
-                m_resultCapture.handleIncomplete( m_assertionInfo );
+            if (!m_completed) {
+                m_resultCapture.handleIncomplete(m_assertionInfo);
             }
         }
 
         template<typename T>
-        void handleExpr( ExprLhs<T> const& expr ) {
-            handleExpr( expr.makeUnaryExpr() );
+        void handleExpr(ExprLhs<T> const& expr) {
+            handleExpr(expr.makeUnaryExpr());
         }
-        void handleExpr( ITransientExpression const& expr );
+        void handleExpr(ITransientExpression const& expr);
 
         void handleMessage(ResultWas::OfType resultType, StringRef const& message);
 
@@ -2579,7 +2594,7 @@ namespace Catch {
         auto allowThrows() const -> bool;
     };
 
-    void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef const& matcherString );
+    void handleExceptionMatchExpr(AssertionHandler& handler, std::string const& str, StringRef const& matcherString);
 
 } // namespace Catch
 
@@ -2592,9 +2607,9 @@ namespace Catch {
 namespace Catch {
 
     struct MessageInfo {
-        MessageInfo(    StringRef const& _macroName,
-                        SourceLineInfo const& _lineInfo,
-                        ResultWas::OfType _type );
+        MessageInfo(StringRef const& _macroName,
+            SourceLineInfo const& _lineInfo,
+            ResultWas::OfType _type);
 
         StringRef macroName;
         std::string message;
@@ -2602,8 +2617,8 @@ namespace Catch {
         ResultWas::OfType type;
         unsigned int sequence;
 
-        bool operator == ( MessageInfo const& other ) const;
-        bool operator < ( MessageInfo const& other ) const;
+        bool operator == (MessageInfo const& other) const;
+        bool operator < (MessageInfo const& other) const;
     private:
         static unsigned int globalCount;
     };
@@ -2611,7 +2626,7 @@ namespace Catch {
     struct MessageStream {
 
         template<typename T>
-        MessageStream& operator << ( T const& value ) {
+        MessageStream& operator << (T const& value) {
             m_stream << value;
             return *this;
         }
@@ -2620,12 +2635,12 @@ namespace Catch {
     };
 
     struct MessageBuilder : MessageStream {
-        MessageBuilder( StringRef const& macroName,
-                        SourceLineInfo const& lineInfo,
-                        ResultWas::OfType type );
+        MessageBuilder(StringRef const& macroName,
+            SourceLineInfo const& lineInfo,
+            ResultWas::OfType type);
 
         template<typename T>
-        MessageBuilder& operator << ( T const& value ) {
+        MessageBuilder& operator << (T const& value) {
             m_stream << value;
             return *this;
         }
@@ -2635,9 +2650,9 @@ namespace Catch {
 
     class ScopedMessage {
     public:
-        explicit ScopedMessage( MessageBuilder const& builder );
-        ScopedMessage( ScopedMessage& duplicate ) = delete;
-        ScopedMessage( ScopedMessage&& old );
+        explicit ScopedMessage(MessageBuilder const& builder);
+        ScopedMessage(ScopedMessage& duplicate) = delete;
+        ScopedMessage(ScopedMessage&& old);
         ~ScopedMessage();
 
         MessageInfo m_info;
@@ -2649,20 +2664,20 @@ namespace Catch {
         IResultCapture& m_resultCapture = getResultCapture();
         size_t m_captured = 0;
     public:
-        Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names );
+        Capturer(StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names);
         ~Capturer();
 
-        void captureValue( size_t index, std::string const& value );
+        void captureValue(size_t index, std::string const& value);
 
         template<typename T>
-        void captureValues( size_t index, T const& value ) {
-            captureValue( index, Catch::Detail::stringify( value ) );
+        void captureValues(size_t index, T const& value) {
+            captureValue(index, Catch::Detail::stringify(value));
         }
 
         template<typename T, typename... Ts>
-        void captureValues( size_t index, T const& value, Ts const&... values ) {
-            captureValue( index, Catch::Detail::stringify(value) );
-            captureValues( index+1, values... );
+        void captureValues(size_t index, T const& value, Ts const&... values) {
+            captureValue(index, Catch::Detail::stringify(value));
+            captureValues(index + 1, values...);
         }
     };
 
@@ -2672,9 +2687,9 @@ namespace Catch {
 #if !defined(CATCH_CONFIG_DISABLE)
 
 #if !defined(CATCH_CONFIG_DISABLE_STRINGIFICATION)
-  #define CATCH_INTERNAL_STRINGIFY(...) #__VA_ARGS__
+#define CATCH_INTERNAL_STRINGIFY(...) #__VA_ARGS__
 #else
-  #define CATCH_INTERNAL_STRINGIFY(...) "Disabled by CATCH_CONFIG_DISABLE_STRINGIFICATION"
+#define CATCH_INTERNAL_STRINGIFY(...) "Disabled by CATCH_CONFIG_DISABLE_STRINGIFICATION"
 #endif
 
 #if defined(CATCH_CONFIG_FAST_COMPILE) || defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
@@ -2822,8 +2837,8 @@ namespace Catch {
 namespace Catch {
 
     struct Counts {
-        Counts operator - ( Counts const& other ) const;
-        Counts& operator += ( Counts const& other );
+        Counts operator - (Counts const& other) const;
+        Counts& operator += (Counts const& other);
 
         std::size_t total() const;
         bool allPassed() const;
@@ -2836,10 +2851,10 @@ namespace Catch {
 
     struct Totals {
 
-        Totals operator - ( Totals const& other ) const;
-        Totals& operator += ( Totals const& other );
+        Totals operator - (Totals const& other) const;
+        Totals& operator += (Totals const& other);
 
-        Totals delta( Totals const& prevTotals ) const;
+        Totals delta(Totals const& prevTotals) const;
 
         int error = 0;
         Counts assertions;
@@ -2854,14 +2869,14 @@ namespace Catch {
 
     struct SectionInfo {
         SectionInfo
-            (   SourceLineInfo const& _lineInfo,
-                std::string const& _name );
+        (SourceLineInfo const& _lineInfo,
+            std::string const& _name);
 
         // Deprecated
         SectionInfo
-            (   SourceLineInfo const& _lineInfo,
-                std::string const& _name,
-                std::string const& ) : SectionInfo( _lineInfo, _name ) {}
+        (SourceLineInfo const& _lineInfo,
+            std::string const& _name,
+            std::string const&) : SectionInfo(_lineInfo, _name) {}
 
         std::string name;
         std::string description; // !Deprecated: this will always be empty
@@ -2890,8 +2905,8 @@ namespace Catch {
         uint64_t m_nanoseconds = 0;
     public:
         void start();
-        auto getElapsedNanoseconds() const -> uint64_t;
-        auto getElapsedMicroseconds() const -> uint64_t;
+        auto getElapsedNanoseconds() const->uint64_t;
+        auto getElapsedMicroseconds() const->uint64_t;
         auto getElapsedMilliseconds() const -> unsigned int;
         auto getElapsedSeconds() const -> double;
     };
@@ -2905,7 +2920,7 @@ namespace Catch {
 
     class Section : NonCopyable {
     public:
-        Section( SectionInfo const& info );
+        Section(SectionInfo const& info);
         ~Section();
 
         // This indicates whether the section should be executed or not
@@ -2970,11 +2985,11 @@ namespace Catch {
 
     struct IMutableRegistryHub {
         virtual ~IMutableRegistryHub();
-        virtual void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) = 0;
-        virtual void registerListener( IReporterFactoryPtr const& factory ) = 0;
-        virtual void registerTest( TestCase const& testInfo ) = 0;
-        virtual void registerTranslator( const IExceptionTranslator* translator ) = 0;
-        virtual void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) = 0;
+        virtual void registerReporter(std::string const& name, IReporterFactoryPtr const& factory) = 0;
+        virtual void registerListener(IReporterFactoryPtr const& factory) = 0;
+        virtual void registerTest(TestCase const& testInfo) = 0;
+        virtual void registerTranslator(const IExceptionTranslator* translator) = 0;
+        virtual void registerTagAlias(std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo) = 0;
         virtual void registerStartupException() noexcept = 0;
         virtual IMutableEnumValuesRegistry& getMutableEnumValuesRegistry() = 0;
     };
@@ -2988,7 +3003,7 @@ namespace Catch {
 
 // end catch_interfaces_registry_hub.h
 #if defined(CATCH_CONFIG_DISABLE)
-    #define INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( translatorName, signature) \
+#define INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( translatorName, signature) \
         static std::string translatorName( signature )
 #endif
 
@@ -3004,7 +3019,7 @@ namespace Catch {
 
     struct IExceptionTranslator {
         virtual ~IExceptionTranslator();
-        virtual std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const = 0;
+        virtual std::string translate(ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd) const = 0;
     };
 
     struct IExceptionTranslatorRegistry {
@@ -3018,35 +3033,35 @@ namespace Catch {
         class ExceptionTranslator : public IExceptionTranslator {
         public:
 
-            ExceptionTranslator( std::string(*translateFunction)( T& ) )
-            : m_translateFunction( translateFunction )
+            ExceptionTranslator(std::string(*translateFunction)(T&))
+                : m_translateFunction(translateFunction)
             {}
 
-            std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const override {
+            std::string translate(ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd) const override {
 #if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
                 return "";
 #else
                 try {
-                    if( it == itEnd )
+                    if (it == itEnd)
                         std::rethrow_exception(std::current_exception());
                     else
-                        return (*it)->translate( it+1, itEnd );
+                        return (*it)->translate(it + 1, itEnd);
                 }
-                catch( T& ex ) {
-                    return m_translateFunction( ex );
+                catch (T& ex) {
+                    return m_translateFunction(ex);
                 }
 #endif
             }
 
         protected:
-            std::string(*m_translateFunction)( T& );
+            std::string(*m_translateFunction)(T&);
         };
 
     public:
         template<typename T>
-        ExceptionTranslatorRegistrar( std::string(*translateFunction)( T& ) ) {
+        ExceptionTranslatorRegistrar(std::string(*translateFunction)(T&)) {
             getMutableRegistryHub().registerTranslator
-                ( new ExceptionTranslator<T>( translateFunction ) );
+            (new ExceptionTranslator<T>(translateFunction));
         }
     };
 }
@@ -3068,118 +3083,118 @@ namespace Catch {
 #include <type_traits>
 
 namespace Catch {
-namespace Detail {
+    namespace Detail {
 
-    class Approx {
-    private:
-        bool equalityComparisonImpl(double other) const;
-        // Validates the new margin (margin >= 0)
-        // out-of-line to avoid including stdexcept in the header
-        void setMargin(double margin);
-        // Validates the new epsilon (0 < epsilon < 1)
-        // out-of-line to avoid including stdexcept in the header
-        void setEpsilon(double epsilon);
+        class Approx {
+        private:
+            bool equalityComparisonImpl(double other) const;
+            // Validates the new margin (margin >= 0)
+            // out-of-line to avoid including stdexcept in the header
+            void setMargin(double margin);
+            // Validates the new epsilon (0 < epsilon < 1)
+            // out-of-line to avoid including stdexcept in the header
+            void setEpsilon(double epsilon);
 
-    public:
-        explicit Approx ( double value );
+        public:
+            explicit Approx(double value);
 
-        static Approx custom();
+            static Approx custom();
 
-        Approx operator-() const;
+            Approx operator-() const;
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        Approx operator()( T const& value ) {
-            Approx approx( static_cast<double>(value) );
-            approx.m_epsilon = m_epsilon;
-            approx.m_margin = m_margin;
-            approx.m_scale = m_scale;
-            return approx;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            Approx operator()(T const& value) const {
+                Approx approx(static_cast<double>(value));
+                approx.m_epsilon = m_epsilon;
+                approx.m_margin = m_margin;
+                approx.m_scale = m_scale;
+                return approx;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        explicit Approx( T const& value ): Approx(static_cast<double>(value))
-        {}
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            explicit Approx(T const& value) : Approx(static_cast<double>(value))
+            {}
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator == ( const T& lhs, Approx const& rhs ) {
-            auto lhs_v = static_cast<double>(lhs);
-            return rhs.equalityComparisonImpl(lhs_v);
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator == (const T& lhs, Approx const& rhs) {
+                auto lhs_v = static_cast<double>(lhs);
+                return rhs.equalityComparisonImpl(lhs_v);
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator == ( Approx const& lhs, const T& rhs ) {
-            return operator==( rhs, lhs );
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator == (Approx const& lhs, const T& rhs) {
+                return operator==(rhs, lhs);
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator != ( T const& lhs, Approx const& rhs ) {
-            return !operator==( lhs, rhs );
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator != (T const& lhs, Approx const& rhs) {
+                return !operator==(lhs, rhs);
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator != ( Approx const& lhs, T const& rhs ) {
-            return !operator==( rhs, lhs );
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator != (Approx const& lhs, T const& rhs) {
+                return !operator==(rhs, lhs);
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator <= ( T const& lhs, Approx const& rhs ) {
-            return static_cast<double>(lhs) < rhs.m_value || lhs == rhs;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator <= (T const& lhs, Approx const& rhs) {
+                return static_cast<double>(lhs) < rhs.m_value || lhs == rhs;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator <= ( Approx const& lhs, T const& rhs ) {
-            return lhs.m_value < static_cast<double>(rhs) || lhs == rhs;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator <= (Approx const& lhs, T const& rhs) {
+                return lhs.m_value < static_cast<double>(rhs) || lhs == rhs;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator >= ( T const& lhs, Approx const& rhs ) {
-            return static_cast<double>(lhs) > rhs.m_value || lhs == rhs;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator >= (T const& lhs, Approx const& rhs) {
+                return static_cast<double>(lhs) > rhs.m_value || lhs == rhs;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        friend bool operator >= ( Approx const& lhs, T const& rhs ) {
-            return lhs.m_value > static_cast<double>(rhs) || lhs == rhs;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            friend bool operator >= (Approx const& lhs, T const& rhs) {
+                return lhs.m_value > static_cast<double>(rhs) || lhs == rhs;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        Approx& epsilon( T const& newEpsilon ) {
-            double epsilonAsDouble = static_cast<double>(newEpsilon);
-            setEpsilon(epsilonAsDouble);
-            return *this;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            Approx& epsilon(T const& newEpsilon) {
+                double epsilonAsDouble = static_cast<double>(newEpsilon);
+                setEpsilon(epsilonAsDouble);
+                return *this;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        Approx& margin( T const& newMargin ) {
-            double marginAsDouble = static_cast<double>(newMargin);
-            setMargin(marginAsDouble);
-            return *this;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            Approx& margin(T const& newMargin) {
+                double marginAsDouble = static_cast<double>(newMargin);
+                setMargin(marginAsDouble);
+                return *this;
+            }
 
-        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-        Approx& scale( T const& newScale ) {
-            m_scale = static_cast<double>(newScale);
-            return *this;
-        }
+            template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            Approx& scale(T const& newScale) {
+                m_scale = static_cast<double>(newScale);
+                return *this;
+            }
 
-        std::string toString() const;
+            std::string toString() const;
 
-    private:
-        double m_epsilon;
-        double m_margin;
-        double m_scale;
-        double m_value;
+        private:
+            double m_epsilon;
+            double m_margin;
+            double m_scale;
+            double m_value;
+        };
+    } // end namespace Detail
+
+    namespace literals {
+        Detail::Approx operator "" _a(long double val);
+        Detail::Approx operator "" _a(unsigned long long val);
+    } // end namespace literals
+
+    template<>
+    struct StringMaker<Catch::Detail::Approx> {
+        static std::string convert(Catch::Detail::Approx const& value);
     };
-} // end namespace Detail
-
-namespace literals {
-    Detail::Approx operator "" _a(long double val);
-    Detail::Approx operator "" _a(unsigned long long val);
-} // end namespace literals
-
-template<>
-struct StringMaker<Catch::Detail::Approx> {
-    static std::string convert(Catch::Detail::Approx const& value);
-};
 
 } // end namespace Catch
 
@@ -3192,26 +3207,26 @@ struct StringMaker<Catch::Detail::Approx> {
 
 namespace Catch {
 
-    bool startsWith( std::string const& s, std::string const& prefix );
-    bool startsWith( std::string const& s, char prefix );
-    bool endsWith( std::string const& s, std::string const& suffix );
-    bool endsWith( std::string const& s, char suffix );
-    bool contains( std::string const& s, std::string const& infix );
-    void toLowerInPlace( std::string& s );
-    std::string toLower( std::string const& s );
+    bool startsWith(std::string const& s, std::string const& prefix);
+    bool startsWith(std::string const& s, char prefix);
+    bool endsWith(std::string const& s, std::string const& suffix);
+    bool endsWith(std::string const& s, char suffix);
+    bool contains(std::string const& s, std::string const& infix);
+    void toLowerInPlace(std::string& s);
+    std::string toLower(std::string const& s);
     //! Returns a new string without whitespace at the start/end
-    std::string trim( std::string const& str );
+    std::string trim(std::string const& str);
     //! Returns a substring of the original ref without whitespace. Beware lifetimes!
     StringRef trim(StringRef ref);
 
     // !!! Be aware, returns refs into original string - make sure original string outlives them
-    std::vector<StringRef> splitStringRef( StringRef str, char delimiter );
-    bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis );
+    std::vector<StringRef> splitStringRef(StringRef str, char delimiter);
+    bool replaceInPlace(std::string& str, std::string const& replaceThis, std::string const& withThis);
 
     struct pluralise {
-        pluralise( std::size_t count, std::string const& label );
+        pluralise(std::size_t count, std::string const& label);
 
-        friend std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser );
+        friend std::ostream& operator << (std::ostream& os, pluralise const& pluraliser);
 
         std::size_t m_count;
         std::string m_label;
@@ -3228,159 +3243,159 @@ namespace Catch {
 #include <vector>
 
 namespace Catch {
-namespace Matchers {
-    namespace Impl {
+    namespace Matchers {
+        namespace Impl {
 
-        template<typename ArgT> struct MatchAllOf;
-        template<typename ArgT> struct MatchAnyOf;
-        template<typename ArgT> struct MatchNotOf;
+            template<typename ArgT> struct MatchAllOf;
+            template<typename ArgT> struct MatchAnyOf;
+            template<typename ArgT> struct MatchNotOf;
 
-        class MatcherUntypedBase {
-        public:
-            MatcherUntypedBase() = default;
-            MatcherUntypedBase ( MatcherUntypedBase const& ) = default;
-            MatcherUntypedBase& operator = ( MatcherUntypedBase const& ) = delete;
-            std::string toString() const;
+            class MatcherUntypedBase {
+            public:
+                MatcherUntypedBase() = default;
+                MatcherUntypedBase(MatcherUntypedBase const&) = default;
+                MatcherUntypedBase& operator = (MatcherUntypedBase const&) = delete;
+                std::string toString() const;
 
-        protected:
-            virtual ~MatcherUntypedBase();
-            virtual std::string describe() const = 0;
-            mutable std::string m_cachedToString;
-        };
+            protected:
+                virtual ~MatcherUntypedBase();
+                virtual std::string describe() const = 0;
+                mutable std::string m_cachedToString;
+            };
 
 #ifdef __clang__
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnon-virtual-dtor"
 #endif
 
-        template<typename ObjectT>
-        struct MatcherMethod {
-            virtual bool match( ObjectT const& arg ) const = 0;
-        };
+            template<typename ObjectT>
+            struct MatcherMethod {
+                virtual bool match(ObjectT const& arg) const = 0;
+            };
 
 #if defined(__OBJC__)
-        // Hack to fix Catch GH issue #1661. Could use id for generic Object support.
-        // use of const for Object pointers is very uncommon and under ARC it causes some kind of signature mismatch that breaks compilation
-        template<>
-        struct MatcherMethod<NSString*> {
-            virtual bool match( NSString* arg ) const = 0;
-        };
+            // Hack to fix Catch GH issue #1661. Could use id for generic Object support.
+            // use of const for Object pointers is very uncommon and under ARC it causes some kind of signature mismatch that breaks compilation
+            template<>
+            struct MatcherMethod<NSString*> {
+                virtual bool match(NSString* arg) const = 0;
+            };
 #endif
 
 #ifdef __clang__
 #    pragma clang diagnostic pop
 #endif
 
-        template<typename T>
-        struct MatcherBase : MatcherUntypedBase, MatcherMethod<T> {
+            template<typename T>
+            struct MatcherBase : MatcherUntypedBase, MatcherMethod<T> {
 
-            MatchAllOf<T> operator && ( MatcherBase const& other ) const;
-            MatchAnyOf<T> operator || ( MatcherBase const& other ) const;
-            MatchNotOf<T> operator ! () const;
-        };
+                MatchAllOf<T> operator && (MatcherBase const& other) const;
+                MatchAnyOf<T> operator || (MatcherBase const& other) const;
+                MatchNotOf<T> operator ! () const;
+            };
 
-        template<typename ArgT>
-        struct MatchAllOf : MatcherBase<ArgT> {
-            bool match( ArgT const& arg ) const override {
-                for( auto matcher : m_matchers ) {
-                    if (!matcher->match(arg))
-                        return false;
+            template<typename ArgT>
+            struct MatchAllOf : MatcherBase<ArgT> {
+                bool match(ArgT const& arg) const override {
+                    for (auto matcher : m_matchers) {
+                        if (!matcher->match(arg))
+                            return false;
+                    }
+                    return true;
                 }
-                return true;
-            }
-            std::string describe() const override {
-                std::string description;
-                description.reserve( 4 + m_matchers.size()*32 );
-                description += "( ";
-                bool first = true;
-                for( auto matcher : m_matchers ) {
-                    if( first )
-                        first = false;
-                    else
-                        description += " and ";
-                    description += matcher->toString();
+                std::string describe() const override {
+                    std::string description;
+                    description.reserve(4 + m_matchers.size() * 32);
+                    description += "( ";
+                    bool first = true;
+                    for (auto matcher : m_matchers) {
+                        if (first)
+                            first = false;
+                        else
+                            description += " and ";
+                        description += matcher->toString();
+                    }
+                    description += " )";
+                    return description;
                 }
-                description += " )";
-                return description;
-            }
 
-            MatchAllOf<ArgT> operator && ( MatcherBase<ArgT> const& other ) {
-                auto copy(*this);
-                copy.m_matchers.push_back( &other );
-                return copy;
-            }
-
-            std::vector<MatcherBase<ArgT> const*> m_matchers;
-        };
-        template<typename ArgT>
-        struct MatchAnyOf : MatcherBase<ArgT> {
-
-            bool match( ArgT const& arg ) const override {
-                for( auto matcher : m_matchers ) {
-                    if (matcher->match(arg))
-                        return true;
+                MatchAllOf<ArgT> operator && (MatcherBase<ArgT> const& other) {
+                    auto copy(*this);
+                    copy.m_matchers.push_back(&other);
+                    return copy;
                 }
-                return false;
-            }
-            std::string describe() const override {
-                std::string description;
-                description.reserve( 4 + m_matchers.size()*32 );
-                description += "( ";
-                bool first = true;
-                for( auto matcher : m_matchers ) {
-                    if( first )
-                        first = false;
-                    else
-                        description += " or ";
-                    description += matcher->toString();
+
+                std::vector<MatcherBase<ArgT> const*> m_matchers;
+            };
+            template<typename ArgT>
+            struct MatchAnyOf : MatcherBase<ArgT> {
+
+                bool match(ArgT const& arg) const override {
+                    for (auto matcher : m_matchers) {
+                        if (matcher->match(arg))
+                            return true;
+                    }
+                    return false;
                 }
-                description += " )";
-                return description;
+                std::string describe() const override {
+                    std::string description;
+                    description.reserve(4 + m_matchers.size() * 32);
+                    description += "( ";
+                    bool first = true;
+                    for (auto matcher : m_matchers) {
+                        if (first)
+                            first = false;
+                        else
+                            description += " or ";
+                        description += matcher->toString();
+                    }
+                    description += " )";
+                    return description;
+                }
+
+                MatchAnyOf<ArgT> operator || (MatcherBase<ArgT> const& other) {
+                    auto copy(*this);
+                    copy.m_matchers.push_back(&other);
+                    return copy;
+                }
+
+                std::vector<MatcherBase<ArgT> const*> m_matchers;
+            };
+
+            template<typename ArgT>
+            struct MatchNotOf : MatcherBase<ArgT> {
+
+                MatchNotOf(MatcherBase<ArgT> const& underlyingMatcher) : m_underlyingMatcher(underlyingMatcher) {}
+
+                bool match(ArgT const& arg) const override {
+                    return !m_underlyingMatcher.match(arg);
+                }
+
+                std::string describe() const override {
+                    return "not " + m_underlyingMatcher.toString();
+                }
+                MatcherBase<ArgT> const& m_underlyingMatcher;
+            };
+
+            template<typename T>
+            MatchAllOf<T> MatcherBase<T>::operator && (MatcherBase const& other) const {
+                return MatchAllOf<T>() && *this && other;
+            }
+            template<typename T>
+            MatchAnyOf<T> MatcherBase<T>::operator || (MatcherBase const& other) const {
+                return MatchAnyOf<T>() || *this || other;
+            }
+            template<typename T>
+            MatchNotOf<T> MatcherBase<T>::operator ! () const {
+                return MatchNotOf<T>(*this);
             }
 
-            MatchAnyOf<ArgT> operator || ( MatcherBase<ArgT> const& other ) {
-                auto copy(*this);
-                copy.m_matchers.push_back( &other );
-                return copy;
-            }
+        } // namespace Impl
 
-            std::vector<MatcherBase<ArgT> const*> m_matchers;
-        };
+    } // namespace Matchers
 
-        template<typename ArgT>
-        struct MatchNotOf : MatcherBase<ArgT> {
-
-            MatchNotOf( MatcherBase<ArgT> const& underlyingMatcher ) : m_underlyingMatcher( underlyingMatcher ) {}
-
-            bool match( ArgT const& arg ) const override {
-                return !m_underlyingMatcher.match( arg );
-            }
-
-            std::string describe() const override {
-                return "not " + m_underlyingMatcher.toString();
-            }
-            MatcherBase<ArgT> const& m_underlyingMatcher;
-        };
-
-        template<typename T>
-        MatchAllOf<T> MatcherBase<T>::operator && ( MatcherBase const& other ) const {
-            return MatchAllOf<T>() && *this && other;
-        }
-        template<typename T>
-        MatchAnyOf<T> MatcherBase<T>::operator || ( MatcherBase const& other ) const {
-            return MatchAnyOf<T>() || *this || other;
-        }
-        template<typename T>
-        MatchNotOf<T> MatcherBase<T>::operator ! () const {
-            return MatchNotOf<T>( *this );
-        }
-
-    } // namespace Impl
-
-} // namespace Matchers
-
-using namespace Matchers;
-using Matchers::Impl::MatcherBase;
+    using namespace Matchers;
+    using Matchers::Impl::MatcherBase;
 
 } // namespace Catch
 
@@ -3388,88 +3403,88 @@ using Matchers::Impl::MatcherBase;
 // start catch_matchers_exception.hpp
 
 namespace Catch {
-namespace Matchers {
-namespace Exception {
+    namespace Matchers {
+        namespace Exception {
 
-class ExceptionMessageMatcher : public MatcherBase<std::exception> {
-    std::string m_message;
-public:
+            class ExceptionMessageMatcher : public MatcherBase<std::exception> {
+                std::string m_message;
+            public:
 
-    ExceptionMessageMatcher(std::string const& message):
-        m_message(message)
-    {}
+                ExceptionMessageMatcher(std::string const& message) :
+                    m_message(message)
+                {}
 
-    bool match(std::exception const& ex) const override;
+                bool match(std::exception const& ex) const override;
 
-    std::string describe() const override;
-};
+                std::string describe() const override;
+            };
 
-} // namespace Exception
+        } // namespace Exception
 
-Exception::ExceptionMessageMatcher Message(std::string const& message);
+        Exception::ExceptionMessageMatcher Message(std::string const& message);
 
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
 
 // end catch_matchers_exception.hpp
 // start catch_matchers_floating.h
 
 namespace Catch {
-namespace Matchers {
+    namespace Matchers {
 
-    namespace Floating {
+        namespace Floating {
 
-        enum class FloatingPointKind : uint8_t;
+            enum class FloatingPointKind : uint8_t;
 
-        struct WithinAbsMatcher : MatcherBase<double> {
-            WithinAbsMatcher(double target, double margin);
-            bool match(double const& matchee) const override;
-            std::string describe() const override;
-        private:
-            double m_target;
-            double m_margin;
-        };
+            struct WithinAbsMatcher : MatcherBase<double> {
+                WithinAbsMatcher(double target, double margin);
+                bool match(double const& matchee) const override;
+                std::string describe() const override;
+            private:
+                double m_target;
+                double m_margin;
+            };
 
-        struct WithinUlpsMatcher : MatcherBase<double> {
-            WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType);
-            bool match(double const& matchee) const override;
-            std::string describe() const override;
-        private:
-            double m_target;
-            uint64_t m_ulps;
-            FloatingPointKind m_type;
-        };
+            struct WithinUlpsMatcher : MatcherBase<double> {
+                WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType);
+                bool match(double const& matchee) const override;
+                std::string describe() const override;
+            private:
+                double m_target;
+                uint64_t m_ulps;
+                FloatingPointKind m_type;
+            };
 
-        // Given IEEE-754 format for floats and doubles, we can assume
-        // that float -> double promotion is lossless. Given this, we can
-        // assume that if we do the standard relative comparison of
-        // |lhs - rhs| <= epsilon * max(fabs(lhs), fabs(rhs)), then we get
-        // the same result if we do this for floats, as if we do this for
-        // doubles that were promoted from floats.
-        struct WithinRelMatcher : MatcherBase<double> {
-            WithinRelMatcher(double target, double epsilon);
-            bool match(double const& matchee) const override;
-            std::string describe() const override;
-        private:
-            double m_target;
-            double m_epsilon;
-        };
+            // Given IEEE-754 format for floats and doubles, we can assume
+            // that float -> double promotion is lossless. Given this, we can
+            // assume that if we do the standard relative comparison of
+            // |lhs - rhs| <= epsilon * max(fabs(lhs), fabs(rhs)), then we get
+            // the same result if we do this for floats, as if we do this for
+            // doubles that were promoted from floats.
+            struct WithinRelMatcher : MatcherBase<double> {
+                WithinRelMatcher(double target, double epsilon);
+                bool match(double const& matchee) const override;
+                std::string describe() const override;
+            private:
+                double m_target;
+                double m_epsilon;
+            };
 
-    } // namespace Floating
+        } // namespace Floating
 
-    // The following functions create the actual matcher objects.
-    // This allows the types to be inferred
-    Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff);
-    Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff);
-    Floating::WithinAbsMatcher WithinAbs(double target, double margin);
-    Floating::WithinRelMatcher WithinRel(double target, double eps);
-    // defaults epsilon to 100*numeric_limits<double>::epsilon()
-    Floating::WithinRelMatcher WithinRel(double target);
-    Floating::WithinRelMatcher WithinRel(float target, float eps);
-    // defaults epsilon to 100*numeric_limits<float>::epsilon()
-    Floating::WithinRelMatcher WithinRel(float target);
+        // The following functions create the actual matcher objects.
+        // This allows the types to be inferred
+        Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff);
+        Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff);
+        Floating::WithinAbsMatcher WithinAbs(double target, double margin);
+        Floating::WithinRelMatcher WithinRel(double target, double eps);
+        // defaults epsilon to 100*numeric_limits<double>::epsilon()
+        Floating::WithinRelMatcher WithinRel(double target);
+        Floating::WithinRelMatcher WithinRel(float target, float eps);
+        // defaults epsilon to 100*numeric_limits<float>::epsilon()
+        Floating::WithinRelMatcher WithinRel(float target);
 
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
 
 // end catch_matchers_floating.h
@@ -3479,45 +3494,45 @@ namespace Matchers {
 #include <string>
 
 namespace Catch {
-namespace Matchers {
-namespace Generic {
+    namespace Matchers {
+        namespace Generic {
 
-namespace Detail {
-    std::string finalizeDescription(const std::string& desc);
-}
+            namespace Detail {
+                std::string finalizeDescription(const std::string& desc);
+            }
 
-template <typename T>
-class PredicateMatcher : public MatcherBase<T> {
-    std::function<bool(T const&)> m_predicate;
-    std::string m_description;
-public:
+            template <typename T>
+            class PredicateMatcher : public MatcherBase<T> {
+                std::function<bool(T const&)> m_predicate;
+                std::string m_description;
+            public:
 
-    PredicateMatcher(std::function<bool(T const&)> const& elem, std::string const& descr)
-        :m_predicate(std::move(elem)),
-        m_description(Detail::finalizeDescription(descr))
-    {}
+                PredicateMatcher(std::function<bool(T const&)> const& elem, std::string const& descr)
+                    :m_predicate(std::move(elem)),
+                    m_description(Detail::finalizeDescription(descr))
+                {}
 
-    bool match( T const& item ) const override {
-        return m_predicate(item);
-    }
+                bool match(T const& item) const override {
+                    return m_predicate(item);
+                }
 
-    std::string describe() const override {
-        return m_description;
-    }
-};
+                std::string describe() const override {
+                    return m_description;
+                }
+            };
 
-} // namespace Generic
+        } // namespace Generic
 
-    // The following functions create the actual matcher objects.
-    // The user has to explicitly specify type to the function, because
-    // inferring std::function<bool(T const&)> is hard (but possible) and
-    // requires a lot of TMP.
-    template<typename T>
-    Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& predicate, std::string const& description = "") {
-        return Generic::PredicateMatcher<T>(predicate, description);
-    }
+            // The following functions create the actual matcher objects.
+            // The user has to explicitly specify type to the function, because
+            // inferring std::function<bool(T const&)> is hard (but possible) and
+            // requires a lot of TMP.
+        template<typename T>
+        Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& predicate, std::string const& description = "") {
+            return Generic::PredicateMatcher<T>(predicate, description);
+        }
 
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
 
 // end catch_matchers_generic.hpp
@@ -3526,67 +3541,67 @@ public:
 #include <string>
 
 namespace Catch {
-namespace Matchers {
+    namespace Matchers {
 
-    namespace StdString {
+        namespace StdString {
 
-        struct CasedString
-        {
-            CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity );
-            std::string adjustString( std::string const& str ) const;
-            std::string caseSensitivitySuffix() const;
+            struct CasedString
+            {
+                CasedString(std::string const& str, CaseSensitive::Choice caseSensitivity);
+                std::string adjustString(std::string const& str) const;
+                std::string caseSensitivitySuffix() const;
 
-            CaseSensitive::Choice m_caseSensitivity;
-            std::string m_str;
-        };
+                CaseSensitive::Choice m_caseSensitivity;
+                std::string m_str;
+            };
 
-        struct StringMatcherBase : MatcherBase<std::string> {
-            StringMatcherBase( std::string const& operation, CasedString const& comparator );
-            std::string describe() const override;
+            struct StringMatcherBase : MatcherBase<std::string> {
+                StringMatcherBase(std::string const& operation, CasedString const& comparator);
+                std::string describe() const override;
 
-            CasedString m_comparator;
-            std::string m_operation;
-        };
+                CasedString m_comparator;
+                std::string m_operation;
+            };
 
-        struct EqualsMatcher : StringMatcherBase {
-            EqualsMatcher( CasedString const& comparator );
-            bool match( std::string const& source ) const override;
-        };
-        struct ContainsMatcher : StringMatcherBase {
-            ContainsMatcher( CasedString const& comparator );
-            bool match( std::string const& source ) const override;
-        };
-        struct StartsWithMatcher : StringMatcherBase {
-            StartsWithMatcher( CasedString const& comparator );
-            bool match( std::string const& source ) const override;
-        };
-        struct EndsWithMatcher : StringMatcherBase {
-            EndsWithMatcher( CasedString const& comparator );
-            bool match( std::string const& source ) const override;
-        };
+            struct EqualsMatcher : StringMatcherBase {
+                EqualsMatcher(CasedString const& comparator);
+                bool match(std::string const& source) const override;
+            };
+            struct ContainsMatcher : StringMatcherBase {
+                ContainsMatcher(CasedString const& comparator);
+                bool match(std::string const& source) const override;
+            };
+            struct StartsWithMatcher : StringMatcherBase {
+                StartsWithMatcher(CasedString const& comparator);
+                bool match(std::string const& source) const override;
+            };
+            struct EndsWithMatcher : StringMatcherBase {
+                EndsWithMatcher(CasedString const& comparator);
+                bool match(std::string const& source) const override;
+            };
 
-        struct RegexMatcher : MatcherBase<std::string> {
-            RegexMatcher( std::string regex, CaseSensitive::Choice caseSensitivity );
-            bool match( std::string const& matchee ) const override;
-            std::string describe() const override;
+            struct RegexMatcher : MatcherBase<std::string> {
+                RegexMatcher(std::string regex, CaseSensitive::Choice caseSensitivity);
+                bool match(std::string const& matchee) const override;
+                std::string describe() const override;
 
-        private:
-            std::string m_regex;
-            CaseSensitive::Choice m_caseSensitivity;
-        };
+            private:
+                std::string m_regex;
+                CaseSensitive::Choice m_caseSensitivity;
+            };
 
-    } // namespace StdString
+        } // namespace StdString
 
-    // The following functions create the actual matcher objects.
-    // This allows the types to be inferred
+        // The following functions create the actual matcher objects.
+        // This allows the types to be inferred
 
-    StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-    StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-    StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-    StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-    StdString::RegexMatcher Matches( std::string const& regex, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+        StdString::EqualsMatcher Equals(std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes);
+        StdString::ContainsMatcher Contains(std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes);
+        StdString::EndsWithMatcher EndsWith(std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes);
+        StdString::StartsWithMatcher StartsWith(std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes);
+        StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes);
 
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
 
 // end catch_matchers_string.h
@@ -3595,167 +3610,167 @@ namespace Matchers {
 #include <algorithm>
 
 namespace Catch {
-namespace Matchers {
+    namespace Matchers {
 
-    namespace Vector {
-        template<typename T, typename Alloc>
-        struct ContainsElementMatcher : MatcherBase<std::vector<T, Alloc>> {
+        namespace Vector {
+            template<typename T, typename Alloc>
+            struct ContainsElementMatcher : MatcherBase<std::vector<T, Alloc>> {
 
-            ContainsElementMatcher(T const &comparator) : m_comparator( comparator) {}
+                ContainsElementMatcher(T const& comparator) : m_comparator(comparator) {}
 
-            bool match(std::vector<T, Alloc> const &v) const override {
-                for (auto const& el : v) {
-                    if (el == m_comparator) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            std::string describe() const override {
-                return "Contains: " + ::Catch::Detail::stringify( m_comparator );
-            }
-
-            T const& m_comparator;
-        };
-
-        template<typename T, typename AllocComp, typename AllocMatch>
-        struct ContainsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
-
-            ContainsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator( comparator ) {}
-
-            bool match(std::vector<T, AllocMatch> const &v) const override {
-                // !TBD: see note in EqualsMatcher
-                if (m_comparator.size() > v.size())
-                    return false;
-                for (auto const& comparator : m_comparator) {
-                    auto present = false;
-                    for (const auto& el : v) {
-                        if (el == comparator) {
-                            present = true;
-                            break;
+                bool match(std::vector<T, Alloc> const& v) const override {
+                    for (auto const& el : v) {
+                        if (el == m_comparator) {
+                            return true;
                         }
                     }
-                    if (!present) {
+                    return false;
+                }
+
+                std::string describe() const override {
+                    return "Contains: " + ::Catch::Detail::stringify(m_comparator);
+                }
+
+                T const& m_comparator;
+            };
+
+            template<typename T, typename AllocComp, typename AllocMatch>
+            struct ContainsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+
+                ContainsMatcher(std::vector<T, AllocComp> const& comparator) : m_comparator(comparator) {}
+
+                bool match(std::vector<T, AllocMatch> const& v) const override {
+                    // !TBD: see note in EqualsMatcher
+                    if (m_comparator.size() > v.size())
+                        return false;
+                    for (auto const& comparator : m_comparator) {
+                        auto present = false;
+                        for (const auto& el : v) {
+                            if (el == comparator) {
+                                present = true;
+                                break;
+                            }
+                        }
+                        if (!present) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                std::string describe() const override {
+                    return "Contains: " + ::Catch::Detail::stringify(m_comparator);
+                }
+
+                std::vector<T, AllocComp> const& m_comparator;
+            };
+
+            template<typename T, typename AllocComp, typename AllocMatch>
+            struct EqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+
+                EqualsMatcher(std::vector<T, AllocComp> const& comparator) : m_comparator(comparator) {}
+
+                bool match(std::vector<T, AllocMatch> const& v) const override {
+                    // !TBD: This currently works if all elements can be compared using !=
+                    // - a more general approach would be via a compare template that defaults
+                    // to using !=. but could be specialised for, e.g. std::vector<T, Alloc> etc
+                    // - then just call that directly
+                    if (m_comparator.size() != v.size())
+                        return false;
+                    for (std::size_t i = 0; i < v.size(); ++i)
+                        if (m_comparator[i] != v[i])
+                            return false;
+                    return true;
+                }
+                std::string describe() const override {
+                    return "Equals: " + ::Catch::Detail::stringify(m_comparator);
+                }
+                std::vector<T, AllocComp> const& m_comparator;
+            };
+
+            template<typename T, typename AllocComp, typename AllocMatch>
+            struct ApproxMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+
+                ApproxMatcher(std::vector<T, AllocComp> const& comparator) : m_comparator(comparator) {}
+
+                bool match(std::vector<T, AllocMatch> const& v) const override {
+                    if (m_comparator.size() != v.size())
+                        return false;
+                    for (std::size_t i = 0; i < v.size(); ++i)
+                        if (m_comparator[i] != approx(v[i]))
+                            return false;
+                    return true;
+                }
+                std::string describe() const override {
+                    return "is approx: " + ::Catch::Detail::stringify(m_comparator);
+                }
+                template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+                ApproxMatcher& epsilon(T const& newEpsilon) {
+                    approx.epsilon(newEpsilon);
+                    return *this;
+                }
+                template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+                ApproxMatcher& margin(T const& newMargin) {
+                    approx.margin(newMargin);
+                    return *this;
+                }
+                template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+                ApproxMatcher& scale(T const& newScale) {
+                    approx.scale(newScale);
+                    return *this;
+                }
+
+                std::vector<T, AllocComp> const& m_comparator;
+                mutable Catch::Detail::Approx approx = Catch::Detail::Approx::custom();
+            };
+
+            template<typename T, typename AllocComp, typename AllocMatch>
+            struct UnorderedEqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+                UnorderedEqualsMatcher(std::vector<T, AllocComp> const& target) : m_target(target) {}
+                bool match(std::vector<T, AllocMatch> const& vec) const override {
+                    if (m_target.size() != vec.size()) {
                         return false;
                     }
+                    return std::is_permutation(m_target.begin(), m_target.end(), vec.begin());
                 }
-                return true;
-            }
-            std::string describe() const override {
-                return "Contains: " + ::Catch::Detail::stringify( m_comparator );
-            }
 
-            std::vector<T, AllocComp> const& m_comparator;
-        };
-
-        template<typename T, typename AllocComp, typename AllocMatch>
-        struct EqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
-
-            EqualsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator( comparator ) {}
-
-            bool match(std::vector<T, AllocMatch> const &v) const override {
-                // !TBD: This currently works if all elements can be compared using !=
-                // - a more general approach would be via a compare template that defaults
-                // to using !=. but could be specialised for, e.g. std::vector<T, Alloc> etc
-                // - then just call that directly
-                if (m_comparator.size() != v.size())
-                    return false;
-                for (std::size_t i = 0; i < v.size(); ++i)
-                    if (m_comparator[i] != v[i])
-                        return false;
-                return true;
-            }
-            std::string describe() const override {
-                return "Equals: " + ::Catch::Detail::stringify( m_comparator );
-            }
-            std::vector<T, AllocComp> const& m_comparator;
-        };
-
-        template<typename T, typename AllocComp, typename AllocMatch>
-        struct ApproxMatcher : MatcherBase<std::vector<T, AllocMatch>> {
-
-            ApproxMatcher(std::vector<T, AllocComp> const& comparator) : m_comparator( comparator ) {}
-
-            bool match(std::vector<T, AllocMatch> const &v) const override {
-                if (m_comparator.size() != v.size())
-                    return false;
-                for (std::size_t i = 0; i < v.size(); ++i)
-                    if (m_comparator[i] != approx(v[i]))
-                        return false;
-                return true;
-            }
-            std::string describe() const override {
-                return "is approx: " + ::Catch::Detail::stringify( m_comparator );
-            }
-            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-            ApproxMatcher& epsilon( T const& newEpsilon ) {
-                approx.epsilon(newEpsilon);
-                return *this;
-            }
-            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-            ApproxMatcher& margin( T const& newMargin ) {
-                approx.margin(newMargin);
-                return *this;
-            }
-            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-            ApproxMatcher& scale( T const& newScale ) {
-                approx.scale(newScale);
-                return *this;
-            }
-
-            std::vector<T, AllocComp> const& m_comparator;
-            mutable Catch::Detail::Approx approx = Catch::Detail::Approx::custom();
-        };
-
-        template<typename T, typename AllocComp, typename AllocMatch>
-        struct UnorderedEqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
-            UnorderedEqualsMatcher(std::vector<T, AllocComp> const& target) : m_target(target) {}
-            bool match(std::vector<T, AllocMatch> const& vec) const override {
-                if (m_target.size() != vec.size()) {
-                    return false;
+                std::string describe() const override {
+                    return "UnorderedEquals: " + ::Catch::Detail::stringify(m_target);
                 }
-                return std::is_permutation(m_target.begin(), m_target.end(), vec.begin());
-            }
+            private:
+                std::vector<T, AllocComp> const& m_target;
+            };
 
-            std::string describe() const override {
-                return "UnorderedEquals: " + ::Catch::Detail::stringify(m_target);
-            }
-        private:
-            std::vector<T, AllocComp> const& m_target;
-        };
+        } // namespace Vector
 
-    } // namespace Vector
+        // The following functions create the actual matcher objects.
+        // This allows the types to be inferred
 
-    // The following functions create the actual matcher objects.
-    // This allows the types to be inferred
+        template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+        Vector::ContainsMatcher<T, AllocComp, AllocMatch> Contains(std::vector<T, AllocComp> const& comparator) {
+            return Vector::ContainsMatcher<T, AllocComp, AllocMatch>(comparator);
+        }
 
-    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-    Vector::ContainsMatcher<T, AllocComp, AllocMatch> Contains( std::vector<T, AllocComp> const& comparator ) {
-        return Vector::ContainsMatcher<T, AllocComp, AllocMatch>( comparator );
-    }
+        template<typename T, typename Alloc = std::allocator<T>>
+        Vector::ContainsElementMatcher<T, Alloc> VectorContains(T const& comparator) {
+            return Vector::ContainsElementMatcher<T, Alloc>(comparator);
+        }
 
-    template<typename T, typename Alloc = std::allocator<T>>
-    Vector::ContainsElementMatcher<T, Alloc> VectorContains( T const& comparator ) {
-        return Vector::ContainsElementMatcher<T, Alloc>( comparator );
-    }
+        template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+        Vector::EqualsMatcher<T, AllocComp, AllocMatch> Equals(std::vector<T, AllocComp> const& comparator) {
+            return Vector::EqualsMatcher<T, AllocComp, AllocMatch>(comparator);
+        }
 
-    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-    Vector::EqualsMatcher<T, AllocComp, AllocMatch> Equals( std::vector<T, AllocComp> const& comparator ) {
-        return Vector::EqualsMatcher<T, AllocComp, AllocMatch>( comparator );
-    }
+        template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+        Vector::ApproxMatcher<T, AllocComp, AllocMatch> Approx(std::vector<T, AllocComp> const& comparator) {
+            return Vector::ApproxMatcher<T, AllocComp, AllocMatch>(comparator);
+        }
 
-    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-    Vector::ApproxMatcher<T, AllocComp, AllocMatch> Approx( std::vector<T, AllocComp> const& comparator ) {
-        return Vector::ApproxMatcher<T, AllocComp, AllocMatch>( comparator );
-    }
+        template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+        Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch> UnorderedEquals(std::vector<T, AllocComp> const& target) {
+            return Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch>(target);
+        }
 
-    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-    Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch> UnorderedEquals(std::vector<T, AllocComp> const& target) {
-        return Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch>( target );
-    }
-
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
 
 // end catch_matchers_vector.h
@@ -3767,17 +3782,17 @@ namespace Catch {
         MatcherT m_matcher;
         StringRef m_matcherString;
     public:
-        MatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString )
-        :   ITransientExpression{ true, matcher.match( arg ) },
-            m_arg( arg ),
-            m_matcher( matcher ),
-            m_matcherString( matcherString )
+        MatchExpr(ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString)
+            : ITransientExpression{ true, matcher.match(arg) },
+            m_arg(arg),
+            m_matcher(matcher),
+            m_matcherString(matcherString)
         {}
 
-        void streamReconstructedExpression( std::ostream &os ) const override {
+        void streamReconstructedExpression(std::ostream& os) const override {
             auto matcherAsString = m_matcher.toString();
-            os << Catch::Detail::stringify( m_arg ) << ' ';
-            if( matcherAsString == Detail::unprintableString )
+            os << Catch::Detail::stringify(m_arg) << ' ';
+            if (matcherAsString == Detail::unprintableString)
                 os << m_matcherString;
             else
                 os << matcherAsString;
@@ -3786,11 +3801,11 @@ namespace Catch {
 
     using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
 
-    void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString  );
+    void handleExceptionMatchExpr(AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString);
 
     template<typename ArgT, typename MatcherT>
-    auto makeMatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString  ) -> MatchExpr<ArgT, MatcherT> {
-        return MatchExpr<ArgT, MatcherT>( arg, matcher, matcherString );
+    auto makeMatchExpr(ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString) -> MatchExpr<ArgT, MatcherT> {
+        return MatchExpr<ArgT, MatcherT>(arg, matcher, matcherString);
     }
 
 } // namespace Catch
@@ -3854,8 +3869,8 @@ namespace Catch {
     struct IGeneratorTracker {
         virtual ~IGeneratorTracker();
         virtual auto hasGenerator() const -> bool = 0;
-        virtual auto getGenerator() const -> Generators::GeneratorBasePtr const& = 0;
-        virtual void setGenerator( Generators::GeneratorBasePtr&& generator ) = 0;
+        virtual auto getGenerator() const->Generators::GeneratorBasePtr const& = 0;
+        virtual void setGenerator(Generators::GeneratorBasePtr&& generator) = 0;
     };
 
 } // namespace Catch
@@ -3911,185 +3926,185 @@ namespace Catch {
 
 namespace Catch {
 
-class GeneratorException : public std::exception {
-    const char* const m_msg = "";
+    class GeneratorException : public std::exception {
+        const char* const m_msg = "";
 
-public:
-    GeneratorException(const char* msg):
-        m_msg(msg)
-    {}
-
-    const char* what() const noexcept override final;
-};
-
-namespace Generators {
-
-    // !TBD move this into its own location?
-    namespace pf{
-        template<typename T, typename... Args>
-        std::unique_ptr<T> make_unique( Args&&... args ) {
-            return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-        }
-    }
-
-    template<typename T>
-    struct IGenerator : GeneratorUntypedBase {
-        virtual ~IGenerator() = default;
-
-        // Returns the current element of the generator
-        //
-        // \Precondition The generator is either freshly constructed,
-        // or the last call to `next()` returned true
-        virtual T const& get() const = 0;
-        using type = T;
-    };
-
-    template<typename T>
-    class SingleValueGenerator final : public IGenerator<T> {
-        T m_value;
     public:
-        SingleValueGenerator(T&& value) : m_value(std::move(value)) {}
-
-        T const& get() const override {
-            return m_value;
-        }
-        bool next() override {
-            return false;
-        }
-    };
-
-    template<typename T>
-    class FixedValuesGenerator final : public IGenerator<T> {
-        static_assert(!std::is_same<T, bool>::value,
-            "FixedValuesGenerator does not support bools because of std::vector<bool>"
-            "specialization, use SingleValue Generator instead.");
-        std::vector<T> m_values;
-        size_t m_idx = 0;
-    public:
-        FixedValuesGenerator( std::initializer_list<T> values ) : m_values( values ) {}
-
-        T const& get() const override {
-            return m_values[m_idx];
-        }
-        bool next() override {
-            ++m_idx;
-            return m_idx < m_values.size();
-        }
-    };
-
-    template <typename T>
-    class GeneratorWrapper final {
-        std::unique_ptr<IGenerator<T>> m_generator;
-    public:
-        GeneratorWrapper(std::unique_ptr<IGenerator<T>> generator):
-            m_generator(std::move(generator))
+        GeneratorException(const char* msg) :
+            m_msg(msg)
         {}
-        T const& get() const {
-            return m_generator->get();
-        }
-        bool next() {
-            return m_generator->next();
-        }
+
+        const char* what() const noexcept override final;
     };
 
-    template <typename T>
-    GeneratorWrapper<T> value(T&& value) {
-        return GeneratorWrapper<T>(pf::make_unique<SingleValueGenerator<T>>(std::forward<T>(value)));
-    }
-    template <typename T>
-    GeneratorWrapper<T> values(std::initializer_list<T> values) {
-        return GeneratorWrapper<T>(pf::make_unique<FixedValuesGenerator<T>>(values));
-    }
+    namespace Generators {
 
-    template<typename T>
-    class Generators : public IGenerator<T> {
-        std::vector<GeneratorWrapper<T>> m_generators;
-        size_t m_current = 0;
-
-        void populate(GeneratorWrapper<T>&& generator) {
-            m_generators.emplace_back(std::move(generator));
-        }
-        void populate(T&& val) {
-            m_generators.emplace_back(value(std::forward<T>(val)));
-        }
-        template<typename U>
-        void populate(U&& val) {
-            populate(T(std::forward<U>(val)));
-        }
-        template<typename U, typename... Gs>
-        void populate(U&& valueOrGenerator, Gs &&... moreGenerators) {
-            populate(std::forward<U>(valueOrGenerator));
-            populate(std::forward<Gs>(moreGenerators)...);
+        // !TBD move this into its own location?
+        namespace pf {
+            template<typename T, typename... Args>
+            std::unique_ptr<T> make_unique(Args&&... args) {
+                return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+            }
         }
 
-    public:
-        template <typename... Gs>
-        Generators(Gs &&... moreGenerators) {
-            m_generators.reserve(sizeof...(Gs));
-            populate(std::forward<Gs>(moreGenerators)...);
-        }
+        template<typename T>
+        struct IGenerator : GeneratorUntypedBase {
+            virtual ~IGenerator() = default;
 
-        T const& get() const override {
-            return m_generators[m_current].get();
-        }
+            // Returns the current element of the generator
+            //
+            // \Precondition The generator is either freshly constructed,
+            // or the last call to `next()` returned true
+            virtual T const& get() const = 0;
+            using type = T;
+        };
 
-        bool next() override {
-            if (m_current >= m_generators.size()) {
+        template<typename T>
+        class SingleValueGenerator final : public IGenerator<T> {
+            T m_value;
+        public:
+            SingleValueGenerator(T&& value) : m_value(std::move(value)) {}
+
+            T const& get() const override {
+                return m_value;
+            }
+            bool next() override {
                 return false;
             }
-            const bool current_status = m_generators[m_current].next();
-            if (!current_status) {
-                ++m_current;
+        };
+
+        template<typename T>
+        class FixedValuesGenerator final : public IGenerator<T> {
+            static_assert(!std::is_same<T, bool>::value,
+                "FixedValuesGenerator does not support bools because of std::vector<bool>"
+                "specialization, use SingleValue Generator instead.");
+            std::vector<T> m_values;
+            size_t m_idx = 0;
+        public:
+            FixedValuesGenerator(std::initializer_list<T> values) : m_values(values) {}
+
+            T const& get() const override {
+                return m_values[m_idx];
             }
-            return m_current < m_generators.size();
+            bool next() override {
+                ++m_idx;
+                return m_idx < m_values.size();
+            }
+        };
+
+        template <typename T>
+        class GeneratorWrapper final {
+            std::unique_ptr<IGenerator<T>> m_generator;
+        public:
+            GeneratorWrapper(std::unique_ptr<IGenerator<T>> generator) :
+                m_generator(std::move(generator))
+            {}
+            T const& get() const {
+                return m_generator->get();
+            }
+            bool next() {
+                return m_generator->next();
+            }
+        };
+
+        template <typename T>
+        GeneratorWrapper<T> value(T&& value) {
+            return GeneratorWrapper<T>(pf::make_unique<SingleValueGenerator<T>>(std::forward<T>(value)));
         }
-    };
-
-    template<typename... Ts>
-    GeneratorWrapper<std::tuple<Ts...>> table( std::initializer_list<std::tuple<typename std::decay<Ts>::type...>> tuples ) {
-        return values<std::tuple<Ts...>>( tuples );
-    }
-
-    // Tag type to signal that a generator sequence should convert arguments to a specific type
-    template <typename T>
-    struct as {};
-
-    template<typename T, typename... Gs>
-    auto makeGenerators( GeneratorWrapper<T>&& generator, Gs &&... moreGenerators ) -> Generators<T> {
-        return Generators<T>(std::move(generator), std::forward<Gs>(moreGenerators)...);
-    }
-    template<typename T>
-    auto makeGenerators( GeneratorWrapper<T>&& generator ) -> Generators<T> {
-        return Generators<T>(std::move(generator));
-    }
-    template<typename T, typename... Gs>
-    auto makeGenerators( T&& val, Gs &&... moreGenerators ) -> Generators<T> {
-        return makeGenerators( value( std::forward<T>( val ) ), std::forward<Gs>( moreGenerators )... );
-    }
-    template<typename T, typename U, typename... Gs>
-    auto makeGenerators( as<T>, U&& val, Gs &&... moreGenerators ) -> Generators<T> {
-        return makeGenerators( value( T( std::forward<U>( val ) ) ), std::forward<Gs>( moreGenerators )... );
-    }
-
-    auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker&;
-
-    template<typename L>
-    // Note: The type after -> is weird, because VS2015 cannot parse
-    //       the expression used in the typedef inside, when it is in
-    //       return type. Yeah.
-    auto generate( StringRef generatorName, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
-        using UnderlyingType = typename decltype(generatorExpression())::type;
-
-        IGeneratorTracker& tracker = acquireGeneratorTracker( generatorName, lineInfo );
-        if (!tracker.hasGenerator()) {
-            tracker.setGenerator(pf::make_unique<Generators<UnderlyingType>>(generatorExpression()));
+        template <typename T>
+        GeneratorWrapper<T> values(std::initializer_list<T> values) {
+            return GeneratorWrapper<T>(pf::make_unique<FixedValuesGenerator<T>>(values));
         }
 
-        auto const& generator = static_cast<IGenerator<UnderlyingType> const&>( *tracker.getGenerator() );
-        return generator.get();
-    }
+        template<typename T>
+        class Generators : public IGenerator<T> {
+            std::vector<GeneratorWrapper<T>> m_generators;
+            size_t m_current = 0;
 
-} // namespace Generators
+            void populate(GeneratorWrapper<T>&& generator) {
+                m_generators.emplace_back(std::move(generator));
+            }
+            void populate(T&& val) {
+                m_generators.emplace_back(value(std::forward<T>(val)));
+            }
+            template<typename U>
+            void populate(U&& val) {
+                populate(T(std::forward<U>(val)));
+            }
+            template<typename U, typename... Gs>
+            void populate(U&& valueOrGenerator, Gs &&... moreGenerators) {
+                populate(std::forward<U>(valueOrGenerator));
+                populate(std::forward<Gs>(moreGenerators)...);
+            }
+
+        public:
+            template <typename... Gs>
+            Generators(Gs &&... moreGenerators) {
+                m_generators.reserve(sizeof...(Gs));
+                populate(std::forward<Gs>(moreGenerators)...);
+            }
+
+            T const& get() const override {
+                return m_generators[m_current].get();
+            }
+
+            bool next() override {
+                if (m_current >= m_generators.size()) {
+                    return false;
+                }
+                const bool current_status = m_generators[m_current].next();
+                if (!current_status) {
+                    ++m_current;
+                }
+                return m_current < m_generators.size();
+            }
+        };
+
+        template<typename... Ts>
+        GeneratorWrapper<std::tuple<Ts...>> table(std::initializer_list<std::tuple<typename std::decay<Ts>::type...>> tuples) {
+            return values<std::tuple<Ts...>>(tuples);
+        }
+
+        // Tag type to signal that a generator sequence should convert arguments to a specific type
+        template <typename T>
+        struct as {};
+
+        template<typename T, typename... Gs>
+        auto makeGenerators(GeneratorWrapper<T>&& generator, Gs &&... moreGenerators) -> Generators<T> {
+            return Generators<T>(std::move(generator), std::forward<Gs>(moreGenerators)...);
+        }
+        template<typename T>
+        auto makeGenerators(GeneratorWrapper<T>&& generator) -> Generators<T> {
+            return Generators<T>(std::move(generator));
+        }
+        template<typename T, typename... Gs>
+        auto makeGenerators(T&& val, Gs &&... moreGenerators) -> Generators<T> {
+            return makeGenerators(value(std::forward<T>(val)), std::forward<Gs>(moreGenerators)...);
+        }
+        template<typename T, typename U, typename... Gs>
+        auto makeGenerators(as<T>, U&& val, Gs &&... moreGenerators) -> Generators<T> {
+            return makeGenerators(value(T(std::forward<U>(val))), std::forward<Gs>(moreGenerators)...);
+        }
+
+        auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const& lineInfo) -> IGeneratorTracker&;
+
+        template<typename L>
+        // Note: The type after -> is weird, because VS2015 cannot parse
+        //       the expression used in the typedef inside, when it is in
+        //       return type. Yeah.
+        auto generate(StringRef generatorName, SourceLineInfo const& lineInfo, L const& generatorExpression) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
+            using UnderlyingType = typename decltype(generatorExpression())::type;
+
+            IGeneratorTracker& tracker = acquireGeneratorTracker(generatorName, lineInfo);
+            if (!tracker.hasGenerator()) {
+                tracker.setGenerator(pf::make_unique<Generators<UnderlyingType>>(generatorExpression()));
+            }
+
+            auto const& generator = static_cast<IGenerator<UnderlyingType> const&>(*tracker.getGenerator());
+            return generator.get();
+        }
+
+    } // namespace Generators
 } // namespace Catch
 
 #define GENERATE( ... ) \
@@ -4109,224 +4124,229 @@ namespace Generators {
 // start catch_generators_generic.hpp
 
 namespace Catch {
-namespace Generators {
+    namespace Generators {
 
-    template <typename T>
-    class TakeGenerator : public IGenerator<T> {
-        GeneratorWrapper<T> m_generator;
-        size_t m_returned = 0;
-        size_t m_target;
-    public:
-        TakeGenerator(size_t target, GeneratorWrapper<T>&& generator):
-            m_generator(std::move(generator)),
-            m_target(target)
-        {
-            assert(target != 0 && "Empty generators are not allowed");
-        }
-        T const& get() const override {
-            return m_generator.get();
-        }
-        bool next() override {
-            ++m_returned;
-            if (m_returned >= m_target) {
-                return false;
+        template <typename T>
+        class TakeGenerator : public IGenerator<T> {
+            GeneratorWrapper<T> m_generator;
+            size_t m_returned = 0;
+            size_t m_target;
+        public:
+            TakeGenerator(size_t target, GeneratorWrapper<T>&& generator) :
+                m_generator(std::move(generator)),
+                m_target(target)
+            {
+                assert(target != 0 && "Empty generators are not allowed");
             }
-
-            const auto success = m_generator.next();
-            // If the underlying generator does not contain enough values
-            // then we cut short as well
-            if (!success) {
-                m_returned = m_target;
+            T const& get() const override {
+                return m_generator.get();
             }
-            return success;
+            bool next() override {
+                ++m_returned;
+                if (m_returned >= m_target) {
+                    return false;
+                }
+
+                const auto success = m_generator.next();
+                // If the underlying generator does not contain enough values
+                // then we cut short as well
+                if (!success) {
+                    m_returned = m_target;
+                }
+                return success;
+            }
+        };
+
+        template <typename T>
+        GeneratorWrapper<T> take(size_t target, GeneratorWrapper<T>&& generator) {
+            return GeneratorWrapper<T>(pf::make_unique<TakeGenerator<T>>(target, std::move(generator)));
         }
-    };
 
-    template <typename T>
-    GeneratorWrapper<T> take(size_t target, GeneratorWrapper<T>&& generator) {
-        return GeneratorWrapper<T>(pf::make_unique<TakeGenerator<T>>(target, std::move(generator)));
-    }
-
-    template <typename T, typename Predicate>
-    class FilterGenerator : public IGenerator<T> {
-        GeneratorWrapper<T> m_generator;
-        Predicate m_predicate;
-    public:
-        template <typename P = Predicate>
-        FilterGenerator(P&& pred, GeneratorWrapper<T>&& generator):
-            m_generator(std::move(generator)),
-            m_predicate(std::forward<P>(pred))
-        {
-            if (!m_predicate(m_generator.get())) {
-                // It might happen that there are no values that pass the
-                // filter. In that case we throw an exception.
-                auto has_initial_value = next();
-                if (!has_initial_value) {
-                    Catch::throw_exception(GeneratorException("No valid value found in filtered generator"));
+        template <typename T, typename Predicate>
+        class FilterGenerator : public IGenerator<T> {
+            GeneratorWrapper<T> m_generator;
+            Predicate m_predicate;
+        public:
+            template <typename P = Predicate>
+            FilterGenerator(P&& pred, GeneratorWrapper<T>&& generator) :
+                m_generator(std::move(generator)),
+                m_predicate(std::forward<P>(pred))
+            {
+                if (!m_predicate(m_generator.get())) {
+                    // It might happen that there are no values that pass the
+                    // filter. In that case we throw an exception.
+                    auto has_initial_value = nextImpl();
+                    if (!has_initial_value) {
+                        Catch::throw_exception(GeneratorException("No valid value found in filtered generator"));
+                    }
                 }
             }
-        }
 
-        T const& get() const override {
-            return m_generator.get();
-        }
-
-        bool next() override {
-            bool success = m_generator.next();
-            if (!success) {
-                return false;
+            T const& get() const override {
+                return m_generator.get();
             }
-            while (!m_predicate(m_generator.get()) && (success = m_generator.next()) == true);
-            return success;
-        }
-    };
 
-    template <typename T, typename Predicate>
-    GeneratorWrapper<T> filter(Predicate&& pred, GeneratorWrapper<T>&& generator) {
-        return GeneratorWrapper<T>(std::unique_ptr<IGenerator<T>>(pf::make_unique<FilterGenerator<T, Predicate>>(std::forward<Predicate>(pred), std::move(generator))));
-    }
-
-    template <typename T>
-    class RepeatGenerator : public IGenerator<T> {
-        static_assert(!std::is_same<T, bool>::value,
-            "RepeatGenerator currently does not support bools"
-            "because of std::vector<bool> specialization");
-        GeneratorWrapper<T> m_generator;
-        mutable std::vector<T> m_returned;
-        size_t m_target_repeats;
-        size_t m_current_repeat = 0;
-        size_t m_repeat_index = 0;
-    public:
-        RepeatGenerator(size_t repeats, GeneratorWrapper<T>&& generator):
-            m_generator(std::move(generator)),
-            m_target_repeats(repeats)
-        {
-            assert(m_target_repeats > 0 && "Repeat generator must repeat at least once");
-        }
-
-        T const& get() const override {
-            if (m_current_repeat == 0) {
-                m_returned.push_back(m_generator.get());
-                return m_returned.back();
+            bool next() override {
+                return nextImpl();
             }
-            return m_returned[m_repeat_index];
-        }
 
-        bool next() override {
-            // There are 2 basic cases:
-            // 1) We are still reading the generator
-            // 2) We are reading our own cache
-
-            // In the first case, we need to poke the underlying generator.
-            // If it happily moves, we are left in that state, otherwise it is time to start reading from our cache
-            if (m_current_repeat == 0) {
-                const auto success = m_generator.next();
+        private:
+            bool nextImpl() {
+                bool success = m_generator.next();
                 if (!success) {
+                    return false;
+                }
+                while (!m_predicate(m_generator.get()) && (success = m_generator.next()) == true);
+                return success;
+            }
+        };
+
+        template <typename T, typename Predicate>
+        GeneratorWrapper<T> filter(Predicate&& pred, GeneratorWrapper<T>&& generator) {
+            return GeneratorWrapper<T>(std::unique_ptr<IGenerator<T>>(pf::make_unique<FilterGenerator<T, Predicate>>(std::forward<Predicate>(pred), std::move(generator))));
+        }
+
+        template <typename T>
+        class RepeatGenerator : public IGenerator<T> {
+            static_assert(!std::is_same<T, bool>::value,
+                "RepeatGenerator currently does not support bools"
+                "because of std::vector<bool> specialization");
+            GeneratorWrapper<T> m_generator;
+            mutable std::vector<T> m_returned;
+            size_t m_target_repeats;
+            size_t m_current_repeat = 0;
+            size_t m_repeat_index = 0;
+        public:
+            RepeatGenerator(size_t repeats, GeneratorWrapper<T>&& generator) :
+                m_generator(std::move(generator)),
+                m_target_repeats(repeats)
+            {
+                assert(m_target_repeats > 0 && "Repeat generator must repeat at least once");
+            }
+
+            T const& get() const override {
+                if (m_current_repeat == 0) {
+                    m_returned.push_back(m_generator.get());
+                    return m_returned.back();
+                }
+                return m_returned[m_repeat_index];
+            }
+
+            bool next() override {
+                // There are 2 basic cases:
+                // 1) We are still reading the generator
+                // 2) We are reading our own cache
+
+                // In the first case, we need to poke the underlying generator.
+                // If it happily moves, we are left in that state, otherwise it is time to start reading from our cache
+                if (m_current_repeat == 0) {
+                    const auto success = m_generator.next();
+                    if (!success) {
+                        ++m_current_repeat;
+                    }
+                    return m_current_repeat < m_target_repeats;
+                }
+
+                // In the second case, we need to move indices forward and check that we haven't run up against the end
+                ++m_repeat_index;
+                if (m_repeat_index == m_returned.size()) {
+                    m_repeat_index = 0;
                     ++m_current_repeat;
                 }
                 return m_current_repeat < m_target_repeats;
             }
+        };
 
-            // In the second case, we need to move indices forward and check that we haven't run up against the end
-            ++m_repeat_index;
-            if (m_repeat_index == m_returned.size()) {
-                m_repeat_index = 0;
-                ++m_current_repeat;
+        template <typename T>
+        GeneratorWrapper<T> repeat(size_t repeats, GeneratorWrapper<T>&& generator) {
+            return GeneratorWrapper<T>(pf::make_unique<RepeatGenerator<T>>(repeats, std::move(generator)));
+        }
+
+        template <typename T, typename U, typename Func>
+        class MapGenerator : public IGenerator<T> {
+            // TBD: provide static assert for mapping function, for friendly error message
+            GeneratorWrapper<U> m_generator;
+            Func m_function;
+            // To avoid returning dangling reference, we have to save the values
+            T m_cache;
+        public:
+            template <typename F2 = Func>
+            MapGenerator(F2&& function, GeneratorWrapper<U>&& generator) :
+                m_generator(std::move(generator)),
+                m_function(std::forward<F2>(function)),
+                m_cache(m_function(m_generator.get()))
+            {}
+
+            T const& get() const override {
+                return m_cache;
             }
-            return m_current_repeat < m_target_repeats;
-        }
-    };
-
-    template <typename T>
-    GeneratorWrapper<T> repeat(size_t repeats, GeneratorWrapper<T>&& generator) {
-        return GeneratorWrapper<T>(pf::make_unique<RepeatGenerator<T>>(repeats, std::move(generator)));
-    }
-
-    template <typename T, typename U, typename Func>
-    class MapGenerator : public IGenerator<T> {
-        // TBD: provide static assert for mapping function, for friendly error message
-        GeneratorWrapper<U> m_generator;
-        Func m_function;
-        // To avoid returning dangling reference, we have to save the values
-        T m_cache;
-    public:
-        template <typename F2 = Func>
-        MapGenerator(F2&& function, GeneratorWrapper<U>&& generator) :
-            m_generator(std::move(generator)),
-            m_function(std::forward<F2>(function)),
-            m_cache(m_function(m_generator.get()))
-        {}
-
-        T const& get() const override {
-            return m_cache;
-        }
-        bool next() override {
-            const auto success = m_generator.next();
-            if (success) {
-                m_cache = m_function(m_generator.get());
+            bool next() override {
+                const auto success = m_generator.next();
+                if (success) {
+                    m_cache = m_function(m_generator.get());
+                }
+                return success;
             }
-            return success;
+        };
+
+        template <typename Func, typename U, typename T = FunctionReturnType<Func, U>>
+        GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
+            return GeneratorWrapper<T>(
+                pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
+            );
         }
-    };
 
-    template <typename Func, typename U, typename T = FunctionReturnType<Func, U>>
-    GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
-        return GeneratorWrapper<T>(
-            pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
-        );
-    }
+        template <typename T, typename U, typename Func>
+        GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
+            return GeneratorWrapper<T>(
+                pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
+            );
+        }
 
-    template <typename T, typename U, typename Func>
-    GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
-        return GeneratorWrapper<T>(
-            pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
-        );
-    }
-
-    template <typename T>
-    class ChunkGenerator final : public IGenerator<std::vector<T>> {
-        std::vector<T> m_chunk;
-        size_t m_chunk_size;
-        GeneratorWrapper<T> m_generator;
-        bool m_used_up = false;
-    public:
-        ChunkGenerator(size_t size, GeneratorWrapper<T> generator) :
-            m_chunk_size(size), m_generator(std::move(generator))
-        {
-            m_chunk.reserve(m_chunk_size);
-            if (m_chunk_size != 0) {
-                m_chunk.push_back(m_generator.get());
-                for (size_t i = 1; i < m_chunk_size; ++i) {
+        template <typename T>
+        class ChunkGenerator final : public IGenerator<std::vector<T>> {
+            std::vector<T> m_chunk;
+            size_t m_chunk_size;
+            GeneratorWrapper<T> m_generator;
+            bool m_used_up = false;
+        public:
+            ChunkGenerator(size_t size, GeneratorWrapper<T> generator) :
+                m_chunk_size(size), m_generator(std::move(generator))
+            {
+                m_chunk.reserve(m_chunk_size);
+                if (m_chunk_size != 0) {
+                    m_chunk.push_back(m_generator.get());
+                    for (size_t i = 1; i < m_chunk_size; ++i) {
+                        if (!m_generator.next()) {
+                            Catch::throw_exception(GeneratorException("Not enough values to initialize the first chunk"));
+                        }
+                        m_chunk.push_back(m_generator.get());
+                    }
+                }
+            }
+            std::vector<T> const& get() const override {
+                return m_chunk;
+            }
+            bool next() override {
+                m_chunk.clear();
+                for (size_t idx = 0; idx < m_chunk_size; ++idx) {
                     if (!m_generator.next()) {
-                        Catch::throw_exception(GeneratorException("Not enough values to initialize the first chunk"));
+                        return false;
                     }
                     m_chunk.push_back(m_generator.get());
                 }
+                return true;
             }
-        }
-        std::vector<T> const& get() const override {
-            return m_chunk;
-        }
-        bool next() override {
-            m_chunk.clear();
-            for (size_t idx = 0; idx < m_chunk_size; ++idx) {
-                if (!m_generator.next()) {
-                    return false;
-                }
-                m_chunk.push_back(m_generator.get());
-            }
-            return true;
-        }
-    };
+        };
 
-    template <typename T>
-    GeneratorWrapper<std::vector<T>> chunk(size_t size, GeneratorWrapper<T>&& generator) {
-        return GeneratorWrapper<std::vector<T>>(
-            pf::make_unique<ChunkGenerator<T>>(size, std::move(generator))
-        );
-    }
+        template <typename T>
+        GeneratorWrapper<std::vector<T>> chunk(size_t size, GeneratorWrapper<T>&& generator) {
+            return GeneratorWrapper<std::vector<T>>(
+                pf::make_unique<ChunkGenerator<T>>(size, std::move(generator))
+            );
+        }
 
-} // namespace Generators
+    } // namespace Generators
 } // namespace Catch
 
 // end catch_generators_generic.hpp
@@ -4357,12 +4377,12 @@ namespace Catch {
     struct IMutableContext : IContext
     {
         virtual ~IMutableContext();
-        virtual void setResultCapture( IResultCapture* resultCapture ) = 0;
-        virtual void setRunner( IRunner* runner ) = 0;
-        virtual void setConfig( IConfigPtr const& config ) = 0;
+        virtual void setResultCapture(IResultCapture* resultCapture) = 0;
+        virtual void setRunner(IRunner* runner) = 0;
+        virtual void setConfig(IConfigPtr const& config) = 0;
 
     private:
-        static IMutableContext *currentContext;
+        static IMutableContext* currentContext;
         friend IMutableContext& getCurrentMutableContext();
         friend void cleanUpContext();
         static void createContext();
@@ -4370,7 +4390,7 @@ namespace Catch {
 
     inline IMutableContext& getCurrentMutableContext()
     {
-        if( !IMutableContext::currentContext )
+        if (!IMutableContext::currentContext)
             IMutableContext::createContext();
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
         return *IMutableContext::currentContext;
@@ -4398,34 +4418,34 @@ namespace Catch {
     template<typename T>
     class Option {
     public:
-        Option() : nullableValue( nullptr ) {}
-        Option( T const& _value )
-        : nullableValue( new( storage ) T( _value ) )
+        Option() : nullableValue(nullptr) {}
+        Option(T const& _value)
+            : nullableValue(new(storage) T(_value))
         {}
-        Option( Option const& _other )
-        : nullableValue( _other ? new( storage ) T( *_other ) : nullptr )
+        Option(Option const& _other)
+            : nullableValue(_other ? new(storage) T(*_other) : nullptr)
         {}
 
         ~Option() {
             reset();
         }
 
-        Option& operator= ( Option const& _other ) {
-            if( &_other != this ) {
+        Option& operator= (Option const& _other) {
+            if (&_other != this) {
                 reset();
-                if( _other )
-                    nullableValue = new( storage ) T( *_other );
+                if (_other)
+                    nullableValue = new(storage) T(*_other);
             }
             return *this;
         }
-        Option& operator = ( T const& _value ) {
+        Option& operator = (T const& _value) {
             reset();
-            nullableValue = new( storage ) T( _value );
+            nullableValue = new(storage) T(_value);
             return *this;
         }
 
         void reset() {
-            if( nullableValue )
+            if (nullableValue)
                 nullableValue->~T();
             nullableValue = nullptr;
         }
@@ -4435,7 +4455,7 @@ namespace Catch {
         T* operator->() { return nullableValue; }
         const T* operator->() const { return nullableValue; }
 
-        T valueOr( T const& defaultValue ) const {
+        T valueOr(T const& defaultValue) const {
             return nullableValue ? *nullableValue : defaultValue;
         }
 
@@ -4448,7 +4468,7 @@ namespace Catch {
         }
 
     private:
-        T *nullableValue;
+        T* nullableValue;
         alignas(alignof(T)) char storage[sizeof(T)];
     };
 
@@ -4469,33 +4489,43 @@ namespace Catch {
         High
     };
 
-    struct WarnAbout { enum What {
-        Nothing = 0x00,
-        NoAssertions = 0x01,
-        NoTests = 0x02
-    }; };
+    struct WarnAbout {
+        enum What {
+            Nothing = 0x00,
+            NoAssertions = 0x01,
+            NoTests = 0x02
+        };
+    };
 
-    struct ShowDurations { enum OrNot {
-        DefaultForReporter,
-        Always,
-        Never
-    }; };
-    struct RunTests { enum InWhatOrder {
-        InDeclarationOrder,
-        InLexicographicalOrder,
-        InRandomOrder
-    }; };
-    struct UseColour { enum YesOrNo {
-        Auto,
-        Yes,
-        No
-    }; };
-    struct WaitForKeypress { enum When {
-        Never,
-        BeforeStart = 1,
-        BeforeExit = 2,
-        BeforeStartAndExit = BeforeStart | BeforeExit
-    }; };
+    struct ShowDurations {
+        enum OrNot {
+            DefaultForReporter,
+            Always,
+            Never
+        };
+    };
+    struct RunTests {
+        enum InWhatOrder {
+            InDeclarationOrder,
+            InLexicographicalOrder,
+            InRandomOrder
+        };
+    };
+    struct UseColour {
+        enum YesOrNo {
+            Auto,
+            Yes,
+            No
+        };
+    };
+    struct WaitForKeypress {
+        enum When {
+            Never,
+            BeforeStart = 1,
+            BeforeExit = 2,
+            BeforeStartAndExit = BeforeStart | BeforeExit
+        };
+    };
 
     class TestSpec;
 
@@ -4549,15 +4579,15 @@ namespace Catch {
         using state_type = std::uint64_t;
     public:
         using result_type = std::uint32_t;
-        static constexpr result_type (min)() {
+        static constexpr result_type(min)() {
             return 0;
         }
-        static constexpr result_type (max)() {
+        static constexpr result_type(max)() {
             return static_cast<result_type>(-1);
         }
 
         // Provide some default initial state for the default constructor
-        SimplePcg32():SimplePcg32(0xed743cc4U) {}
+        SimplePcg32() :SimplePcg32(0xed743cc4U) {}
 
         explicit SimplePcg32(result_type seed_);
 
@@ -4587,157 +4617,157 @@ namespace Catch {
 #include <random>
 
 namespace Catch {
-namespace Generators {
+    namespace Generators {
 
-template <typename Float>
-class RandomFloatingGenerator final : public IGenerator<Float> {
-    Catch::SimplePcg32& m_rng;
-    std::uniform_real_distribution<Float> m_dist;
-    Float m_current_number;
-public:
+        template <typename Float>
+        class RandomFloatingGenerator final : public IGenerator<Float> {
+            Catch::SimplePcg32& m_rng;
+            std::uniform_real_distribution<Float> m_dist;
+            Float m_current_number;
+        public:
 
-    RandomFloatingGenerator(Float a, Float b):
-        m_rng(rng()),
-        m_dist(a, b) {
-        static_cast<void>(next());
-    }
+            RandomFloatingGenerator(Float a, Float b) :
+                m_rng(rng()),
+                m_dist(a, b) {
+                static_cast<void>(next());
+            }
 
-    Float const& get() const override {
-        return m_current_number;
-    }
-    bool next() override {
-        m_current_number = m_dist(m_rng);
-        return true;
-    }
-};
+            Float const& get() const override {
+                return m_current_number;
+            }
+            bool next() override {
+                m_current_number = m_dist(m_rng);
+                return true;
+            }
+        };
 
-template <typename Integer>
-class RandomIntegerGenerator final : public IGenerator<Integer> {
-    Catch::SimplePcg32& m_rng;
-    std::uniform_int_distribution<Integer> m_dist;
-    Integer m_current_number;
-public:
+        template <typename Integer>
+        class RandomIntegerGenerator final : public IGenerator<Integer> {
+            Catch::SimplePcg32& m_rng;
+            std::uniform_int_distribution<Integer> m_dist;
+            Integer m_current_number;
+        public:
 
-    RandomIntegerGenerator(Integer a, Integer b):
-        m_rng(rng()),
-        m_dist(a, b) {
-        static_cast<void>(next());
-    }
+            RandomIntegerGenerator(Integer a, Integer b) :
+                m_rng(rng()),
+                m_dist(a, b) {
+                static_cast<void>(next());
+            }
 
-    Integer const& get() const override {
-        return m_current_number;
-    }
-    bool next() override {
-        m_current_number = m_dist(m_rng);
-        return true;
-    }
-};
+            Integer const& get() const override {
+                return m_current_number;
+            }
+            bool next() override {
+                m_current_number = m_dist(m_rng);
+                return true;
+            }
+        };
 
-// TODO: Ideally this would be also constrained against the various char types,
-//       but I don't expect users to run into that in practice.
-template <typename T>
-typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, bool>::value,
-GeneratorWrapper<T>>::type
-random(T a, T b) {
-    return GeneratorWrapper<T>(
-        pf::make_unique<RandomIntegerGenerator<T>>(a, b)
-    );
-}
-
-template <typename T>
-typename std::enable_if<std::is_floating_point<T>::value,
-GeneratorWrapper<T>>::type
-random(T a, T b) {
-    return GeneratorWrapper<T>(
-        pf::make_unique<RandomFloatingGenerator<T>>(a, b)
-    );
-}
-
-template <typename T>
-class RangeGenerator final : public IGenerator<T> {
-    T m_current;
-    T m_end;
-    T m_step;
-    bool m_positive;
-
-public:
-    RangeGenerator(T const& start, T const& end, T const& step):
-        m_current(start),
-        m_end(end),
-        m_step(step),
-        m_positive(m_step > T(0))
-    {
-        assert(m_current != m_end && "Range start and end cannot be equal");
-        assert(m_step != T(0) && "Step size cannot be zero");
-        assert(((m_positive && m_current <= m_end) || (!m_positive && m_current >= m_end)) && "Step moves away from end");
-    }
-
-    RangeGenerator(T const& start, T const& end):
-        RangeGenerator(start, end, (start < end) ? T(1) : T(-1))
-    {}
-
-    T const& get() const override {
-        return m_current;
-    }
-
-    bool next() override {
-        m_current += m_step;
-        return (m_positive) ? (m_current < m_end) : (m_current > m_end);
-    }
-};
-
-template <typename T>
-GeneratorWrapper<T> range(T const& start, T const& end, T const& step) {
-    static_assert(std::is_arithmetic<T>::value && !std::is_same<T, bool>::value, "Type must be numeric");
-    return GeneratorWrapper<T>(pf::make_unique<RangeGenerator<T>>(start, end, step));
-}
-
-template <typename T>
-GeneratorWrapper<T> range(T const& start, T const& end) {
-    static_assert(std::is_integral<T>::value && !std::is_same<T, bool>::value, "Type must be an integer");
-    return GeneratorWrapper<T>(pf::make_unique<RangeGenerator<T>>(start, end));
-}
-
-template <typename T>
-class IteratorGenerator final : public IGenerator<T> {
-    static_assert(!std::is_same<T, bool>::value,
-        "IteratorGenerator currently does not support bools"
-        "because of std::vector<bool> specialization");
-
-    std::vector<T> m_elems;
-    size_t m_current = 0;
-public:
-    template <typename InputIterator, typename InputSentinel>
-    IteratorGenerator(InputIterator first, InputSentinel last):m_elems(first, last) {
-        if (m_elems.empty()) {
-            Catch::throw_exception(GeneratorException("IteratorGenerator received no valid values"));
+        // TODO: Ideally this would be also constrained against the various char types,
+        //       but I don't expect users to run into that in practice.
+        template <typename T>
+        typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, bool>::value,
+            GeneratorWrapper<T>>::type
+            random(T a, T b) {
+            return GeneratorWrapper<T>(
+                pf::make_unique<RandomIntegerGenerator<T>>(a, b)
+            );
         }
-    }
 
-    T const& get() const override {
-        return m_elems[m_current];
-    }
+        template <typename T>
+        typename std::enable_if<std::is_floating_point<T>::value,
+            GeneratorWrapper<T>>::type
+            random(T a, T b) {
+            return GeneratorWrapper<T>(
+                pf::make_unique<RandomFloatingGenerator<T>>(a, b)
+            );
+        }
 
-    bool next() override {
-        ++m_current;
-        return m_current != m_elems.size();
-    }
-};
+        template <typename T>
+        class RangeGenerator final : public IGenerator<T> {
+            T m_current;
+            T m_end;
+            T m_step;
+            bool m_positive;
 
-template <typename InputIterator,
-          typename InputSentinel,
-          typename ResultType = typename std::iterator_traits<InputIterator>::value_type>
-GeneratorWrapper<ResultType> from_range(InputIterator from, InputSentinel to) {
-    return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(from, to));
-}
+        public:
+            RangeGenerator(T const& start, T const& end, T const& step) :
+                m_current(start),
+                m_end(end),
+                m_step(step),
+                m_positive(m_step > T(0))
+            {
+                assert(m_current != m_end && "Range start and end cannot be equal");
+                assert(m_step != T(0) && "Step size cannot be zero");
+                assert(((m_positive && m_current <= m_end) || (!m_positive && m_current >= m_end)) && "Step moves away from end");
+            }
 
-template <typename Container,
-          typename ResultType = typename Container::value_type>
-GeneratorWrapper<ResultType> from_range(Container const& cnt) {
-    return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(cnt.begin(), cnt.end()));
-}
+            RangeGenerator(T const& start, T const& end) :
+                RangeGenerator(start, end, (start < end) ? T(1) : T(-1))
+            {}
 
-} // namespace Generators
+            T const& get() const override {
+                return m_current;
+            }
+
+            bool next() override {
+                m_current += m_step;
+                return (m_positive) ? (m_current < m_end) : (m_current > m_end);
+            }
+        };
+
+        template <typename T>
+        GeneratorWrapper<T> range(T const& start, T const& end, T const& step) {
+            static_assert(std::is_arithmetic<T>::value && !std::is_same<T, bool>::value, "Type must be numeric");
+            return GeneratorWrapper<T>(pf::make_unique<RangeGenerator<T>>(start, end, step));
+        }
+
+        template <typename T>
+        GeneratorWrapper<T> range(T const& start, T const& end) {
+            static_assert(std::is_integral<T>::value && !std::is_same<T, bool>::value, "Type must be an integer");
+            return GeneratorWrapper<T>(pf::make_unique<RangeGenerator<T>>(start, end));
+        }
+
+        template <typename T>
+        class IteratorGenerator final : public IGenerator<T> {
+            static_assert(!std::is_same<T, bool>::value,
+                "IteratorGenerator currently does not support bools"
+                "because of std::vector<bool> specialization");
+
+            std::vector<T> m_elems;
+            size_t m_current = 0;
+        public:
+            template <typename InputIterator, typename InputSentinel>
+            IteratorGenerator(InputIterator first, InputSentinel last) :m_elems(first, last) {
+                if (m_elems.empty()) {
+                    Catch::throw_exception(GeneratorException("IteratorGenerator received no valid values"));
+                }
+            }
+
+            T const& get() const override {
+                return m_elems[m_current];
+            }
+
+            bool next() override {
+                ++m_current;
+                return m_current != m_elems.size();
+            }
+        };
+
+        template <typename InputIterator,
+            typename InputSentinel,
+            typename ResultType = typename std::iterator_traits<InputIterator>::value_type>
+        GeneratorWrapper<ResultType> from_range(InputIterator from, InputSentinel to) {
+            return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(from, to));
+        }
+
+        template <typename Container,
+            typename ResultType = typename Container::value_type>
+        GeneratorWrapper<ResultType> from_range(Container const& cnt) {
+            return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(cnt.begin(), cnt.end()));
+        }
+
+    } // namespace Generators
 } // namespace Catch
 
 // end catch_generators_specific.hpp
@@ -4760,7 +4790,7 @@ namespace Catch {
     struct ITestInvoker;
 
     struct TestCaseInfo {
-        enum SpecialProperties{
+        enum SpecialProperties {
             None = 0,
             IsHidden = 1 << 1,
             ShouldFail = 1 << 2,
@@ -4770,13 +4800,13 @@ namespace Catch {
             Benchmark = 1 << 6
         };
 
-        TestCaseInfo(   std::string const& _name,
-                        std::string const& _className,
-                        std::string const& _description,
-                        std::vector<std::string> const& _tags,
-                        SourceLineInfo const& _lineInfo );
+        TestCaseInfo(std::string const& _name,
+            std::string const& _className,
+            std::string const& _description,
+            std::vector<std::string> const& _tags,
+            SourceLineInfo const& _lineInfo);
 
-        friend void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags );
+        friend void setTags(TestCaseInfo& testCaseInfo, std::vector<std::string> tags);
 
         bool isHidden() const;
         bool throws() const;
@@ -4797,25 +4827,25 @@ namespace Catch {
     class TestCase : public TestCaseInfo {
     public:
 
-        TestCase( ITestInvoker* testCase, TestCaseInfo&& info );
+        TestCase(ITestInvoker* testCase, TestCaseInfo&& info);
 
-        TestCase withName( std::string const& _newName ) const;
+        TestCase withName(std::string const& _newName) const;
 
         void invoke() const;
 
         TestCaseInfo const& getTestCaseInfo() const;
 
-        bool operator == ( TestCase const& other ) const;
-        bool operator < ( TestCase const& other ) const;
+        bool operator == (TestCase const& other) const;
+        bool operator < (TestCase const& other) const;
 
     private:
         std::shared_ptr<ITestInvoker> test;
     };
 
-    TestCase makeTestCase(  ITestInvoker* testCase,
-                            std::string const& className,
-                            NameAndTags const& nameAndTags,
-                            SourceLineInfo const& lineInfo );
+    TestCase makeTestCase(ITestInvoker* testCase,
+        std::string const& className,
+        NameAndTags const& nameAndTags,
+        SourceLineInfo const& lineInfo);
 }
 
 #ifdef __clang__
@@ -4853,8 +4883,8 @@ namespace Catch {
 
 @optional
 
--(void) setUp;
--(void) tearDown;
+- (void)setUp;
+-(void)tearDown;
 
 @end
 
@@ -4863,16 +4893,16 @@ namespace Catch {
     class OcMethod : public ITestInvoker {
 
     public:
-        OcMethod( Class cls, SEL sel ) : m_cls( cls ), m_sel( sel ) {}
+        OcMethod(Class cls, SEL sel) : m_cls(cls), m_sel(sel) {}
 
         virtual void invoke() const {
-            id obj = [[m_cls alloc] init];
+            id obj = [[m_cls alloc]init];
 
-            performOptionalSelector( obj, @selector(setUp)  );
-            performOptionalSelector( obj, m_sel );
-            performOptionalSelector( obj, @selector(tearDown)  );
+            performOptionalSelector(obj, @selector(setUp));
+            performOptionalSelector(obj, m_sel);
+            performOptionalSelector(obj, @selector(tearDown));
 
-            arcSafeRelease( obj );
+            arcSafeRelease(obj);
         }
     private:
         virtual ~OcMethod() {}
@@ -4881,43 +4911,43 @@ namespace Catch {
         SEL m_sel;
     };
 
-    namespace Detail{
+    namespace Detail {
 
-        inline std::string getAnnotation(   Class cls,
-                                            std::string const& annotationName,
-                                            std::string const& testCaseName ) {
-            NSString* selStr = [[NSString alloc] initWithFormat:@"Catch_%s_%s", annotationName.c_str(), testCaseName.c_str()];
-            SEL sel = NSSelectorFromString( selStr );
-            arcSafeRelease( selStr );
-            id value = performOptionalSelector( cls, sel );
-            if( value )
-                return [(NSString*)value UTF8String];
+        inline std::string getAnnotation(Class cls,
+            std::string const& annotationName,
+            std::string const& testCaseName) {
+            NSString* selStr = [[NSString alloc]initWithFormat:@"Catch_%s_%s", annotationName.c_str(), testCaseName.c_str()];
+            SEL sel = NSSelectorFromString(selStr);
+            arcSafeRelease(selStr);
+            id value = performOptionalSelector(cls, sel);
+            if (value)
+                return[(NSString*)value UTF8String];
             return "";
         }
     }
 
     inline std::size_t registerTestMethods() {
         std::size_t noTestMethods = 0;
-        int noClasses = objc_getClassList( nullptr, 0 );
+        int noClasses = objc_getClassList(nullptr, 0);
 
-        Class* classes = (CATCH_UNSAFE_UNRETAINED Class *)malloc( sizeof(Class) * noClasses);
-        objc_getClassList( classes, noClasses );
+        Class* classes = (CATCH_UNSAFE_UNRETAINED Class*)malloc(sizeof(Class) * noClasses);
+        objc_getClassList(classes, noClasses);
 
-        for( int c = 0; c < noClasses; c++ ) {
+        for (int c = 0; c < noClasses; c++) {
             Class cls = classes[c];
             {
                 u_int count;
-                Method* methods = class_copyMethodList( cls, &count );
-                for( u_int m = 0; m < count ; m++ ) {
+                Method* methods = class_copyMethodList(cls, &count);
+                for (u_int m = 0; m < count; m++) {
                     SEL selector = method_getName(methods[m]);
                     std::string methodName = sel_getName(selector);
-                    if( startsWith( methodName, "Catch_TestCase_" ) ) {
-                        std::string testCaseName = methodName.substr( 15 );
-                        std::string name = Detail::getAnnotation( cls, "Name", testCaseName );
-                        std::string desc = Detail::getAnnotation( cls, "Description", testCaseName );
-                        const char* className = class_getName( cls );
+                    if (startsWith(methodName, "Catch_TestCase_")) {
+                        std::string testCaseName = methodName.substr(15);
+                        std::string name = Detail::getAnnotation(cls, "Name", testCaseName);
+                        std::string desc = Detail::getAnnotation(cls, "Description", testCaseName);
+                        const char* className = class_getName(cls);
 
-                        getMutableRegistryHub().registerTest( makeTestCase( new OcMethod( cls, selector ), className, NameAndTags( name.c_str(), desc.c_str() ), SourceLineInfo("",0) ) );
+                        getMutableRegistryHub().registerTest(makeTestCase(new OcMethod(cls, selector), className, NameAndTags(name.c_str(), desc.c_str()), SourceLineInfo("", 0)));
                         noTestMethods++;
                     }
                 }
@@ -4931,87 +4961,87 @@ namespace Catch {
 
     namespace Matchers {
         namespace Impl {
-        namespace NSStringMatchers {
+            namespace NSStringMatchers {
 
-            struct StringHolder : MatcherBase<NSString*>{
-                StringHolder( NSString* substr ) : m_substr( [substr copy] ){}
-                StringHolder( StringHolder const& other ) : m_substr( [other.m_substr copy] ){}
-                StringHolder() {
-                    arcSafeRelease( m_substr );
-                }
+                struct StringHolder : MatcherBase<NSString*> {
+                    StringHolder(NSString* substr) : m_substr([substr copy]) {}
+                    StringHolder(StringHolder const& other) : m_substr([other.m_substr copy]) {}
+                    StringHolder() {
+                        arcSafeRelease(m_substr);
+                    }
 
-                bool match( NSString* str ) const override {
-                    return false;
-                }
+                    bool match(NSString* str) const override {
+                        return false;
+                    }
 
-                NSString* CATCH_ARC_STRONG m_substr;
-            };
+                    NSString* CATCH_ARC_STRONG m_substr;
+                };
 
-            struct Equals : StringHolder {
-                Equals( NSString* substr ) : StringHolder( substr ){}
+                struct Equals : StringHolder {
+                    Equals(NSString* substr) : StringHolder(substr) {}
 
-                bool match( NSString* str ) const override {
-                    return  (str != nil || m_substr == nil ) &&
-                            [str isEqualToString:m_substr];
-                }
+                    bool match(NSString* str) const override {
+                        return  (str != nil || m_substr == nil) &&
+                            [str isEqualToString : m_substr];
+                    }
 
-                std::string describe() const override {
-                    return "equals string: " + Catch::Detail::stringify( m_substr );
-                }
-            };
+                    std::string describe() const override {
+                        return "equals string: " + Catch::Detail::stringify(m_substr);
+                    }
+                };
 
-            struct Contains : StringHolder {
-                Contains( NSString* substr ) : StringHolder( substr ){}
+                struct Contains : StringHolder {
+                    Contains(NSString* substr) : StringHolder(substr) {}
 
-                bool match( NSString* str ) const override {
-                    return  (str != nil || m_substr == nil ) &&
-                            [str rangeOfString:m_substr].location != NSNotFound;
-                }
+                    bool match(NSString* str) const override {
+                        return  (str != nil || m_substr == nil) &&
+                            [str rangeOfString : m_substr].location != NSNotFound;
+                    }
 
-                std::string describe() const override {
-                    return "contains string: " + Catch::Detail::stringify( m_substr );
-                }
-            };
+                    std::string describe() const override {
+                        return "contains string: " + Catch::Detail::stringify(m_substr);
+                    }
+                };
 
-            struct StartsWith : StringHolder {
-                StartsWith( NSString* substr ) : StringHolder( substr ){}
+                struct StartsWith : StringHolder {
+                    StartsWith(NSString* substr) : StringHolder(substr) {}
 
-                bool match( NSString* str ) const override {
-                    return  (str != nil || m_substr == nil ) &&
-                            [str rangeOfString:m_substr].location == 0;
-                }
+                    bool match(NSString* str) const override {
+                        return  (str != nil || m_substr == nil) &&
+                            [str rangeOfString : m_substr].location == 0;
+                    }
 
-                std::string describe() const override {
-                    return "starts with: " + Catch::Detail::stringify( m_substr );
-                }
-            };
-            struct EndsWith : StringHolder {
-                EndsWith( NSString* substr ) : StringHolder( substr ){}
+                    std::string describe() const override {
+                        return "starts with: " + Catch::Detail::stringify(m_substr);
+                    }
+                };
+                struct EndsWith : StringHolder {
+                    EndsWith(NSString* substr) : StringHolder(substr) {}
 
-                bool match( NSString* str ) const override {
-                    return  (str != nil || m_substr == nil ) &&
-                            [str rangeOfString:m_substr].location == [str length] - [m_substr length];
-                }
+                    bool match(NSString* str) const override {
+                        return  (str != nil || m_substr == nil) &&
+                            [str rangeOfString : m_substr].location == [str length] - [m_substr length];
+                    }
 
-                std::string describe() const override {
-                    return "ends with: " + Catch::Detail::stringify( m_substr );
-                }
-            };
+                    std::string describe() const override {
+                        return "ends with: " + Catch::Detail::stringify(m_substr);
+                    }
+                };
 
-        } // namespace NSStringMatchers
+            } // namespace NSStringMatchers
         } // namespace Impl
 
         inline Impl::NSStringMatchers::Equals
-            Equals( NSString* substr ){ return Impl::NSStringMatchers::Equals( substr ); }
+            Equals(NSString* substr) { return Impl::NSStringMatchers::Equals(substr); }
 
         inline Impl::NSStringMatchers::Contains
-            Contains( NSString* substr ){ return Impl::NSStringMatchers::Contains( substr ); }
+            Contains(NSString* substr) { return Impl::NSStringMatchers::Contains(substr); }
 
         inline Impl::NSStringMatchers::StartsWith
-            StartsWith( NSString* substr ){ return Impl::NSStringMatchers::StartsWith( substr ); }
+            StartsWith(NSString* substr) { return Impl::NSStringMatchers::StartsWith(substr); }
 
         inline Impl::NSStringMatchers::EndsWith
-            EndsWith( NSString* substr ){ return Impl::NSStringMatchers::EndsWith( substr ); }
+            EndsWith(NSString* substr) { return Impl::NSStringMatchers::EndsWith(substr); }
 
     } // namespace Matchers
 
@@ -5077,12 +5107,12 @@ namespace Catch
 
     public:
 
-        WildcardPattern( std::string const& pattern, CaseSensitive::Choice caseSensitivity );
+        WildcardPattern(std::string const& pattern, CaseSensitive::Choice caseSensitivity);
         virtual ~WildcardPattern() = default;
-        virtual bool matches( std::string const& str ) const;
+        virtual bool matches(std::string const& str) const;
 
     private:
-        std::string normaliseString( std::string const& str ) const;
+        std::string normaliseString(std::string const& str) const;
         CaseSensitive::Choice m_caseSensitivity;
         WildcardPosition m_wildcard = NoWildcard;
         std::string m_pattern;
@@ -5101,9 +5131,9 @@ namespace Catch {
     class TestSpec {
         class Pattern {
         public:
-            explicit Pattern( std::string const& name );
+            explicit Pattern(std::string const& name);
             virtual ~Pattern();
-            virtual bool matches( TestCaseInfo const& testCase ) const = 0;
+            virtual bool matches(TestCaseInfo const& testCase) const = 0;
             std::string const& name() const;
         private:
             std::string const m_name;
@@ -5112,24 +5142,24 @@ namespace Catch {
 
         class NamePattern : public Pattern {
         public:
-            explicit NamePattern( std::string const& name, std::string const& filterString );
-            bool matches( TestCaseInfo const& testCase ) const override;
+            explicit NamePattern(std::string const& name, std::string const& filterString);
+            bool matches(TestCaseInfo const& testCase) const override;
         private:
             WildcardPattern m_wildcardPattern;
         };
 
         class TagPattern : public Pattern {
         public:
-            explicit TagPattern( std::string const& tag, std::string const& filterString );
-            bool matches( TestCaseInfo const& testCase ) const override;
+            explicit TagPattern(std::string const& tag, std::string const& filterString);
+            bool matches(TestCaseInfo const& testCase) const override;
         private:
             std::string m_tag;
         };
 
         class ExcludedPattern : public Pattern {
         public:
-            explicit ExcludedPattern( PatternPtr const& underlyingPattern );
-            bool matches( TestCaseInfo const& testCase ) const override;
+            explicit ExcludedPattern(PatternPtr const& underlyingPattern);
+            bool matches(TestCaseInfo const& testCase) const override;
         private:
             PatternPtr m_underlyingPattern;
         };
@@ -5137,7 +5167,7 @@ namespace Catch {
         struct Filter {
             std::vector<PatternPtr> m_patterns;
 
-            bool matches( TestCaseInfo const& testCase ) const;
+            bool matches(TestCaseInfo const& testCase) const;
             std::string name() const;
         };
 
@@ -5150,9 +5180,9 @@ namespace Catch {
         using vectorStrings = std::vector<std::string>;
 
         bool hasFilters() const;
-        bool matches( TestCaseInfo const& testCase ) const;
-        Matches matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const;
-        const vectorStrings & getInvalidArgs() const;
+        bool matches(TestCaseInfo const& testCase) const;
+        Matches matchesByFilter(std::vector<TestCase> const& testCases, IConfig const& config) const;
+        const vectorStrings& getInvalidArgs() const;
 
     private:
         std::vector<Filter> m_filters;
@@ -5177,8 +5207,8 @@ namespace Catch {
     struct ITagAliasRegistry {
         virtual ~ITagAliasRegistry();
         // Nullptr if not present
-        virtual TagAlias const* find( std::string const& alias ) const = 0;
-        virtual std::string expandAliases( std::string const& unexpandedTestSpec ) const = 0;
+        virtual TagAlias const* find(std::string const& alias) const = 0;
+        virtual std::string expandAliases(std::string const& unexpandedTestSpec) const = 0;
 
         static ITagAliasRegistry const& get();
     };
@@ -5189,7 +5219,7 @@ namespace Catch {
 namespace Catch {
 
     class TestSpecParser {
-        enum Mode{ None, Name, QuotedName, Tag, EscapedName };
+        enum Mode { None, Name, QuotedName, Tag, EscapedName };
         Mode m_mode = None;
         Mode lastMode = None;
         bool m_exclusion = false;
@@ -5204,20 +5234,20 @@ namespace Catch {
         ITagAliasRegistry const* m_tagAliases = nullptr;
 
     public:
-        TestSpecParser( ITagAliasRegistry const& tagAliases );
+        TestSpecParser(ITagAliasRegistry const& tagAliases);
 
-        TestSpecParser& parse( std::string const& arg );
+        TestSpecParser& parse(std::string const& arg);
         TestSpec testSpec();
 
     private:
-        bool visitChar( char c );
-        void startNewMode( Mode mode );
-        bool processNoneChar( char c );
-        void processNameChar( char c );
-        bool processOtherChar( char c );
+        bool visitChar(char c);
+        void startNewMode(Mode mode);
+        bool processNoneChar(char c);
+        void processNameChar(char c);
+        bool processOtherChar(char c);
         void endMode();
         void escape();
-        bool isControlChar( char c ) const;
+        bool isControlChar(char c) const;
         void saveLastMode();
         void revertBackToLastMode();
         void addFilter();
@@ -5237,7 +5267,7 @@ namespace Catch {
         }
 
     };
-    TestSpec parseTestSpec( std::string const& arg );
+    TestSpec parseTestSpec(std::string const& arg);
 
 } // namespace Catch
 
@@ -5308,7 +5338,7 @@ namespace Catch {
     public:
 
         Config() = default;
-        Config( ConfigData const& data );
+        Config(ConfigData const& data);
         virtual ~Config() = default;
 
         std::string const& getFilename() const;
@@ -5374,7 +5404,7 @@ namespace Catch {
     {
         AssertionResultData() = delete;
 
-        AssertionResultData( ResultWas::OfType _resultType, LazyExpression const& _lazyExpression );
+        AssertionResultData(ResultWas::OfType _resultType, LazyExpression const& _lazyExpression);
 
         std::string message;
         mutable std::string reconstructedExpression;
@@ -5387,7 +5417,7 @@ namespace Catch {
     class AssertionResult {
     public:
         AssertionResult() = delete;
-        AssertionResult( AssertionInfo const& info, AssertionResultData const& data );
+        AssertionResult(AssertionInfo const& info, AssertionResultData const& data);
 
         bool isOk() const;
         bool succeeded() const;
@@ -5402,7 +5432,7 @@ namespace Catch {
         SourceLineInfo getSourceInfo() const;
         StringRef getTestMacroName() const;
 
-    //protected:
+        //protected:
         AssertionInfo m_info;
         AssertionResultData m_resultData;
     };
@@ -5455,6 +5485,8 @@ namespace Catch {
 } // namespace Catch
 
 // end catch_outlier_classification.hpp
+
+#include <iterator>
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 #include <string>
@@ -5467,9 +5499,9 @@ namespace Catch {
 namespace Catch {
 
     struct ReporterConfig {
-        explicit ReporterConfig( IConfigPtr const& _fullConfig );
+        explicit ReporterConfig(IConfigPtr const& _fullConfig);
 
-        ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream );
+        ReporterConfig(IConfigPtr const& _fullConfig, std::ostream& _stream);
 
         std::ostream& stream() const;
         IConfigPtr fullConfig() const;
@@ -5486,8 +5518,8 @@ namespace Catch {
 
     template<typename T>
     struct LazyStat : Option<T> {
-        LazyStat& operator=( T const& _value ) {
-            Option<T>::operator=( _value );
+        LazyStat& operator=(T const& _value) {
+            Option<T>::operator=(_value);
             used = false;
             return *this;
         }
@@ -5499,13 +5531,13 @@ namespace Catch {
     };
 
     struct TestRunInfo {
-        TestRunInfo( std::string const& _name );
+        TestRunInfo(std::string const& _name);
         std::string name;
     };
     struct GroupInfo {
-        GroupInfo(  std::string const& _name,
-                    std::size_t _groupIndex,
-                    std::size_t _groupsCount );
+        GroupInfo(std::string const& _name,
+            std::size_t _groupIndex,
+            std::size_t _groupsCount);
 
         std::string name;
         std::size_t groupIndex;
@@ -5513,14 +5545,14 @@ namespace Catch {
     };
 
     struct AssertionStats {
-        AssertionStats( AssertionResult const& _assertionResult,
-                        std::vector<MessageInfo> const& _infoMessages,
-                        Totals const& _totals );
+        AssertionStats(AssertionResult const& _assertionResult,
+            std::vector<MessageInfo> const& _infoMessages,
+            Totals const& _totals);
 
-        AssertionStats( AssertionStats const& )              = default;
-        AssertionStats( AssertionStats && )                  = default;
-        AssertionStats& operator = ( AssertionStats const& ) = delete;
-        AssertionStats& operator = ( AssertionStats && )     = delete;
+        AssertionStats(AssertionStats const&) = default;
+        AssertionStats(AssertionStats&&) = default;
+        AssertionStats& operator = (AssertionStats const&) = delete;
+        AssertionStats& operator = (AssertionStats&&) = delete;
         virtual ~AssertionStats();
 
         AssertionResult assertionResult;
@@ -5529,14 +5561,14 @@ namespace Catch {
     };
 
     struct SectionStats {
-        SectionStats(   SectionInfo const& _sectionInfo,
-                        Counts const& _assertions,
-                        double _durationInSeconds,
-                        bool _missingAssertions );
-        SectionStats( SectionStats const& )              = default;
-        SectionStats( SectionStats && )                  = default;
-        SectionStats& operator = ( SectionStats const& ) = default;
-        SectionStats& operator = ( SectionStats && )     = default;
+        SectionStats(SectionInfo const& _sectionInfo,
+            Counts const& _assertions,
+            double _durationInSeconds,
+            bool _missingAssertions);
+        SectionStats(SectionStats const&) = default;
+        SectionStats(SectionStats&&) = default;
+        SectionStats& operator = (SectionStats const&) = default;
+        SectionStats& operator = (SectionStats&&) = default;
         virtual ~SectionStats();
 
         SectionInfo sectionInfo;
@@ -5546,16 +5578,16 @@ namespace Catch {
     };
 
     struct TestCaseStats {
-        TestCaseStats(  TestCaseInfo const& _testInfo,
-                        Totals const& _totals,
-                        std::string const& _stdOut,
-                        std::string const& _stdErr,
-                        bool _aborting );
+        TestCaseStats(TestCaseInfo const& _testInfo,
+            Totals const& _totals,
+            std::string const& _stdOut,
+            std::string const& _stdErr,
+            bool _aborting);
 
-        TestCaseStats( TestCaseStats const& )              = default;
-        TestCaseStats( TestCaseStats && )                  = default;
-        TestCaseStats& operator = ( TestCaseStats const& ) = default;
-        TestCaseStats& operator = ( TestCaseStats && )     = default;
+        TestCaseStats(TestCaseStats const&) = default;
+        TestCaseStats(TestCaseStats&&) = default;
+        TestCaseStats& operator = (TestCaseStats const&) = default;
+        TestCaseStats& operator = (TestCaseStats&&) = default;
         virtual ~TestCaseStats();
 
         TestCaseInfo testInfo;
@@ -5566,15 +5598,15 @@ namespace Catch {
     };
 
     struct TestGroupStats {
-        TestGroupStats( GroupInfo const& _groupInfo,
-                        Totals const& _totals,
-                        bool _aborting );
-        TestGroupStats( GroupInfo const& _groupInfo );
+        TestGroupStats(GroupInfo const& _groupInfo,
+            Totals const& _totals,
+            bool _aborting);
+        TestGroupStats(GroupInfo const& _groupInfo);
 
-        TestGroupStats( TestGroupStats const& )              = default;
-        TestGroupStats( TestGroupStats && )                  = default;
-        TestGroupStats& operator = ( TestGroupStats const& ) = default;
-        TestGroupStats& operator = ( TestGroupStats && )     = default;
+        TestGroupStats(TestGroupStats const&) = default;
+        TestGroupStats(TestGroupStats&&) = default;
+        TestGroupStats& operator = (TestGroupStats const&) = default;
+        TestGroupStats& operator = (TestGroupStats&&) = default;
         virtual ~TestGroupStats();
 
         GroupInfo groupInfo;
@@ -5583,14 +5615,14 @@ namespace Catch {
     };
 
     struct TestRunStats {
-        TestRunStats(   TestRunInfo const& _runInfo,
-                        Totals const& _totals,
-                        bool _aborting );
+        TestRunStats(TestRunInfo const& _runInfo,
+            Totals const& _totals,
+            bool _aborting);
 
-        TestRunStats( TestRunStats const& )              = default;
-        TestRunStats( TestRunStats && )                  = default;
-        TestRunStats& operator = ( TestRunStats const& ) = default;
-        TestRunStats& operator = ( TestRunStats && )     = default;
+        TestRunStats(TestRunStats const&) = default;
+        TestRunStats(TestRunStats&&) = default;
+        TestRunStats& operator = (TestRunStats const&) = default;
+        TestRunStats& operator = (TestRunStats&&) = default;
         virtual ~TestRunStats();
 
         TestRunInfo runInfo;
@@ -5645,37 +5677,37 @@ namespace Catch {
 
         virtual ReporterPreferences getPreferences() const = 0;
 
-        virtual void noMatchingTestCases( std::string const& spec ) = 0;
+        virtual void noMatchingTestCases(std::string const& spec) = 0;
 
         virtual void reportInvalidArguments(std::string const&) {}
 
-        virtual void testRunStarting( TestRunInfo const& testRunInfo ) = 0;
-        virtual void testGroupStarting( GroupInfo const& groupInfo ) = 0;
+        virtual void testRunStarting(TestRunInfo const& testRunInfo) = 0;
+        virtual void testGroupStarting(GroupInfo const& groupInfo) = 0;
 
-        virtual void testCaseStarting( TestCaseInfo const& testInfo ) = 0;
-        virtual void sectionStarting( SectionInfo const& sectionInfo ) = 0;
+        virtual void testCaseStarting(TestCaseInfo const& testInfo) = 0;
+        virtual void sectionStarting(SectionInfo const& sectionInfo) = 0;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-        virtual void benchmarkPreparing( std::string const& ) {}
-        virtual void benchmarkStarting( BenchmarkInfo const& ) {}
-        virtual void benchmarkEnded( BenchmarkStats<> const& ) {}
-        virtual void benchmarkFailed( std::string const& ) {}
+        virtual void benchmarkPreparing(std::string const&) {}
+        virtual void benchmarkStarting(BenchmarkInfo const&) {}
+        virtual void benchmarkEnded(BenchmarkStats<> const&) {}
+        virtual void benchmarkFailed(std::string const&) {}
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-        virtual void assertionStarting( AssertionInfo const& assertionInfo ) = 0;
+        virtual void assertionStarting(AssertionInfo const& assertionInfo) = 0;
 
         // The return value indicates if the messages buffer should be cleared:
-        virtual bool assertionEnded( AssertionStats const& assertionStats ) = 0;
+        virtual bool assertionEnded(AssertionStats const& assertionStats) = 0;
 
-        virtual void sectionEnded( SectionStats const& sectionStats ) = 0;
-        virtual void testCaseEnded( TestCaseStats const& testCaseStats ) = 0;
-        virtual void testGroupEnded( TestGroupStats const& testGroupStats ) = 0;
-        virtual void testRunEnded( TestRunStats const& testRunStats ) = 0;
+        virtual void sectionEnded(SectionStats const& sectionStats) = 0;
+        virtual void testCaseEnded(TestCaseStats const& testCaseStats) = 0;
+        virtual void testGroupEnded(TestGroupStats const& testGroupStats) = 0;
+        virtual void testRunEnded(TestRunStats const& testRunStats) = 0;
 
-        virtual void skipTest( TestCaseInfo const& testInfo ) = 0;
+        virtual void skipTest(TestCaseInfo const& testInfo) = 0;
 
         // Default empty implementation provided
-        virtual void fatalErrorEncountered( StringRef name );
+        virtual void fatalErrorEncountered(StringRef name);
 
         virtual bool isMulti() const;
     };
@@ -5683,7 +5715,7 @@ namespace Catch {
 
     struct IReporterFactory {
         virtual ~IReporterFactory();
-        virtual IStreamingReporterPtr create( ReporterConfig const& config ) const = 0;
+        virtual IStreamingReporterPtr create(ReporterConfig const& config) const = 0;
         virtual std::string getDescription() const = 0;
     };
     using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
@@ -5693,7 +5725,7 @@ namespace Catch {
         using Listeners = std::vector<IReporterFactoryPtr>;
 
         virtual ~IReporterRegistry();
-        virtual IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const = 0;
+        virtual IStreamingReporterPtr create(std::string const& name, IConfigPtr const& config) const = 0;
         virtual FactoryMap const& getFactories() const = 0;
         virtual Listeners const& getListeners() const = 0;
     };
@@ -5713,23 +5745,23 @@ namespace Catch {
     void prepareExpandedExpression(AssertionResult& result);
 
     // Returns double formatted as %.3f (format expected on output)
-    std::string getFormattedDuration( double duration );
+    std::string getFormattedDuration(double duration);
 
     //! Should the reporter show
-    bool shouldShowDuration( IConfig const& config, double duration );
+    bool shouldShowDuration(IConfig const& config, double duration);
 
-    std::string serializeFilters( std::vector<std::string> const& container );
+    std::string serializeFilters(std::vector<std::string> const& container);
 
     template<typename DerivedT>
     struct StreamingReporterBase : IStreamingReporter {
 
-        StreamingReporterBase( ReporterConfig const& _config )
-        :   m_config( _config.fullConfig() ),
-            stream( _config.stream() )
+        StreamingReporterBase(ReporterConfig const& _config)
+            : m_config(_config.fullConfig()),
+            stream(_config.stream())
         {
             m_reporterPrefs.shouldRedirectStdOut = false;
-            if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
-                CATCH_ERROR( "Verbosity level not supported by this reporter" );
+            if (!DerivedT::getSupportedVerbosities().count(m_config->verbosity()))
+                CATCH_ERROR("Verbosity level not supported by this reporter");
         }
 
         ReporterPreferences getPreferences() const override {
@@ -5754,7 +5786,7 @@ namespace Catch {
             currentGroupInfo = _groupInfo;
         }
 
-        void testCaseStarting(TestCaseInfo const& _testInfo) override  {
+        void testCaseStarting(TestCaseInfo const& _testInfo) override {
             currentTestCaseInfo = _testInfo;
         }
         void sectionStarting(SectionInfo const& _sectionInfo) override {
@@ -5796,7 +5828,7 @@ namespace Catch {
     struct CumulativeReporterBase : IStreamingReporter {
         template<typename T, typename ChildNodeT>
         struct Node {
-            explicit Node( T const& _value ) : value( _value ) {}
+            explicit Node(T const& _value) : value(_value) {}
             virtual ~Node() {}
 
             using ChildNodes = std::vector<std::shared_ptr<ChildNodeT>>;
@@ -5824,11 +5856,11 @@ namespace Catch {
         };
 
         struct BySectionInfo {
-            BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
-            BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
+            BySectionInfo(SectionInfo const& other) : m_other(other) {}
+            BySectionInfo(BySectionInfo const& other) : m_other(other.m_other) {}
             bool operator() (std::shared_ptr<SectionNode> const& node) const {
                 return ((node->stats.sectionInfo.name == m_other.name) &&
-                        (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
+                    (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
             }
             void operator=(BySectionInfo const&) = delete;
 
@@ -5840,13 +5872,13 @@ namespace Catch {
         using TestGroupNode = Node<TestGroupStats, TestCaseNode>;
         using TestRunNode = Node<TestRunStats, TestGroupNode>;
 
-        CumulativeReporterBase( ReporterConfig const& _config )
-        :   m_config( _config.fullConfig() ),
-            stream( _config.stream() )
+        CumulativeReporterBase(ReporterConfig const& _config)
+            : m_config(_config.fullConfig()),
+            stream(_config.stream())
         {
             m_reporterPrefs.shouldRedirectStdOut = false;
-            if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
-                CATCH_ERROR( "Verbosity level not supported by this reporter" );
+            if (!DerivedT::getSupportedVerbosities().count(m_config->verbosity()))
+                CATCH_ERROR("Verbosity level not supported by this reporter");
         }
         ~CumulativeReporterBase() override = default;
 
@@ -5858,33 +5890,33 @@ namespace Catch {
             return { Verbosity::Normal };
         }
 
-        void testRunStarting( TestRunInfo const& ) override {}
-        void testGroupStarting( GroupInfo const& ) override {}
+        void testRunStarting(TestRunInfo const&) override {}
+        void testGroupStarting(GroupInfo const&) override {}
 
-        void testCaseStarting( TestCaseInfo const& ) override {}
+        void testCaseStarting(TestCaseInfo const&) override {}
 
-        void sectionStarting( SectionInfo const& sectionInfo ) override {
-            SectionStats incompleteStats( sectionInfo, Counts(), 0, false );
+        void sectionStarting(SectionInfo const& sectionInfo) override {
+            SectionStats incompleteStats(sectionInfo, Counts(), 0, false);
             std::shared_ptr<SectionNode> node;
-            if( m_sectionStack.empty() ) {
-                if( !m_rootSection )
-                    m_rootSection = std::make_shared<SectionNode>( incompleteStats );
+            if (m_sectionStack.empty()) {
+                if (!m_rootSection)
+                    m_rootSection = std::make_shared<SectionNode>(incompleteStats);
                 node = m_rootSection;
             }
             else {
                 SectionNode& parentNode = *m_sectionStack.back();
                 auto it =
-                    std::find_if(   parentNode.childSections.begin(),
-                                    parentNode.childSections.end(),
-                                    BySectionInfo( sectionInfo ) );
-                if( it == parentNode.childSections.end() ) {
-                    node = std::make_shared<SectionNode>( incompleteStats );
-                    parentNode.childSections.push_back( node );
+                    std::find_if(parentNode.childSections.begin(),
+                        parentNode.childSections.end(),
+                        BySectionInfo(sectionInfo));
+                if (it == parentNode.childSections.end()) {
+                    node = std::make_shared<SectionNode>(incompleteStats);
+                    parentNode.childSections.push_back(node);
                 }
                 else
                     node = *it;
             }
-            m_sectionStack.push_back( node );
+            m_sectionStack.push_back(node);
             m_deepestSection = std::move(node);
         }
 
@@ -5897,7 +5929,7 @@ namespace Catch {
             // Our section stack copy of the assertionResult will likely outlive the
             // temporary, so it must be expanded or discarded now to avoid calling
             // a destroyed object later.
-            prepareExpandedExpression(const_cast<AssertionResult&>( assertionStats.assertionResult ) );
+            prepareExpandedExpression(const_cast<AssertionResult&>(assertionStats.assertionResult));
             SectionNode& sectionNode = *m_sectionStack.back();
             sectionNode.assertions.push_back(assertionStats);
             return true;
@@ -5951,16 +5983,16 @@ namespace Catch {
 
     template<char C>
     char const* getLineOfChars() {
-        static char line[CATCH_CONFIG_CONSOLE_WIDTH] = {0};
-        if( !*line ) {
-            std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
-            line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;
+        static char line[CATCH_CONFIG_CONSOLE_WIDTH] = { 0 };
+        if (!*line) {
+            std::memset(line, C, CATCH_CONFIG_CONSOLE_WIDTH - 1);
+            line[CATCH_CONFIG_CONSOLE_WIDTH - 1] = 0;
         }
         return line;
     }
 
     struct TestEventListenerBase : StreamingReporterBase<TestEventListenerBase> {
-        TestEventListenerBase( ReporterConfig const& _config );
+        TestEventListenerBase(ReporterConfig const& _config);
 
         static std::set<Verbosity> getSupportedVerbosities();
 
@@ -6013,19 +6045,19 @@ namespace Catch {
         };
 
         // Use constructed object for RAII guard
-        Colour( Code _colourCode );
-        Colour( Colour&& other ) noexcept;
-        Colour& operator=( Colour&& other ) noexcept;
+        Colour(Code _colourCode);
+        Colour(Colour&& other) noexcept;
+        Colour& operator=(Colour&& other) noexcept;
         ~Colour();
 
         // Use static method for one-shot changes
-        static void use( Code _colourCode );
+        static void use(Code _colourCode);
 
     private:
         bool m_moved = false;
     };
 
-    std::ostream& operator << ( std::ostream& os, Colour const& );
+    std::ostream& operator << (std::ostream& os, Colour const&);
 
 } // end namespace Catch
 
@@ -6040,8 +6072,8 @@ namespace Catch {
 
         class ReporterFactory : public IReporterFactory {
 
-            IStreamingReporterPtr create( ReporterConfig const& config ) const override {
-                return std::unique_ptr<T>( new T( config ) );
+            IStreamingReporterPtr create(ReporterConfig const& config) const override {
+                return std::unique_ptr<T>(new T(config));
             }
 
             std::string getDescription() const override {
@@ -6051,8 +6083,8 @@ namespace Catch {
 
     public:
 
-        explicit ReporterRegistrar( std::string const& name ) {
-            getMutableRegistryHub().registerReporter( name, std::make_shared<ReporterFactory>() );
+        explicit ReporterRegistrar(std::string const& name) {
+            getMutableRegistryHub().registerReporter(name, std::make_shared<ReporterFactory>());
         }
     };
 
@@ -6061,8 +6093,8 @@ namespace Catch {
 
         class ListenerFactory : public IReporterFactory {
 
-            IStreamingReporterPtr create( ReporterConfig const& config ) const override {
-                return std::unique_ptr<T>( new T( config ) );
+            IStreamingReporterPtr create(ReporterConfig const& config) const override {
+                return std::unique_ptr<T>(new T(config));
             }
             std::string getDescription() const override {
                 return std::string();
@@ -6072,7 +6104,7 @@ namespace Catch {
     public:
 
         ListenerRegistrar() {
-            getMutableRegistryHub().registerListener( std::make_shared<ListenerFactory>() );
+            getMutableRegistryHub().registerListener(std::make_shared<ListenerFactory>());
         }
     };
 }
@@ -6149,7 +6181,7 @@ namespace Catch {
 
         void noMatchingTestCases(std::string const& spec) override;
 
-        void reportInvalidArguments(std::string const&arg) override;
+        void reportInvalidArguments(std::string const& arg) override;
 
         void assertionStarting(AssertionInfo const&) override;
 
@@ -6223,11 +6255,11 @@ namespace Catch {
     public:
         enum ForWhat { ForTextNodes, ForAttributes };
 
-        XmlEncode( std::string const& str, ForWhat forWhat = ForTextNodes );
+        XmlEncode(std::string const& str, ForWhat forWhat = ForTextNodes);
 
-        void encodeTo( std::ostream& os ) const;
+        void encodeTo(std::ostream& os) const;
 
-        friend std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
+        friend std::ostream& operator << (std::ostream& os, XmlEncode const& xmlEncode);
 
     private:
         std::string m_str;
@@ -6239,18 +6271,18 @@ namespace Catch {
 
         class ScopedElement {
         public:
-            ScopedElement( XmlWriter* writer, XmlFormatting fmt );
+            ScopedElement(XmlWriter* writer, XmlFormatting fmt);
 
-            ScopedElement( ScopedElement&& other ) noexcept;
-            ScopedElement& operator=( ScopedElement&& other ) noexcept;
+            ScopedElement(ScopedElement&& other) noexcept;
+            ScopedElement& operator=(ScopedElement&& other) noexcept;
 
             ~ScopedElement();
 
-            ScopedElement& writeText( std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent );
+            ScopedElement& writeText(std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
             template<typename T>
-            ScopedElement& writeAttribute( std::string const& name, T const& attribute ) {
-                m_writer->writeAttribute( name, attribute );
+            ScopedElement& writeAttribute(std::string const& name, T const& attribute) {
+                m_writer->writeAttribute(name, attribute);
                 return *this;
             }
 
@@ -6259,34 +6291,34 @@ namespace Catch {
             XmlFormatting m_fmt;
         };
 
-        XmlWriter( std::ostream& os = Catch::cout() );
+        XmlWriter(std::ostream& os = Catch::cout());
         ~XmlWriter();
 
-        XmlWriter( XmlWriter const& ) = delete;
-        XmlWriter& operator=( XmlWriter const& ) = delete;
+        XmlWriter(XmlWriter const&) = delete;
+        XmlWriter& operator=(XmlWriter const&) = delete;
 
-        XmlWriter& startElement( std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+        XmlWriter& startElement(std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-        ScopedElement scopedElement( std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+        ScopedElement scopedElement(std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
         XmlWriter& endElement(XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-        XmlWriter& writeAttribute( std::string const& name, std::string const& attribute );
+        XmlWriter& writeAttribute(std::string const& name, std::string const& attribute);
 
-        XmlWriter& writeAttribute( std::string const& name, bool attribute );
+        XmlWriter& writeAttribute(std::string const& name, bool attribute);
 
         template<typename T>
-        XmlWriter& writeAttribute( std::string const& name, T const& attribute ) {
+        XmlWriter& writeAttribute(std::string const& name, T const& attribute) {
             ReusableStringStream rss;
             rss << attribute;
-            return writeAttribute( name, rss.str() );
+            return writeAttribute(name, rss.str());
         }
 
-        XmlWriter& writeText( std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+        XmlWriter& writeText(std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
         XmlWriter& writeComment(std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-        void writeStylesheetRef( std::string const& url );
+        void writeStylesheetRef(std::string const& url);
 
         XmlWriter& writeBlankLine();
 
@@ -6340,8 +6372,9 @@ namespace Catch {
         void writeTestCase(TestCaseNode const& testCaseNode);
 
         void writeSection(std::string const& className,
-                          std::string const& rootName,
-                          SectionNode const& sectionNode);
+            std::string const& rootName,
+            SectionNode const& sectionNode,
+            bool testOkToFail);
 
         void writeAssertions(SectionNode const& sectionNode);
         void writeAssertion(AssertionStats const& stats);
@@ -6730,7 +6763,7 @@ namespace Catch {
 
                 template <typename Fun,
                     typename std::enable_if<!is_related<Fun, BenchmarkFunction>::value, int>::type = 0>
-                    BenchmarkFunction(Fun&& fun)
+                BenchmarkFunction(Fun&& fun)
                     : f(new model<typename std::decay<Fun>::type>(std::forward<Fun>(fun))) {}
 
                 BenchmarkFunction(BenchmarkFunction&& that)
@@ -6876,7 +6909,7 @@ namespace Catch {
                     }
                     iters *= 2;
                 }
-                throw optimized_away_error{};
+                Catch::throw_exception(optimized_away_error{});
             }
         } // namespace Detail
     } // namespace Benchmark
@@ -6884,6 +6917,7 @@ namespace Catch {
 
 // end catch_run_for_at_least.hpp
 #include <algorithm>
+#include <iterator>
 
 namespace Catch {
     namespace Benchmark {
@@ -6901,7 +6935,7 @@ namespace Catch {
             }
 
             template <typename Clock>
-            std::vector<FloatDuration<Clock>> run(const IConfig &cfg, Environment<FloatDuration<Clock>> env) const {
+            std::vector<FloatDuration<Clock>> run(const IConfig& cfg, Environment<FloatDuration<Clock>> env) const {
                 // warmup a bit
                 Detail::run_for_at_least<Clock>(std::chrono::duration_cast<ClockDuration<Clock>>(warmup_time), warmup_iterations, Detail::repeat(now<Clock>{}));
 
@@ -6913,7 +6947,7 @@ namespace Catch {
                     auto sample_time = model.elapsed() - env.clock_cost.mean;
                     if (sample_time < FloatDuration<Clock>::zero()) sample_time = FloatDuration<Clock>::zero();
                     return sample_time / iterations_per_sample;
-                });
+                    });
                 return times;
             }
         };
@@ -6992,7 +7026,7 @@ namespace Catch {
                     resampled.reserve(n);
                     std::generate_n(std::back_inserter(resampled), n, [first, &dist, &rng] { return first[dist(rng)]; });
                     return estimator(resampled.begin(), resampled.end());
-                });
+                    });
                 std::sort(out.begin(), out.end());
                 return out;
             }
@@ -7036,7 +7070,7 @@ namespace Catch {
                     auto d2 = d * d;
                     auto d3 = d2 * d;
                     return { sqcb.first + d2, sqcb.second + d3 };
-                });
+                    });
 
                 double accel = sum_cubes / (6 * std::pow(sum_squares, 1.5));
                 int n = static_cast<int>(resample.size());
@@ -7054,8 +7088,8 @@ namespace Catch {
                 double b2 = bias - z1;
                 double a1 = a(b1);
                 double a2 = a(b2);
-                auto lo = std::max(cumn(a1), 0);
-                auto hi = std::min(cumn(a2), n - 1);
+                auto lo = (std::max)(cumn(a1), 0);
+                auto hi = (std::min)(cumn(a2), n - 1);
 
                 return { point, resample[lo], resample[hi], confidence_level };
             }
@@ -7124,15 +7158,17 @@ namespace Catch {
             }
             template <typename Clock>
             EnvironmentEstimate<FloatDuration<Clock>> estimate_clock_cost(FloatDuration<Clock> resolution) {
-                auto time_limit = std::min(resolution * clock_cost_estimation_tick_limit, FloatDuration<Clock>(clock_cost_estimation_time_limit));
+                auto time_limit = (std::min)(
+                    resolution * clock_cost_estimation_tick_limit,
+                    FloatDuration<Clock>(clock_cost_estimation_time_limit));
                 auto time_clock = [](int k) {
                     return Detail::measure<Clock>([k] {
                         for (int i = 0; i < k; ++i) {
                             volatile auto ignored = Clock::now();
                             (void)ignored;
                         }
-                    }).elapsed;
-                };
+                        }).elapsed;
+                    };
                 time_clock(1);
                 int iters = clock_cost_estimation_iterations;
                 auto&& r = run_for_at_least<Clock>(std::chrono::duration_cast<ClockDuration<Clock>>(clock_cost_estimation_time), iters, time_clock);
@@ -7141,7 +7177,7 @@ namespace Catch {
                 times.reserve(nsamples);
                 std::generate_n(std::back_inserter(times), nsamples, [time_clock, &r] {
                     return static_cast<double>((time_clock(r.iterations) / r.iterations).count());
-                });
+                    });
                 return {
                     FloatDuration<Clock>(mean(times.begin(), times.end())),
                     classify_outliers(times.begin(), times.end()),
@@ -7218,7 +7254,7 @@ namespace Catch {
     namespace Benchmark {
         namespace Detail {
             template <typename Duration, typename Iterator>
-            SampleAnalysis<Duration> analyse(const IConfig &cfg, Environment<Duration>, Iterator first, Iterator last) {
+            SampleAnalysis<Duration> analyse(const IConfig& cfg, Environment<Duration>, Iterator first, Iterator last) {
                 if (!cfg.benchmarkNoAnalysis()) {
                     std::vector<double> samples;
                     samples.reserve(last - first);
@@ -7234,7 +7270,7 @@ namespace Catch {
                                 Duration(e.upper_bound),
                                 e.confidence_interval,
                         };
-                    };
+                        };
                     std::vector<Duration> samples2;
                     samples2.reserve(samples.size());
                     std::transform(samples.begin(), samples.end(), std::back_inserter(samples2), [](double d) { return Duration(d); });
@@ -7245,7 +7281,8 @@ namespace Catch {
                         outliers,
                         analysis.outlier_variance,
                     };
-                } else {
+                }
+                else {
                     std::vector<Duration> samples;
                     samples.reserve(last - first);
 
@@ -7280,15 +7317,15 @@ namespace Catch {
 namespace Catch {
     namespace Benchmark {
         struct Benchmark {
-            Benchmark(std::string &&name)
+            Benchmark(std::string&& name)
                 : name(std::move(name)) {}
 
             template <class FUN>
-            Benchmark(std::string &&name, FUN &&func)
+            Benchmark(std::string&& name, FUN&& func)
                 : fun(std::move(func)), name(std::move(name)) {}
 
             template <typename Clock>
-            ExecutionPlan<FloatDuration<Clock>> prepare(const IConfig &cfg, Environment<FloatDuration<Clock>> env) const {
+            ExecutionPlan<FloatDuration<Clock>> prepare(const IConfig& cfg, Environment<FloatDuration<Clock>> env) const {
                 auto min_time = env.clock_resolution.mean * Detail::minimum_ticks;
                 auto run_time = std::max(min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
                 auto&& test = Detail::run_for_at_least<Clock>(std::chrono::duration_cast<ClockDuration<Clock>>(run_time), 1, fun);
@@ -7337,7 +7374,7 @@ namespace Catch {
             // sets lambda to be used in fun *and* executes benchmark!
             template <typename Fun,
                 typename std::enable_if<!Detail::is_related<Fun, Benchmark>::value, int>::type = 0>
-                Benchmark & operator=(Fun func) {
+            Benchmark& operator=(Fun func) {
                 fun = Detail::BenchmarkFunction(func);
                 run();
                 return *this;
@@ -7379,8 +7416,6 @@ namespace Catch {
             template <typename T, bool Destruct>
             struct ObjectStorage
             {
-                using TStorage = typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type;
-
                 ObjectStorage() : data() {}
 
                 ObjectStorage(const ObjectStorage& other)
@@ -7423,7 +7458,7 @@ namespace Catch {
                     return *static_cast<T*>(static_cast<void*>(&data));
                 }
 
-                TStorage data;
+                struct { alignas(T) unsigned char data[sizeof(T)]; }  data;
             };
         }
 
@@ -7457,162 +7492,162 @@ namespace Catch {
 #include <memory>
 
 namespace Catch {
-namespace TestCaseTracking {
+    namespace TestCaseTracking {
 
-    struct NameAndLocation {
-        std::string name;
-        SourceLineInfo location;
+        struct NameAndLocation {
+            std::string name;
+            SourceLineInfo location;
 
-        NameAndLocation( std::string const& _name, SourceLineInfo const& _location );
-        friend bool operator==(NameAndLocation const& lhs, NameAndLocation const& rhs) {
-            return lhs.name == rhs.name
-                && lhs.location == rhs.location;
-        }
-    };
-
-    class ITracker;
-
-    using ITrackerPtr = std::shared_ptr<ITracker>;
-
-    class  ITracker {
-        NameAndLocation m_nameAndLocation;
-
-    public:
-        ITracker(NameAndLocation const& nameAndLoc) :
-            m_nameAndLocation(nameAndLoc)
-        {}
-
-        // static queries
-        NameAndLocation const& nameAndLocation() const {
-            return m_nameAndLocation;
-        }
-
-        virtual ~ITracker();
-
-        // dynamic queries
-        virtual bool isComplete() const = 0; // Successfully completed or failed
-        virtual bool isSuccessfullyCompleted() const = 0;
-        virtual bool isOpen() const = 0; // Started but not complete
-        virtual bool hasChildren() const = 0;
-        virtual bool hasStarted() const = 0;
-
-        virtual ITracker& parent() = 0;
-
-        // actions
-        virtual void close() = 0; // Successfully complete
-        virtual void fail() = 0;
-        virtual void markAsNeedingAnotherRun() = 0;
-
-        virtual void addChild( ITrackerPtr const& child ) = 0;
-        virtual ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) = 0;
-        virtual void openChild() = 0;
-
-        // Debug/ checking
-        virtual bool isSectionTracker() const = 0;
-        virtual bool isGeneratorTracker() const = 0;
-    };
-
-    class TrackerContext {
-
-        enum RunState {
-            NotStarted,
-            Executing,
-            CompletedCycle
+            NameAndLocation(std::string const& _name, SourceLineInfo const& _location);
+            friend bool operator==(NameAndLocation const& lhs, NameAndLocation const& rhs) {
+                return lhs.name == rhs.name
+                    && lhs.location == rhs.location;
+            }
         };
 
-        ITrackerPtr m_rootTracker;
-        ITracker* m_currentTracker = nullptr;
-        RunState m_runState = NotStarted;
+        class ITracker;
 
-    public:
+        using ITrackerPtr = std::shared_ptr<ITracker>;
 
-        ITracker& startRun();
-        void endRun();
+        class  ITracker {
+            NameAndLocation m_nameAndLocation;
 
-        void startCycle();
-        void completeCycle();
+        public:
+            ITracker(NameAndLocation const& nameAndLoc) :
+                m_nameAndLocation(nameAndLoc)
+            {}
 
-        bool completedCycle() const;
-        ITracker& currentTracker();
-        void setCurrentTracker( ITracker* tracker );
-    };
+            // static queries
+            NameAndLocation const& nameAndLocation() const {
+                return m_nameAndLocation;
+            }
 
-    class TrackerBase : public ITracker {
-    protected:
-        enum CycleState {
-            NotStarted,
-            Executing,
-            ExecutingChildren,
-            NeedsAnotherRun,
-            CompletedSuccessfully,
-            Failed
+            virtual ~ITracker();
+
+            // dynamic queries
+            virtual bool isComplete() const = 0; // Successfully completed or failed
+            virtual bool isSuccessfullyCompleted() const = 0;
+            virtual bool isOpen() const = 0; // Started but not complete
+            virtual bool hasChildren() const = 0;
+            virtual bool hasStarted() const = 0;
+
+            virtual ITracker& parent() = 0;
+
+            // actions
+            virtual void close() = 0; // Successfully complete
+            virtual void fail() = 0;
+            virtual void markAsNeedingAnotherRun() = 0;
+
+            virtual void addChild(ITrackerPtr const& child) = 0;
+            virtual ITrackerPtr findChild(NameAndLocation const& nameAndLocation) = 0;
+            virtual void openChild() = 0;
+
+            // Debug/ checking
+            virtual bool isSectionTracker() const = 0;
+            virtual bool isGeneratorTracker() const = 0;
         };
 
-        using Children = std::vector<ITrackerPtr>;
-        TrackerContext& m_ctx;
-        ITracker* m_parent;
-        Children m_children;
-        CycleState m_runState = NotStarted;
+        class TrackerContext {
 
-    public:
-        TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+            enum RunState {
+                NotStarted,
+                Executing,
+                CompletedCycle
+            };
 
-        bool isComplete() const override;
-        bool isSuccessfullyCompleted() const override;
-        bool isOpen() const override;
-        bool hasChildren() const override;
-        bool hasStarted() const override {
-            return m_runState != NotStarted;
-        }
+            ITrackerPtr m_rootTracker;
+            ITracker* m_currentTracker = nullptr;
+            RunState m_runState = NotStarted;
 
-        void addChild( ITrackerPtr const& child ) override;
+        public:
 
-        ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) override;
-        ITracker& parent() override;
+            ITracker& startRun();
+            void endRun();
 
-        void openChild() override;
+            void startCycle();
+            void completeCycle();
 
-        bool isSectionTracker() const override;
-        bool isGeneratorTracker() const override;
+            bool completedCycle() const;
+            ITracker& currentTracker();
+            void setCurrentTracker(ITracker* tracker);
+        };
 
-        void open();
+        class TrackerBase : public ITracker {
+        protected:
+            enum CycleState {
+                NotStarted,
+                Executing,
+                ExecutingChildren,
+                NeedsAnotherRun,
+                CompletedSuccessfully,
+                Failed
+            };
 
-        void close() override;
-        void fail() override;
-        void markAsNeedingAnotherRun() override;
+            using Children = std::vector<ITrackerPtr>;
+            TrackerContext& m_ctx;
+            ITracker* m_parent;
+            Children m_children;
+            CycleState m_runState = NotStarted;
 
-    private:
-        void moveToParent();
-        void moveToThis();
-    };
+        public:
+            TrackerBase(NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent);
 
-    class SectionTracker : public TrackerBase {
-        std::vector<std::string> m_filters;
-        std::string m_trimmed_name;
-    public:
-        SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+            bool isComplete() const override;
+            bool isSuccessfullyCompleted() const override;
+            bool isOpen() const override;
+            bool hasChildren() const override;
+            bool hasStarted() const override {
+                return m_runState != NotStarted;
+            }
 
-        bool isSectionTracker() const override;
+            void addChild(ITrackerPtr const& child) override;
 
-        bool isComplete() const override;
+            ITrackerPtr findChild(NameAndLocation const& nameAndLocation) override;
+            ITracker& parent() override;
 
-        static SectionTracker& acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation );
+            void openChild() override;
 
-        void tryOpen();
+            bool isSectionTracker() const override;
+            bool isGeneratorTracker() const override;
 
-        void addInitialFilters( std::vector<std::string> const& filters );
-        void addNextFilters( std::vector<std::string> const& filters );
-        //! Returns filters active in this tracker
-        std::vector<std::string> const& getFilters() const;
-        //! Returns whitespace-trimmed name of the tracked section
-        std::string const& trimmedName() const;
-    };
+            void open();
 
-} // namespace TestCaseTracking
+            void close() override;
+            void fail() override;
+            void markAsNeedingAnotherRun() override;
 
-using TestCaseTracking::ITracker;
-using TestCaseTracking::TrackerContext;
-using TestCaseTracking::SectionTracker;
+        private:
+            void moveToParent();
+            void moveToThis();
+        };
+
+        class SectionTracker : public TrackerBase {
+            std::vector<std::string> m_filters;
+            std::string m_trimmed_name;
+        public:
+            SectionTracker(NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent);
+
+            bool isSectionTracker() const override;
+
+            bool isComplete() const override;
+
+            static SectionTracker& acquire(TrackerContext& ctx, NameAndLocation const& nameAndLocation);
+
+            void tryOpen();
+
+            void addInitialFilters(std::vector<std::string> const& filters);
+            void addNextFilters(std::vector<std::string> const& filters);
+            //! Returns filters active in this tracker
+            std::vector<std::string> const& getFilters() const;
+            //! Returns whitespace-trimmed name of the tracked section
+            std::string const& trimmedName() const;
+        };
+
+    } // namespace TestCaseTracking
+
+    using TestCaseTracking::ITracker;
+    using TestCaseTracking::TrackerContext;
+    using TestCaseTracking::SectionTracker;
 
 } // namespace Catch
 
@@ -7675,7 +7710,8 @@ namespace {
             p = -0.0060336708714301490533 + p * w;
             p = 0.24015818242558961693 + p * w;
             p = 1.6536545626831027356 + p * w;
-        } else if (w < 16.000000) {
+        }
+        else if (w < 16.000000) {
             w = sqrt(w) - 3.250000;
             p = 2.2137376921775787049e-09;
             p = 9.0756561938885390979e-08 + p * w;
@@ -7696,7 +7732,8 @@ namespace {
             p = 0.005370914553590063617 + p * w;
             p = 1.0052589676941592334 + p * w;
             p = 3.0838856104922207635 + p * w;
-        } else {
+        }
+        else {
             w = sqrt(w) - 5.000000;
             p = -2.7109920616438573243e-11;
             p = -2.5556418169965252055e-10 + p * w;
@@ -7771,7 +7808,7 @@ namespace Catch {
                 double sb = stddev.point;
                 double mn = mean.point / n;
                 double mg_min = mn / 2.;
-                double sg = std::min(mg_min / 4., sb / std::sqrt(n));
+                double sg = (std::min)(mg_min / 4., sb / std::sqrt(n));
                 double sg2 = sg * sg;
                 double sb2 = sb * sb;
 
@@ -7783,23 +7820,23 @@ namespace Catch {
                     double k1 = sb2 - n * sg2 + nd;
                     double det = k1 * k1 - 4 * sg2 * k0;
                     return (int)(-2. * k0 / (k1 + std::sqrt(det)));
-                };
+                    };
 
                 auto var_out = [n, sb2, sg2](double c) {
                     double nc = n - c;
                     return (nc / n) * (sb2 - nc * sg2);
-                };
+                    };
 
-                return std::min(var_out(1), var_out(std::min(c_max(0.), c_max(mg_min)))) / sb2;
+                return (std::min)(var_out(1), var_out((std::min)(c_max(0.), c_max(mg_min)))) / sb2;
             }
 
             bootstrap_analysis analyse_samples(double confidence_level, int n_resamples, std::vector<double>::iterator first, std::vector<double>::iterator last) {
                 CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
-                CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
-                static std::random_device entropy;
+                    CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
+                    static std::random_device entropy;
                 CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
-                auto n = static_cast<int>(last - first); // seriously, one can't use integral types without hell in C++
+                    auto n = static_cast<int>(last - first); // seriously, one can't use integral types without hell in C++
 
                 auto mean = &Detail::mean<std::vector<double>::iterator>;
                 auto stddev = &standard_deviation;
@@ -7811,8 +7848,8 @@ namespace Catch {
                         std::mt19937 rng(seed);
                         auto resampled = resample(rng, n_resamples, first, last, f);
                         return bootstrap(confidence_level, first, last, resampled, f);
-                    });
-                };
+                        });
+                    };
 
                 auto mean_future = Estimate(mean);
                 auto stddev_future = Estimate(stddev);
@@ -7825,7 +7862,7 @@ namespace Catch {
                     std::mt19937 rng(seed);
                     auto resampled = resample(rng, n_resamples, first, last, f);
                     return bootstrap(confidence_level, first, last, resampled, f);
-                };
+                    };
 
                 auto mean_estimate = Estimate(mean);
                 auto stddev_estimate = Estimate(stddev);
@@ -7848,75 +7885,75 @@ namespace Catch {
 
 namespace {
 
-// Performs equivalent check of std::fabs(lhs - rhs) <= margin
-// But without the subtraction to allow for INFINITY in comparison
-bool marginComparison(double lhs, double rhs, double margin) {
-    return (lhs + margin >= rhs) && (rhs + margin >= lhs);
-}
+    // Performs equivalent check of std::fabs(lhs - rhs) <= margin
+    // But without the subtraction to allow for INFINITY in comparison
+    bool marginComparison(double lhs, double rhs, double margin) {
+        return (lhs + margin >= rhs) && (rhs + margin >= lhs);
+    }
 
 }
 
 namespace Catch {
-namespace Detail {
+    namespace Detail {
 
-    Approx::Approx ( double value )
-    :   m_epsilon( std::numeric_limits<float>::epsilon()*100 ),
-        m_margin( 0.0 ),
-        m_scale( 0.0 ),
-        m_value( value )
-    {}
+        Approx::Approx(double value)
+            : m_epsilon(std::numeric_limits<float>::epsilon() * 100),
+            m_margin(0.0),
+            m_scale(0.0),
+            m_value(value)
+        {}
 
-    Approx Approx::custom() {
-        return Approx( 0 );
+        Approx Approx::custom() {
+            return Approx(0);
+        }
+
+        Approx Approx::operator-() const {
+            auto temp(*this);
+            temp.m_value = -temp.m_value;
+            return temp;
+        }
+
+        std::string Approx::toString() const {
+            ReusableStringStream rss;
+            rss << "Approx( " << ::Catch::Detail::stringify(m_value) << " )";
+            return rss.str();
+        }
+
+        bool Approx::equalityComparisonImpl(const double other) const {
+            // First try with fixed margin, then compute margin based on epsilon, scale and Approx's value
+            // Thanks to Richard Harris for his help refining the scaled margin value
+            return marginComparison(m_value, other, m_margin)
+                || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(std::isinf(m_value) ? 0 : m_value)));
+        }
+
+        void Approx::setMargin(double newMargin) {
+            CATCH_ENFORCE(newMargin >= 0,
+                "Invalid Approx::margin: " << newMargin << '.'
+                << " Approx::Margin has to be non-negative.");
+            m_margin = newMargin;
+        }
+
+        void Approx::setEpsilon(double newEpsilon) {
+            CATCH_ENFORCE(newEpsilon >= 0 && newEpsilon <= 1.0,
+                "Invalid Approx::epsilon: " << newEpsilon << '.'
+                << " Approx::epsilon has to be in [0, 1]");
+            m_epsilon = newEpsilon;
+        }
+
+    } // end namespace Detail
+
+    namespace literals {
+        Detail::Approx operator "" _a(long double val) {
+            return Detail::Approx(val);
+        }
+        Detail::Approx operator "" _a(unsigned long long val) {
+            return Detail::Approx(val);
+        }
+    } // end namespace literals
+
+    std::string StringMaker<Catch::Detail::Approx>::convert(Catch::Detail::Approx const& value) {
+        return value.toString();
     }
-
-    Approx Approx::operator-() const {
-        auto temp(*this);
-        temp.m_value = -temp.m_value;
-        return temp;
-    }
-
-    std::string Approx::toString() const {
-        ReusableStringStream rss;
-        rss << "Approx( " << ::Catch::Detail::stringify( m_value ) << " )";
-        return rss.str();
-    }
-
-    bool Approx::equalityComparisonImpl(const double other) const {
-        // First try with fixed margin, then compute margin based on epsilon, scale and Approx's value
-        // Thanks to Richard Harris for his help refining the scaled margin value
-        return marginComparison(m_value, other, m_margin)
-            || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(std::isinf(m_value)? 0 : m_value)));
-    }
-
-    void Approx::setMargin(double newMargin) {
-        CATCH_ENFORCE(newMargin >= 0,
-            "Invalid Approx::margin: " << newMargin << '.'
-            << " Approx::Margin has to be non-negative.");
-        m_margin = newMargin;
-    }
-
-    void Approx::setEpsilon(double newEpsilon) {
-        CATCH_ENFORCE(newEpsilon >= 0 && newEpsilon <= 1.0,
-            "Invalid Approx::epsilon: " << newEpsilon << '.'
-            << " Approx::epsilon has to be in [0, 1]");
-        m_epsilon = newEpsilon;
-    }
-
-} // end namespace Detail
-
-namespace literals {
-    Detail::Approx operator "" _a(long double val) {
-        return Detail::Approx(val);
-    }
-    Detail::Approx operator "" _a(unsigned long long val) {
-        return Detail::Approx(val);
-    }
-} // end namespace literals
-
-std::string StringMaker<Catch::Detail::Approx>::convert(Catch::Detail::Approx const& value) {
-    return value.toString();
-}
 
 } // end namespace Catch
 // end catch_approx.cpp
@@ -7930,49 +7967,49 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #if defined(__i386__) || defined(__x86_64__)
-        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
-    #elif defined(__aarch64__)
-        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
-    #endif
+#if defined(__i386__) || defined(__x86_64__)
+#define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+#elif defined(__aarch64__)
+#define CATCH_TRAP()  __asm__(".inst 0xd43e0000")
+#endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)
 
-    // use inline assembler
-    #if defined(__i386__) || defined(__x86_64__)
-        #define CATCH_TRAP()  __asm__("int $3")
-    #elif defined(__aarch64__)
-        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
-    #elif defined(__arm__) && !defined(__thumb__)
-        #define CATCH_TRAP()  __asm__(".inst 0xe7f001f0")
-    #elif defined(__arm__) &&  defined(__thumb__)
-        #define CATCH_TRAP()  __asm__(".inst 0xde01")
-    #endif
+// use inline assembler
+#if defined(__i386__) || defined(__x86_64__)
+#define CATCH_TRAP()  __asm__("int $3")
+#elif defined(__aarch64__)
+#define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+#elif defined(__arm__) && !defined(__thumb__)
+#define CATCH_TRAP()  __asm__(".inst 0xe7f001f0")
+#elif defined(__arm__) &&  defined(__thumb__)
+#define CATCH_TRAP()  __asm__(".inst 0xde01")
+#endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
-    // If we can use inline assembler, do it because this allows us to break
-    // directly at the location of the failing check instead of breaking inside
-    // raise() called from it, i.e. one stack frame below.
-    #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
-        #define CATCH_TRAP() asm volatile ("int $3") /* NOLINT */
-    #else // Fall back to the generic way.
-        #include <signal.h>
+// If we can use inline assembler, do it because this allows us to break
+// directly at the location of the failing check instead of breaking inside
+// raise() called from it, i.e. one stack frame below.
+#if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+#define CATCH_TRAP() asm volatile ("int $3") /* NOLINT */
+#else // Fall back to the generic way.
+#include <signal.h>
 
-        #define CATCH_TRAP() raise(SIGTRAP)
-    #endif
+#define CATCH_TRAP() raise(SIGTRAP)
+#endif
 #elif defined(_MSC_VER)
-    #define CATCH_TRAP() __debugbreak()
+#define CATCH_TRAP() __debugbreak()
 #elif defined(__MINGW32__)
-    extern "C" __declspec(dllimport) void __stdcall DebugBreak();
-    #define CATCH_TRAP() DebugBreak()
+extern "C" __declspec(dllimport) void __stdcall DebugBreak();
+#define CATCH_TRAP() DebugBreak()
 #endif
 
 #ifndef CATCH_BREAK_INTO_DEBUGGER
-    #ifdef CATCH_TRAP
-        #define CATCH_BREAK_INTO_DEBUGGER() []{ if( Catch::isDebuggerActive() ) { CATCH_TRAP(); } }()
-    #else
-        #define CATCH_BREAK_INTO_DEBUGGER() []{}()
-    #endif
+#ifdef CATCH_TRAP
+#define CATCH_BREAK_INTO_DEBUGGER() []{ if( Catch::isDebuggerActive() ) { CATCH_TRAP(); } }()
+#else
+#define CATCH_BREAK_INTO_DEBUGGER() []{}()
+#endif
 #endif
 
 // end catch_debugger.h
@@ -7980,86 +8017,58 @@ namespace Catch {
 
 // start catch_fatal_condition.h
 
-// start catch_windows_h_proxy.h
-
-
-#if defined(CATCH_PLATFORM_WINDOWS)
-
-#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
-#  define CATCH_DEFINED_NOMINMAX
-#  define NOMINMAX
-#endif
-#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
-#  define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-#endif
-
-#ifdef __AFXDLL
-#include <AfxWin.h>
-#else
-#include <windows.h>
-#endif
-
-#ifdef CATCH_DEFINED_NOMINMAX
-#  undef NOMINMAX
-#endif
-#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
-#  undef WIN32_LEAN_AND_MEAN
-#endif
-
-#endif // defined(CATCH_PLATFORM_WINDOWS)
-
-// end catch_windows_h_proxy.h
-#if defined( CATCH_CONFIG_WINDOWS_SEH )
+#include <cassert>
 
 namespace Catch {
 
-    struct FatalConditionHandler {
+    // Wrapper for platform-specific fatal error (signals/SEH) handlers
+    //
+    // Tries to be cooperative with other handlers, and not step over
+    // other handlers. This means that unknown structured exceptions
+    // are passed on, previous signal handlers are called, and so on.
+    //
+    // Can only be instantiated once, and assumes that once a signal
+    // is caught, the binary will end up terminating. Thus, there
+    class FatalConditionHandler {
+        bool m_started = false;
 
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo);
-        FatalConditionHandler();
-        static void reset();
-        ~FatalConditionHandler();
-
-    private:
-        static bool isSet;
-        static ULONG guaranteeSize;
-        static PVOID exceptionHandlerHandle;
-    };
-
-} // namespace Catch
-
-#elif defined ( CATCH_CONFIG_POSIX_SIGNALS )
-
-#include <signal.h>
-
-namespace Catch {
-
-    struct FatalConditionHandler {
-
-        static bool isSet;
-        static struct sigaction oldSigActions[];
-        static stack_t oldSigStack;
-        static char altStackMem[];
-
-        static void handleSignal( int sig );
-
+        // Install/disengage implementation for specific platform.
+        // Should be if-defed to work on current platform, can assume
+        // engage-disengage 1:1 pairing.
+        void engage_platform();
+        void disengage_platform();
+    public:
+        // Should also have platform-specific implementations as needed
         FatalConditionHandler();
         ~FatalConditionHandler();
-        static void reset();
+
+        void engage() {
+            assert(!m_started && "Handler cannot be installed twice.");
+            m_started = true;
+            engage_platform();
+        }
+
+        void disengage() {
+            assert(m_started && "Handler cannot be uninstalled without being installed first");
+            m_started = false;
+            disengage_platform();
+        }
     };
 
-} // namespace Catch
-
-#else
-
-namespace Catch {
-    struct FatalConditionHandler {
-        void reset();
+    //! Simple RAII guard for (dis)engaging the FatalConditionHandler
+    class FatalConditionHandlerGuard {
+        FatalConditionHandler* m_handler;
+    public:
+        FatalConditionHandlerGuard(FatalConditionHandler* handler) :
+            m_handler(handler) {
+            m_handler->engage();
+        }
+        ~FatalConditionHandlerGuard() {
+            m_handler->disengage();
+        }
     };
-}
 
-#endif
+} // end namespace Catch
 
 // end catch_fatal_condition.h
 #include <string>
@@ -8073,15 +8082,15 @@ namespace Catch {
     class RunContext : public IResultCapture, public IRunner {
 
     public:
-        RunContext( RunContext const& ) = delete;
-        RunContext& operator =( RunContext const& ) = delete;
+        RunContext(RunContext const&) = delete;
+        RunContext& operator =(RunContext const&) = delete;
 
-        explicit RunContext( IConfigPtr const& _config, IStreamingReporterPtr&& reporter );
+        explicit RunContext(IConfigPtr const& _config, IStreamingReporterPtr&& reporter);
 
         ~RunContext() override;
 
-        void testGroupStarting( std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount );
-        void testGroupEnded( std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount );
+        void testGroupStarting(std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount);
+        void testGroupEnded(std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount);
 
         Totals runTest(TestCase const& testCase);
 
@@ -8092,46 +8101,46 @@ namespace Catch {
 
         // Assertion handlers
         void handleExpr
-                (   AssertionInfo const& info,
-                    ITransientExpression const& expr,
-                    AssertionReaction& reaction ) override;
+        (AssertionInfo const& info,
+            ITransientExpression const& expr,
+            AssertionReaction& reaction) override;
         void handleMessage
-                (   AssertionInfo const& info,
-                    ResultWas::OfType resultType,
-                    StringRef const& message,
-                    AssertionReaction& reaction ) override;
+        (AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            StringRef const& message,
+            AssertionReaction& reaction) override;
         void handleUnexpectedExceptionNotThrown
-                (   AssertionInfo const& info,
-                    AssertionReaction& reaction ) override;
+        (AssertionInfo const& info,
+            AssertionReaction& reaction) override;
         void handleUnexpectedInflightException
-                (   AssertionInfo const& info,
-                    std::string const& message,
-                    AssertionReaction& reaction ) override;
+        (AssertionInfo const& info,
+            std::string const& message,
+            AssertionReaction& reaction) override;
         void handleIncomplete
-                (   AssertionInfo const& info ) override;
+        (AssertionInfo const& info) override;
         void handleNonExpr
-                (   AssertionInfo const &info,
-                    ResultWas::OfType resultType,
-                    AssertionReaction &reaction ) override;
+        (AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            AssertionReaction& reaction) override;
 
-        bool sectionStarted( SectionInfo const& sectionInfo, Counts& assertions ) override;
+        bool sectionStarted(SectionInfo const& sectionInfo, Counts& assertions) override;
 
-        void sectionEnded( SectionEndInfo const& endInfo ) override;
-        void sectionEndedEarly( SectionEndInfo const& endInfo ) override;
+        void sectionEnded(SectionEndInfo const& endInfo) override;
+        void sectionEndedEarly(SectionEndInfo const& endInfo) override;
 
-        auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& override;
+        auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const& lineInfo) -> IGeneratorTracker & override;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-        void benchmarkPreparing( std::string const& name ) override;
-        void benchmarkStarting( BenchmarkInfo const& info ) override;
-        void benchmarkEnded( BenchmarkStats<> const& stats ) override;
-        void benchmarkFailed( std::string const& error ) override;
+        void benchmarkPreparing(std::string const& name) override;
+        void benchmarkStarting(BenchmarkInfo const& info) override;
+        void benchmarkEnded(BenchmarkStats<> const& stats) override;
+        void benchmarkFailed(std::string const& error) override;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-        void pushScopedMessage( MessageInfo const& message ) override;
-        void popScopedMessage( MessageInfo const& message ) override;
+        void pushScopedMessage(MessageInfo const& message) override;
+        void popScopedMessage(MessageInfo const& message) override;
 
-        void emplaceUnscopedMessage( MessageBuilder const& builder ) override;
+        void emplaceUnscopedMessage(MessageBuilder const& builder) override;
 
         std::string getCurrentTestName() const override;
 
@@ -8139,7 +8148,7 @@ namespace Catch {
 
         void exceptionEarlyReported() override;
 
-        void handleFatalErrorCondition( StringRef message ) override;
+        void handleFatalErrorCondition(StringRef message) override;
 
         bool lastAssertionPassed() override;
 
@@ -8151,20 +8160,20 @@ namespace Catch {
 
     private:
 
-        void runCurrentTest( std::string& redirectedCout, std::string& redirectedCerr );
+        void runCurrentTest(std::string& redirectedCout, std::string& redirectedCerr);
         void invokeActiveTestCase();
 
         void resetAssertionInfo();
-        bool testForMissingAssertions( Counts& assertions );
+        bool testForMissingAssertions(Counts& assertions);
 
-        void assertionEnded( AssertionResult const& result );
+        void assertionEnded(AssertionResult const& result);
         void reportExpr
-                (   AssertionInfo const &info,
-                    ResultWas::OfType resultType,
-                    ITransientExpression const *expr,
-                    bool negated );
+        (AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            ITransientExpression const* expr,
+            bool negated);
 
-        void populateReaction( AssertionReaction& reaction );
+        void populateReaction(AssertionReaction& reaction);
 
     private:
 
@@ -8185,6 +8194,7 @@ namespace Catch {
         std::vector<SectionEndInfo> m_unfinishedSections;
         std::vector<ITracker*> m_activeSections;
         TrackerContext m_trackerContext;
+        FatalConditionHandler m_fatalConditionhandler;
         bool m_lastAssertionPassed = false;
         bool m_shouldReportUnexpected = true;
         bool m_includeSuccessfulResults;
@@ -8198,28 +8208,28 @@ namespace Catch {
 namespace Catch {
 
     namespace {
-        auto operator <<( std::ostream& os, ITransientExpression const& expr ) -> std::ostream& {
-            expr.streamReconstructedExpression( os );
+        auto operator <<(std::ostream& os, ITransientExpression const& expr) -> std::ostream& {
+            expr.streamReconstructedExpression(os);
             return os;
         }
     }
 
-    LazyExpression::LazyExpression( bool isNegated )
-    :   m_isNegated( isNegated )
+    LazyExpression::LazyExpression(bool isNegated)
+        : m_isNegated(isNegated)
     {}
 
-    LazyExpression::LazyExpression( LazyExpression const& other ) : m_isNegated( other.m_isNegated ) {}
+    LazyExpression::LazyExpression(LazyExpression const& other) : m_isNegated(other.m_isNegated) {}
 
     LazyExpression::operator bool() const {
         return m_transientExpression != nullptr;
     }
 
-    auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream& {
-        if( lazyExpr.m_isNegated )
+    auto operator << (std::ostream& os, LazyExpression const& lazyExpr) -> std::ostream& {
+        if (lazyExpr.m_isNegated)
             os << "!";
 
-        if( lazyExpr ) {
-            if( lazyExpr.m_isNegated && lazyExpr.m_transientExpression->isBinaryExpression() )
+        if (lazyExpr) {
+            if (lazyExpr.m_isNegated && lazyExpr.m_transientExpression->isBinaryExpression())
                 os << "(" << *lazyExpr.m_transientExpression << ")";
             else
                 os << *lazyExpr.m_transientExpression;
@@ -8231,19 +8241,19 @@ namespace Catch {
     }
 
     AssertionHandler::AssertionHandler
-        (   StringRef const& macroName,
-            SourceLineInfo const& lineInfo,
-            StringRef capturedExpression,
-            ResultDisposition::Flags resultDisposition )
-    :   m_assertionInfo{ macroName, lineInfo, capturedExpression, resultDisposition },
-        m_resultCapture( getResultCapture() )
+    (StringRef const& macroName,
+        SourceLineInfo const& lineInfo,
+        StringRef capturedExpression,
+        ResultDisposition::Flags resultDisposition)
+        : m_assertionInfo{ macroName, lineInfo, capturedExpression, resultDisposition },
+        m_resultCapture(getResultCapture())
     {}
 
-    void AssertionHandler::handleExpr( ITransientExpression const& expr ) {
-        m_resultCapture.handleExpr( m_assertionInfo, expr, m_reaction );
+    void AssertionHandler::handleExpr(ITransientExpression const& expr) {
+        m_resultCapture.handleExpr(m_assertionInfo, expr, m_reaction);
     }
     void AssertionHandler::handleMessage(ResultWas::OfType resultType, StringRef const& message) {
-        m_resultCapture.handleMessage( m_assertionInfo, resultType, message, m_reaction );
+        m_resultCapture.handleMessage(m_assertionInfo, resultType, message, m_reaction);
     }
 
     auto AssertionHandler::allowThrows() const -> bool {
@@ -8252,7 +8262,7 @@ namespace Catch {
 
     void AssertionHandler::complete() {
         setCompleted();
-        if( m_reaction.shouldDebugBreak ) {
+        if (m_reaction.shouldDebugBreak) {
 
             // If you find your debugger stopping you here then go one level up on the
             // call-stack for the code that caused it (typically a failed assertion)
@@ -8264,7 +8274,7 @@ namespace Catch {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
             throw Catch::TestFailureException();
 #else
-            CATCH_ERROR( "Test failure requires aborting test!" );
+            CATCH_ERROR("Test failure requires aborting test!");
 #endif
         }
     }
@@ -8273,7 +8283,7 @@ namespace Catch {
     }
 
     void AssertionHandler::handleUnexpectedInflightException() {
-        m_resultCapture.handleUnexpectedInflightException( m_assertionInfo, Catch::translateActiveException(), m_reaction );
+        m_resultCapture.handleUnexpectedInflightException(m_assertionInfo, Catch::translateActiveException(), m_reaction);
     }
 
     void AssertionHandler::handleExceptionThrownAsExpected() {
@@ -8284,7 +8294,7 @@ namespace Catch {
     }
 
     void AssertionHandler::handleUnexpectedExceptionNotThrown() {
-        m_resultCapture.handleUnexpectedExceptionNotThrown( m_assertionInfo, m_reaction );
+        m_resultCapture.handleUnexpectedExceptionNotThrown(m_assertionInfo, m_reaction);
     }
 
     void AssertionHandler::handleThrowingCallSkipped() {
@@ -8293,8 +8303,8 @@ namespace Catch {
 
     // This is the overload that takes a string and infers the Equals matcher from it
     // The more general overload, that takes any string matcher, is in catch_capture_matchers.cpp
-    void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef const& matcherString  ) {
-        handleExceptionMatchExpr( handler, Matchers::Equals( str ), matcherString );
+    void handleExceptionMatchExpr(AssertionHandler& handler, std::string const& str, StringRef const& matcherString) {
+        handleExceptionMatchExpr(handler, Matchers::Equals(str), matcherString);
     }
 
 } // namespace Catch
@@ -8302,14 +8312,14 @@ namespace Catch {
 // start catch_assertionresult.cpp
 
 namespace Catch {
-    AssertionResultData::AssertionResultData(ResultWas::OfType _resultType, LazyExpression const & _lazyExpression):
+    AssertionResultData::AssertionResultData(ResultWas::OfType _resultType, LazyExpression const& _lazyExpression) :
         lazyExpression(_lazyExpression),
         resultType(_resultType) {}
 
     std::string AssertionResultData::reconstructExpression() const {
 
-        if( reconstructedExpression.empty() ) {
-            if( lazyExpression ) {
+        if (reconstructedExpression.empty()) {
+            if (lazyExpression) {
                 ReusableStringStream rss;
                 rss << lazyExpression;
                 reconstructedExpression = rss.str();
@@ -8318,19 +8328,19 @@ namespace Catch {
         return reconstructedExpression;
     }
 
-    AssertionResult::AssertionResult( AssertionInfo const& info, AssertionResultData const& data )
-    :   m_info( info ),
-        m_resultData( data )
+    AssertionResult::AssertionResult(AssertionInfo const& info, AssertionResultData const& data)
+        : m_info(info),
+        m_resultData(data)
     {}
 
     // Result was a success
     bool AssertionResult::succeeded() const {
-        return Catch::isOk( m_resultData.resultType );
+        return Catch::isOk(m_resultData.resultType);
     }
 
     // Result was a success, or failure is suppressed
     bool AssertionResult::isOk() const {
-        return Catch::isOk( m_resultData.resultType ) || shouldSuppressFailure( m_info.resultDisposition );
+        return Catch::isOk(m_resultData.resultType) || shouldSuppressFailure(m_info.resultDisposition);
     }
 
     ResultWas::OfType AssertionResult::getResultType() const {
@@ -8360,10 +8370,10 @@ namespace Catch {
 
     std::string AssertionResult::getExpressionInMacro() const {
         std::string expr;
-        if( m_info.macroName.empty() )
+        if (m_info.macroName.empty())
             expr = static_cast<std::string>(m_info.capturedExpression);
         else {
-            expr.reserve( m_info.macroName.size() + m_info.capturedExpression.size() + 4 );
+            expr.reserve(m_info.macroName.size() + m_info.capturedExpression.size() + 4);
             expr += m_info.macroName;
             expr += "( ";
             expr += m_info.capturedExpression;
@@ -8379,8 +8389,8 @@ namespace Catch {
     std::string AssertionResult::getExpandedExpression() const {
         std::string expr = m_resultData.reconstructExpression();
         return expr.empty()
-                ? getExpression()
-                : expr;
+            ? getExpression()
+            : expr;
     }
 
     std::string AssertionResult::getMessage() const {
@@ -8405,10 +8415,10 @@ namespace Catch {
     // This is the general overload that takes a any string matcher
     // There is another overload, in catch_assertionhandler.h/.cpp, that only takes a string and infers
     // the Equals matcher (so the header does not mention matchers)
-    void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString  ) {
+    void handleExceptionMatchExpr(AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString) {
         std::string exceptionMessage = Catch::translateActiveException();
-        MatchExpr<std::string, StringMatcher const&> expr( exceptionMessage, matcher, matcherString );
-        handler.handleExpr( expr );
+        MatchExpr<std::string, StringMatcher const&> expr(exceptionMessage, matcher, matcherString);
+        handler.handleExpr(expr);
     }
 
 } // namespace Catch
@@ -8483,320 +8493,323 @@ namespace Catch {
 #endif
 
 namespace Catch {
-namespace clara {
-namespace TextFlow {
+    namespace clara {
+        namespace TextFlow {
 
-inline auto isWhitespace(char c) -> bool {
-	static std::string chars = " \t\n\r";
-	return chars.find(c) != std::string::npos;
-}
-inline auto isBreakableBefore(char c) -> bool {
-	static std::string chars = "[({<|";
-	return chars.find(c) != std::string::npos;
-}
-inline auto isBreakableAfter(char c) -> bool {
-	static std::string chars = "])}>.,:;*+-=&/\\";
-	return chars.find(c) != std::string::npos;
-}
+            inline auto isWhitespace(char c) -> bool {
+                static std::string chars = " \t\n\r";
+                return chars.find(c) != std::string::npos;
+            }
+            inline auto isBreakableBefore(char c) -> bool {
+                static std::string chars = "[({<|";
+                return chars.find(c) != std::string::npos;
+            }
+            inline auto isBreakableAfter(char c) -> bool {
+                static std::string chars = "])}>.,:;*+-=&/\\";
+                return chars.find(c) != std::string::npos;
+            }
 
-class Columns;
+            class Columns;
 
-class Column {
-	std::vector<std::string> m_strings;
-	size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
-	size_t m_indent = 0;
-	size_t m_initialIndent = std::string::npos;
+            class Column {
+                std::vector<std::string> m_strings;
+                size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
+                size_t m_indent = 0;
+                size_t m_initialIndent = std::string::npos;
 
-public:
-	class iterator {
-		friend Column;
+            public:
+                class iterator {
+                    friend Column;
 
-		Column const& m_column;
-		size_t m_stringIndex = 0;
-		size_t m_pos = 0;
+                    Column const& m_column;
+                    size_t m_stringIndex = 0;
+                    size_t m_pos = 0;
 
-		size_t m_len = 0;
-		size_t m_end = 0;
-		bool m_suffix = false;
+                    size_t m_len = 0;
+                    size_t m_end = 0;
+                    bool m_suffix = false;
 
-		iterator(Column const& column, size_t stringIndex)
-			: m_column(column),
-			m_stringIndex(stringIndex) {}
+                    iterator(Column const& column, size_t stringIndex)
+                        : m_column(column),
+                        m_stringIndex(stringIndex) {}
 
-		auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
+                    auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
 
-		auto isBoundary(size_t at) const -> bool {
-			assert(at > 0);
-			assert(at <= line().size());
+                    auto isBoundary(size_t at) const -> bool {
+                        assert(at > 0);
+                        assert(at <= line().size());
 
-			return at == line().size() ||
-				(isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
-				isBreakableBefore(line()[at]) ||
-				isBreakableAfter(line()[at - 1]);
-		}
+                        return at == line().size() ||
+                            (isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
+                            isBreakableBefore(line()[at]) ||
+                            isBreakableAfter(line()[at - 1]);
+                    }
 
-		void calcLength() {
-			assert(m_stringIndex < m_column.m_strings.size());
+                    void calcLength() {
+                        assert(m_stringIndex < m_column.m_strings.size());
 
-			m_suffix = false;
-			auto width = m_column.m_width - indent();
-			m_end = m_pos;
-			if (line()[m_pos] == '\n') {
-				++m_end;
-			}
-			while (m_end < line().size() && line()[m_end] != '\n')
-				++m_end;
+                        m_suffix = false;
+                        auto width = m_column.m_width - indent();
+                        m_end = m_pos;
+                        if (line()[m_pos] == '\n') {
+                            ++m_end;
+                        }
+                        while (m_end < line().size() && line()[m_end] != '\n')
+                            ++m_end;
 
-			if (m_end < m_pos + width) {
-				m_len = m_end - m_pos;
-			} else {
-				size_t len = width;
-				while (len > 0 && !isBoundary(m_pos + len))
-					--len;
-				while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
-					--len;
+                        if (m_end < m_pos + width) {
+                            m_len = m_end - m_pos;
+                        }
+                        else {
+                            size_t len = width;
+                            while (len > 0 && !isBoundary(m_pos + len))
+                                --len;
+                            while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
+                                --len;
 
-				if (len > 0) {
-					m_len = len;
-				} else {
-					m_suffix = true;
-					m_len = width - 1;
-				}
-			}
-		}
+                            if (len > 0) {
+                                m_len = len;
+                            }
+                            else {
+                                m_suffix = true;
+                                m_len = width - 1;
+                            }
+                        }
+                    }
 
-		auto indent() const -> size_t {
-			auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
-			return initial == std::string::npos ? m_column.m_indent : initial;
-		}
+                    auto indent() const -> size_t {
+                        auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
+                        return initial == std::string::npos ? m_column.m_indent : initial;
+                    }
 
-		auto addIndentAndSuffix(std::string const &plain) const -> std::string {
-			return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
-		}
+                    auto addIndentAndSuffix(std::string const& plain) const -> std::string {
+                        return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
+                    }
 
-	public:
-		using difference_type = std::ptrdiff_t;
-		using value_type = std::string;
-		using pointer = value_type * ;
-		using reference = value_type & ;
-		using iterator_category = std::forward_iterator_tag;
+                public:
+                    using difference_type = std::ptrdiff_t;
+                    using value_type = std::string;
+                    using pointer = value_type*;
+                    using reference = value_type&;
+                    using iterator_category = std::forward_iterator_tag;
 
-		explicit iterator(Column const& column) : m_column(column) {
-			assert(m_column.m_width > m_column.m_indent);
-			assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
-			calcLength();
-			if (m_len == 0)
-				m_stringIndex++; // Empty string
-		}
+                    explicit iterator(Column const& column) : m_column(column) {
+                        assert(m_column.m_width > m_column.m_indent);
+                        assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
+                        calcLength();
+                        if (m_len == 0)
+                            m_stringIndex++; // Empty string
+                    }
 
-		auto operator *() const -> std::string {
-			assert(m_stringIndex < m_column.m_strings.size());
-			assert(m_pos <= m_end);
-			return addIndentAndSuffix(line().substr(m_pos, m_len));
-		}
+                    auto operator *() const -> std::string {
+                        assert(m_stringIndex < m_column.m_strings.size());
+                        assert(m_pos <= m_end);
+                        return addIndentAndSuffix(line().substr(m_pos, m_len));
+                    }
 
-		auto operator ++() -> iterator& {
-			m_pos += m_len;
-			if (m_pos < line().size() && line()[m_pos] == '\n')
-				m_pos += 1;
-			else
-				while (m_pos < line().size() && isWhitespace(line()[m_pos]))
-					++m_pos;
+                    auto operator ++() -> iterator& {
+                        m_pos += m_len;
+                        if (m_pos < line().size() && line()[m_pos] == '\n')
+                            m_pos += 1;
+                        else
+                            while (m_pos < line().size() && isWhitespace(line()[m_pos]))
+                                ++m_pos;
 
-			if (m_pos == line().size()) {
-				m_pos = 0;
-				++m_stringIndex;
-			}
-			if (m_stringIndex < m_column.m_strings.size())
-				calcLength();
-			return *this;
-		}
-		auto operator ++(int) -> iterator {
-			iterator prev(*this);
-			operator++();
-			return prev;
-		}
+                        if (m_pos == line().size()) {
+                            m_pos = 0;
+                            ++m_stringIndex;
+                        }
+                        if (m_stringIndex < m_column.m_strings.size())
+                            calcLength();
+                        return *this;
+                    }
+                    auto operator ++(int) -> iterator {
+                        iterator prev(*this);
+                        operator++();
+                        return prev;
+                    }
 
-		auto operator ==(iterator const& other) const -> bool {
-			return
-				m_pos == other.m_pos &&
-				m_stringIndex == other.m_stringIndex &&
-				&m_column == &other.m_column;
-		}
-		auto operator !=(iterator const& other) const -> bool {
-			return !operator==(other);
-		}
-	};
-	using const_iterator = iterator;
+                    auto operator ==(iterator const& other) const -> bool {
+                        return
+                            m_pos == other.m_pos &&
+                            m_stringIndex == other.m_stringIndex &&
+                            &m_column == &other.m_column;
+                    }
+                    auto operator !=(iterator const& other) const -> bool {
+                        return !operator==(other);
+                    }
+                };
+                using const_iterator = iterator;
 
-	explicit Column(std::string const& text) { m_strings.push_back(text); }
+                explicit Column(std::string const& text) { m_strings.push_back(text); }
 
-	auto width(size_t newWidth) -> Column& {
-		assert(newWidth > 0);
-		m_width = newWidth;
-		return *this;
-	}
-	auto indent(size_t newIndent) -> Column& {
-		m_indent = newIndent;
-		return *this;
-	}
-	auto initialIndent(size_t newIndent) -> Column& {
-		m_initialIndent = newIndent;
-		return *this;
-	}
+                auto width(size_t newWidth) -> Column& {
+                    assert(newWidth > 0);
+                    m_width = newWidth;
+                    return *this;
+                }
+                auto indent(size_t newIndent) -> Column& {
+                    m_indent = newIndent;
+                    return *this;
+                }
+                auto initialIndent(size_t newIndent) -> Column& {
+                    m_initialIndent = newIndent;
+                    return *this;
+                }
 
-	auto width() const -> size_t { return m_width; }
-	auto begin() const -> iterator { return iterator(*this); }
-	auto end() const -> iterator { return { *this, m_strings.size() }; }
+                auto width() const -> size_t { return m_width; }
+                auto begin() const -> iterator { return iterator(*this); }
+                auto end() const -> iterator { return { *this, m_strings.size() }; }
 
-	inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
-		bool first = true;
-		for (auto line : col) {
-			if (first)
-				first = false;
-			else
-				os << "\n";
-			os << line;
-		}
-		return os;
-	}
+                inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
+                    bool first = true;
+                    for (auto line : col) {
+                        if (first)
+                            first = false;
+                        else
+                            os << "\n";
+                        os << line;
+                    }
+                    return os;
+                }
 
-	auto operator + (Column const& other)->Columns;
+                auto operator + (Column const& other)->Columns;
 
-	auto toString() const -> std::string {
-		std::ostringstream oss;
-		oss << *this;
-		return oss.str();
-	}
-};
+                auto toString() const -> std::string {
+                    std::ostringstream oss;
+                    oss << *this;
+                    return oss.str();
+                }
+            };
 
-class Spacer : public Column {
+            class Spacer : public Column {
 
-public:
-	explicit Spacer(size_t spaceWidth) : Column("") {
-		width(spaceWidth);
-	}
-};
+            public:
+                explicit Spacer(size_t spaceWidth) : Column("") {
+                    width(spaceWidth);
+                }
+            };
 
-class Columns {
-	std::vector<Column> m_columns;
+            class Columns {
+                std::vector<Column> m_columns;
 
-public:
+            public:
 
-	class iterator {
-		friend Columns;
-		struct EndTag {};
+                class iterator {
+                    friend Columns;
+                    struct EndTag {};
 
-		std::vector<Column> const& m_columns;
-		std::vector<Column::iterator> m_iterators;
-		size_t m_activeIterators;
+                    std::vector<Column> const& m_columns;
+                    std::vector<Column::iterator> m_iterators;
+                    size_t m_activeIterators;
 
-		iterator(Columns const& columns, EndTag)
-			: m_columns(columns.m_columns),
-			m_activeIterators(0) {
-			m_iterators.reserve(m_columns.size());
+                    iterator(Columns const& columns, EndTag)
+                        : m_columns(columns.m_columns),
+                        m_activeIterators(0) {
+                        m_iterators.reserve(m_columns.size());
 
-			for (auto const& col : m_columns)
-				m_iterators.push_back(col.end());
-		}
+                        for (auto const& col : m_columns)
+                            m_iterators.push_back(col.end());
+                    }
 
-	public:
-		using difference_type = std::ptrdiff_t;
-		using value_type = std::string;
-		using pointer = value_type * ;
-		using reference = value_type & ;
-		using iterator_category = std::forward_iterator_tag;
+                public:
+                    using difference_type = std::ptrdiff_t;
+                    using value_type = std::string;
+                    using pointer = value_type*;
+                    using reference = value_type&;
+                    using iterator_category = std::forward_iterator_tag;
 
-		explicit iterator(Columns const& columns)
-			: m_columns(columns.m_columns),
-			m_activeIterators(m_columns.size()) {
-			m_iterators.reserve(m_columns.size());
+                    explicit iterator(Columns const& columns)
+                        : m_columns(columns.m_columns),
+                        m_activeIterators(m_columns.size()) {
+                        m_iterators.reserve(m_columns.size());
 
-			for (auto const& col : m_columns)
-				m_iterators.push_back(col.begin());
-		}
+                        for (auto const& col : m_columns)
+                            m_iterators.push_back(col.begin());
+                    }
 
-		auto operator ==(iterator const& other) const -> bool {
-			return m_iterators == other.m_iterators;
-		}
-		auto operator !=(iterator const& other) const -> bool {
-			return m_iterators != other.m_iterators;
-		}
-		auto operator *() const -> std::string {
-			std::string row, padding;
+                    auto operator ==(iterator const& other) const -> bool {
+                        return m_iterators == other.m_iterators;
+                    }
+                    auto operator !=(iterator const& other) const -> bool {
+                        return m_iterators != other.m_iterators;
+                    }
+                    auto operator *() const -> std::string {
+                        std::string row, padding;
 
-			for (size_t i = 0; i < m_columns.size(); ++i) {
-				auto width = m_columns[i].width();
-				if (m_iterators[i] != m_columns[i].end()) {
-					std::string col = *m_iterators[i];
-					row += padding + col;
-					if (col.size() < width)
-						padding = std::string(width - col.size(), ' ');
-					else
-						padding = "";
-				} else {
-					padding += std::string(width, ' ');
-				}
-			}
-			return row;
-		}
-		auto operator ++() -> iterator& {
-			for (size_t i = 0; i < m_columns.size(); ++i) {
-				if (m_iterators[i] != m_columns[i].end())
-					++m_iterators[i];
-			}
-			return *this;
-		}
-		auto operator ++(int) -> iterator {
-			iterator prev(*this);
-			operator++();
-			return prev;
-		}
-	};
-	using const_iterator = iterator;
+                        for (size_t i = 0; i < m_columns.size(); ++i) {
+                            auto width = m_columns[i].width();
+                            if (m_iterators[i] != m_columns[i].end()) {
+                                std::string col = *m_iterators[i];
+                                row += padding + col;
+                                if (col.size() < width)
+                                    padding = std::string(width - col.size(), ' ');
+                                else
+                                    padding = "";
+                            }
+                            else {
+                                padding += std::string(width, ' ');
+                            }
+                        }
+                        return row;
+                    }
+                    auto operator ++() -> iterator& {
+                        for (size_t i = 0; i < m_columns.size(); ++i) {
+                            if (m_iterators[i] != m_columns[i].end())
+                                ++m_iterators[i];
+                        }
+                        return *this;
+                    }
+                    auto operator ++(int) -> iterator {
+                        iterator prev(*this);
+                        operator++();
+                        return prev;
+                    }
+                };
+                using const_iterator = iterator;
 
-	auto begin() const -> iterator { return iterator(*this); }
-	auto end() const -> iterator { return { *this, iterator::EndTag() }; }
+                auto begin() const -> iterator { return iterator(*this); }
+                auto end() const -> iterator { return { *this, iterator::EndTag() }; }
 
-	auto operator += (Column const& col) -> Columns& {
-		m_columns.push_back(col);
-		return *this;
-	}
-	auto operator + (Column const& col) -> Columns {
-		Columns combined = *this;
-		combined += col;
-		return combined;
-	}
+                auto operator += (Column const& col) -> Columns& {
+                    m_columns.push_back(col);
+                    return *this;
+                }
+                auto operator + (Column const& col) -> Columns {
+                    Columns combined = *this;
+                    combined += col;
+                    return combined;
+                }
 
-	inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
+                inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
 
-		bool first = true;
-		for (auto line : cols) {
-			if (first)
-				first = false;
-			else
-				os << "\n";
-			os << line;
-		}
-		return os;
-	}
+                    bool first = true;
+                    for (auto line : cols) {
+                        if (first)
+                            first = false;
+                        else
+                            os << "\n";
+                        os << line;
+                    }
+                    return os;
+                }
 
-	auto toString() const -> std::string {
-		std::ostringstream oss;
-		oss << *this;
-		return oss.str();
-	}
-};
+                auto toString() const -> std::string {
+                    std::ostringstream oss;
+                    oss << *this;
+                    return oss.str();
+                }
+            };
 
-inline auto Column::operator + (Column const& other) -> Columns {
-	Columns cols;
-	cols += *this;
-	cols += other;
-	return cols;
-}
-}
+            inline auto Column::operator + (Column const& other) -> Columns {
+                Columns cols;
+                cols += *this;
+                cols += other;
+                return cols;
+            }
+        }
 
-}
+    }
 }
 
 // ----------- end of #include from clara_textflow.hpp -----------
@@ -8812,881 +8825,888 @@ inline auto Column::operator + (Column const& other) -> Columns {
 #define CATCH_PLATFORM_WINDOWS
 #endif
 
-namespace Catch { namespace clara {
-namespace detail {
+namespace Catch {
+    namespace clara {
+        namespace detail {
 
-    // Traits for extracting arg and return type of lambdas (for single argument lambdas)
-    template<typename L>
-    struct UnaryLambdaTraits : UnaryLambdaTraits<decltype( &L::operator() )> {};
+            // Traits for extracting arg and return type of lambdas (for single argument lambdas)
+            template<typename L>
+            struct UnaryLambdaTraits : UnaryLambdaTraits<decltype(&L::operator())> {};
 
-    template<typename ClassT, typename ReturnT, typename... Args>
-    struct UnaryLambdaTraits<ReturnT( ClassT::* )( Args... ) const> {
-        static const bool isValid = false;
-    };
+            template<typename ClassT, typename ReturnT, typename... Args>
+            struct UnaryLambdaTraits<ReturnT(ClassT::*)(Args...) const> {
+                static const bool isValid = false;
+            };
 
-    template<typename ClassT, typename ReturnT, typename ArgT>
-    struct UnaryLambdaTraits<ReturnT( ClassT::* )( ArgT ) const> {
-        static const bool isValid = true;
-        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
-        using ReturnType = ReturnT;
-    };
+            template<typename ClassT, typename ReturnT, typename ArgT>
+            struct UnaryLambdaTraits<ReturnT(ClassT::*)(ArgT) const> {
+                static const bool isValid = true;
+                using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
+                using ReturnType = ReturnT;
+            };
 
-    class TokenStream;
+            class TokenStream;
 
-    // Transport for raw args (copied from main args, or supplied via init list for testing)
-    class Args {
-        friend TokenStream;
-        std::string m_exeName;
-        std::vector<std::string> m_args;
+            // Transport for raw args (copied from main args, or supplied via init list for testing)
+            class Args {
+                friend TokenStream;
+                std::string m_exeName;
+                std::vector<std::string> m_args;
 
-    public:
-        Args( int argc, char const* const* argv )
-            : m_exeName(argv[0]),
-              m_args(argv + 1, argv + argc) {}
+            public:
+                Args(int argc, char const* const* argv)
+                    : m_exeName(argv[0]),
+                    m_args(argv + 1, argv + argc) {}
 
-        Args( std::initializer_list<std::string> args )
-        :   m_exeName( *args.begin() ),
-            m_args( args.begin()+1, args.end() )
-        {}
+                Args(std::initializer_list<std::string> args)
+                    : m_exeName(*args.begin()),
+                    m_args(args.begin() + 1, args.end())
+                {}
 
-        auto exeName() const -> std::string {
-            return m_exeName;
-        }
-    };
+                auto exeName() const -> std::string {
+                    return m_exeName;
+                }
+            };
 
-    // Wraps a token coming from a token stream. These may not directly correspond to strings as a single string
-    // may encode an option + its argument if the : or = form is used
-    enum class TokenType {
-        Option, Argument
-    };
-    struct Token {
-        TokenType type;
-        std::string token;
-    };
+            // Wraps a token coming from a token stream. These may not directly correspond to strings as a single string
+            // may encode an option + its argument if the : or = form is used
+            enum class TokenType {
+                Option, Argument
+            };
+            struct Token {
+                TokenType type;
+                std::string token;
+            };
 
-    inline auto isOptPrefix( char c ) -> bool {
-        return c == '-'
+            inline auto isOptPrefix(char c) -> bool {
+                return c == '-'
 #ifdef CATCH_PLATFORM_WINDOWS
-            || c == '/'
+                    || c == '/'
 #endif
-        ;
-    }
+                    ;
+            }
 
-    // Abstracts iterators into args as a stream of tokens, with option arguments uniformly handled
-    class TokenStream {
-        using Iterator = std::vector<std::string>::const_iterator;
-        Iterator it;
-        Iterator itEnd;
-        std::vector<Token> m_tokenBuffer;
+            // Abstracts iterators into args as a stream of tokens, with option arguments uniformly handled
+            class TokenStream {
+                using Iterator = std::vector<std::string>::const_iterator;
+                Iterator it;
+                Iterator itEnd;
+                std::vector<Token> m_tokenBuffer;
 
-        void loadBuffer() {
-            m_tokenBuffer.resize( 0 );
+                void loadBuffer() {
+                    m_tokenBuffer.resize(0);
 
-            // Skip any empty strings
-            while( it != itEnd && it->empty() )
-                ++it;
+                    // Skip any empty strings
+                    while (it != itEnd && it->empty())
+                        ++it;
 
-            if( it != itEnd ) {
-                auto const &next = *it;
-                if( isOptPrefix( next[0] ) ) {
-                    auto delimiterPos = next.find_first_of( " :=" );
-                    if( delimiterPos != std::string::npos ) {
-                        m_tokenBuffer.push_back( { TokenType::Option, next.substr( 0, delimiterPos ) } );
-                        m_tokenBuffer.push_back( { TokenType::Argument, next.substr( delimiterPos + 1 ) } );
-                    } else {
-                        if( next[1] != '-' && next.size() > 2 ) {
-                            std::string opt = "- ";
-                            for( size_t i = 1; i < next.size(); ++i ) {
-                                opt[1] = next[i];
-                                m_tokenBuffer.push_back( { TokenType::Option, opt } );
+                    if (it != itEnd) {
+                        auto const& next = *it;
+                        if (isOptPrefix(next[0])) {
+                            auto delimiterPos = next.find_first_of(" :=");
+                            if (delimiterPos != std::string::npos) {
+                                m_tokenBuffer.push_back({ TokenType::Option, next.substr(0, delimiterPos) });
+                                m_tokenBuffer.push_back({ TokenType::Argument, next.substr(delimiterPos + 1) });
                             }
-                        } else {
-                            m_tokenBuffer.push_back( { TokenType::Option, next } );
+                            else {
+                                if (next[1] != '-' && next.size() > 2) {
+                                    std::string opt = "- ";
+                                    for (size_t i = 1; i < next.size(); ++i) {
+                                        opt[1] = next[i];
+                                        m_tokenBuffer.push_back({ TokenType::Option, opt });
+                                    }
+                                }
+                                else {
+                                    m_tokenBuffer.push_back({ TokenType::Option, next });
+                                }
+                            }
+                        }
+                        else {
+                            m_tokenBuffer.push_back({ TokenType::Argument, next });
                         }
                     }
-                } else {
-                    m_tokenBuffer.push_back( { TokenType::Argument, next } );
                 }
+
+            public:
+                explicit TokenStream(Args const& args) : TokenStream(args.m_args.begin(), args.m_args.end()) {}
+
+                TokenStream(Iterator it, Iterator itEnd) : it(it), itEnd(itEnd) {
+                    loadBuffer();
+                }
+
+                explicit operator bool() const {
+                    return !m_tokenBuffer.empty() || it != itEnd;
+                }
+
+                auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
+
+                auto operator*() const -> Token {
+                    assert(!m_tokenBuffer.empty());
+                    return m_tokenBuffer.front();
+                }
+
+                auto operator->() const -> Token const* {
+                    assert(!m_tokenBuffer.empty());
+                    return &m_tokenBuffer.front();
+                }
+
+                auto operator++() -> TokenStream& {
+                    if (m_tokenBuffer.size() >= 2) {
+                        m_tokenBuffer.erase(m_tokenBuffer.begin());
+                    }
+                    else {
+                        if (it != itEnd)
+                            ++it;
+                        loadBuffer();
+                    }
+                    return *this;
+                }
+            };
+
+            class ResultBase {
+            public:
+                enum Type {
+                    Ok, LogicError, RuntimeError
+                };
+
+            protected:
+                ResultBase(Type type) : m_type(type) {}
+                virtual ~ResultBase() = default;
+
+                virtual void enforceOk() const = 0;
+
+                Type m_type;
+            };
+
+            template<typename T>
+            class ResultValueBase : public ResultBase {
+            public:
+                auto value() const -> T const& {
+                    enforceOk();
+                    return m_value;
+                }
+
+            protected:
+                ResultValueBase(Type type) : ResultBase(type) {}
+
+                ResultValueBase(ResultValueBase const& other) : ResultBase(other) {
+                    if (m_type == ResultBase::Ok)
+                        new(&m_value) T(other.m_value);
+                }
+
+                ResultValueBase(Type, T const& value) : ResultBase(Ok) {
+                    new(&m_value) T(value);
+                }
+
+                auto operator=(ResultValueBase const& other) -> ResultValueBase& {
+                    if (m_type == ResultBase::Ok)
+                        m_value.~T();
+                    ResultBase::operator=(other);
+                    if (m_type == ResultBase::Ok)
+                        new(&m_value) T(other.m_value);
+                    return *this;
+                }
+
+                ~ResultValueBase() override {
+                    if (m_type == Ok)
+                        m_value.~T();
+                }
+
+                union {
+                    T m_value;
+                };
+            };
+
+            template<>
+            class ResultValueBase<void> : public ResultBase {
+            protected:
+                using ResultBase::ResultBase;
+            };
+
+            template<typename T = void>
+            class BasicResult : public ResultValueBase<T> {
+            public:
+                template<typename U>
+                explicit BasicResult(BasicResult<U> const& other)
+                    : ResultValueBase<T>(other.type()),
+                    m_errorMessage(other.errorMessage())
+                {
+                    assert(type() != ResultBase::Ok);
+                }
+
+                template<typename U>
+                static auto ok(U const& value) -> BasicResult { return { ResultBase::Ok, value }; }
+                static auto ok() -> BasicResult { return { ResultBase::Ok }; }
+                static auto logicError(std::string const& message) -> BasicResult { return { ResultBase::LogicError, message }; }
+                static auto runtimeError(std::string const& message) -> BasicResult { return { ResultBase::RuntimeError, message }; }
+
+                explicit operator bool() const { return m_type == ResultBase::Ok; }
+                auto type() const -> ResultBase::Type { return m_type; }
+                auto errorMessage() const -> std::string { return m_errorMessage; }
+
+            protected:
+                void enforceOk() const override {
+
+                    // Errors shouldn't reach this point, but if they do
+                    // the actual error message will be in m_errorMessage
+                    assert(m_type != ResultBase::LogicError);
+                    assert(m_type != ResultBase::RuntimeError);
+                    if (m_type != ResultBase::Ok)
+                        std::abort();
+                }
+
+                std::string m_errorMessage; // Only populated if resultType is an error
+
+                BasicResult(ResultBase::Type type, std::string const& message)
+                    : ResultValueBase<T>(type),
+                    m_errorMessage(message)
+                {
+                    assert(m_type != ResultBase::Ok);
+                }
+
+                using ResultValueBase<T>::ResultValueBase;
+                using ResultBase::m_type;
+            };
+
+            enum class ParseResultType {
+                Matched, NoMatch, ShortCircuitAll, ShortCircuitSame
+            };
+
+            class ParseState {
+            public:
+
+                ParseState(ParseResultType type, TokenStream const& remainingTokens)
+                    : m_type(type),
+                    m_remainingTokens(remainingTokens)
+                {}
+
+                auto type() const -> ParseResultType { return m_type; }
+                auto remainingTokens() const -> TokenStream { return m_remainingTokens; }
+
+            private:
+                ParseResultType m_type;
+                TokenStream m_remainingTokens;
+            };
+
+            using Result = BasicResult<void>;
+            using ParserResult = BasicResult<ParseResultType>;
+            using InternalParseResult = BasicResult<ParseState>;
+
+            struct HelpColumns {
+                std::string left;
+                std::string right;
+            };
+
+            template<typename T>
+            inline auto convertInto(std::string const& source, T& target) -> ParserResult {
+                std::stringstream ss;
+                ss << source;
+                ss >> target;
+                if (ss.fail())
+                    return ParserResult::runtimeError("Unable to convert '" + source + "' to destination type");
+                else
+                    return ParserResult::ok(ParseResultType::Matched);
             }
-        }
-
-    public:
-        explicit TokenStream( Args const &args ) : TokenStream( args.m_args.begin(), args.m_args.end() ) {}
-
-        TokenStream( Iterator it, Iterator itEnd ) : it( it ), itEnd( itEnd ) {
-            loadBuffer();
-        }
-
-        explicit operator bool() const {
-            return !m_tokenBuffer.empty() || it != itEnd;
-        }
-
-        auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
-
-        auto operator*() const -> Token {
-            assert( !m_tokenBuffer.empty() );
-            return m_tokenBuffer.front();
-        }
-
-        auto operator->() const -> Token const * {
-            assert( !m_tokenBuffer.empty() );
-            return &m_tokenBuffer.front();
-        }
-
-        auto operator++() -> TokenStream & {
-            if( m_tokenBuffer.size() >= 2 ) {
-                m_tokenBuffer.erase( m_tokenBuffer.begin() );
-            } else {
-                if( it != itEnd )
-                    ++it;
-                loadBuffer();
+            inline auto convertInto(std::string const& source, std::string& target) -> ParserResult {
+                target = source;
+                return ParserResult::ok(ParseResultType::Matched);
             }
-            return *this;
-        }
-    };
-
-    class ResultBase {
-    public:
-        enum Type {
-            Ok, LogicError, RuntimeError
-        };
-
-    protected:
-        ResultBase( Type type ) : m_type( type ) {}
-        virtual ~ResultBase() = default;
-
-        virtual void enforceOk() const = 0;
-
-        Type m_type;
-    };
-
-    template<typename T>
-    class ResultValueBase : public ResultBase {
-    public:
-        auto value() const -> T const & {
-            enforceOk();
-            return m_value;
-        }
-
-    protected:
-        ResultValueBase( Type type ) : ResultBase( type ) {}
-
-        ResultValueBase( ResultValueBase const &other ) : ResultBase( other ) {
-            if( m_type == ResultBase::Ok )
-                new( &m_value ) T( other.m_value );
-        }
-
-        ResultValueBase( Type, T const &value ) : ResultBase( Ok ) {
-            new( &m_value ) T( value );
-        }
-
-        auto operator=( ResultValueBase const &other ) -> ResultValueBase & {
-            if( m_type == ResultBase::Ok )
-                m_value.~T();
-            ResultBase::operator=(other);
-            if( m_type == ResultBase::Ok )
-                new( &m_value ) T( other.m_value );
-            return *this;
-        }
-
-        ~ResultValueBase() override {
-            if( m_type == Ok )
-                m_value.~T();
-        }
-
-        union {
-            T m_value;
-        };
-    };
-
-    template<>
-    class ResultValueBase<void> : public ResultBase {
-    protected:
-        using ResultBase::ResultBase;
-    };
-
-    template<typename T = void>
-    class BasicResult : public ResultValueBase<T> {
-    public:
-        template<typename U>
-        explicit BasicResult( BasicResult<U> const &other )
-        :   ResultValueBase<T>( other.type() ),
-            m_errorMessage( other.errorMessage() )
-        {
-            assert( type() != ResultBase::Ok );
-        }
-
-        template<typename U>
-        static auto ok( U const &value ) -> BasicResult { return { ResultBase::Ok, value }; }
-        static auto ok() -> BasicResult { return { ResultBase::Ok }; }
-        static auto logicError( std::string const &message ) -> BasicResult { return { ResultBase::LogicError, message }; }
-        static auto runtimeError( std::string const &message ) -> BasicResult { return { ResultBase::RuntimeError, message }; }
-
-        explicit operator bool() const { return m_type == ResultBase::Ok; }
-        auto type() const -> ResultBase::Type { return m_type; }
-        auto errorMessage() const -> std::string { return m_errorMessage; }
-
-    protected:
-        void enforceOk() const override {
-
-            // Errors shouldn't reach this point, but if they do
-            // the actual error message will be in m_errorMessage
-            assert( m_type != ResultBase::LogicError );
-            assert( m_type != ResultBase::RuntimeError );
-            if( m_type != ResultBase::Ok )
-                std::abort();
-        }
-
-        std::string m_errorMessage; // Only populated if resultType is an error
-
-        BasicResult( ResultBase::Type type, std::string const &message )
-        :   ResultValueBase<T>(type),
-            m_errorMessage(message)
-        {
-            assert( m_type != ResultBase::Ok );
-        }
-
-        using ResultValueBase<T>::ResultValueBase;
-        using ResultBase::m_type;
-    };
-
-    enum class ParseResultType {
-        Matched, NoMatch, ShortCircuitAll, ShortCircuitSame
-    };
-
-    class ParseState {
-    public:
-
-        ParseState( ParseResultType type, TokenStream const &remainingTokens )
-        : m_type(type),
-          m_remainingTokens( remainingTokens )
-        {}
-
-        auto type() const -> ParseResultType { return m_type; }
-        auto remainingTokens() const -> TokenStream { return m_remainingTokens; }
-
-    private:
-        ParseResultType m_type;
-        TokenStream m_remainingTokens;
-    };
-
-    using Result = BasicResult<void>;
-    using ParserResult = BasicResult<ParseResultType>;
-    using InternalParseResult = BasicResult<ParseState>;
-
-    struct HelpColumns {
-        std::string left;
-        std::string right;
-    };
-
-    template<typename T>
-    inline auto convertInto( std::string const &source, T& target ) -> ParserResult {
-        std::stringstream ss;
-        ss << source;
-        ss >> target;
-        if( ss.fail() )
-            return ParserResult::runtimeError( "Unable to convert '" + source + "' to destination type" );
-        else
-            return ParserResult::ok( ParseResultType::Matched );
-    }
-    inline auto convertInto( std::string const &source, std::string& target ) -> ParserResult {
-        target = source;
-        return ParserResult::ok( ParseResultType::Matched );
-    }
-    inline auto convertInto( std::string const &source, bool &target ) -> ParserResult {
-        std::string srcLC = source;
-        std::transform( srcLC.begin(), srcLC.end(), srcLC.begin(), []( unsigned char c ) { return static_cast<char>( std::tolower(c) ); } );
-        if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
-            target = true;
-        else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")
-            target = false;
-        else
-            return ParserResult::runtimeError( "Expected a boolean value but did not recognise: '" + source + "'" );
-        return ParserResult::ok( ParseResultType::Matched );
-    }
+            inline auto convertInto(std::string const& source, bool& target) -> ParserResult {
+                std::string srcLC = source;
+                std::transform(srcLC.begin(), srcLC.end(), srcLC.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
+                    target = true;
+                else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")
+                    target = false;
+                else
+                    return ParserResult::runtimeError("Expected a boolean value but did not recognise: '" + source + "'");
+                return ParserResult::ok(ParseResultType::Matched);
+            }
 #ifdef CLARA_CONFIG_OPTIONAL_TYPE
-    template<typename T>
-    inline auto convertInto( std::string const &source, CLARA_CONFIG_OPTIONAL_TYPE<T>& target ) -> ParserResult {
-        T temp;
-        auto result = convertInto( source, temp );
-        if( result )
-            target = std::move(temp);
-        return result;
-    }
+            template<typename T>
+            inline auto convertInto(std::string const& source, CLARA_CONFIG_OPTIONAL_TYPE<T>& target) -> ParserResult {
+                T temp;
+                auto result = convertInto(source, temp);
+                if (result)
+                    target = std::move(temp);
+                return result;
+            }
 #endif // CLARA_CONFIG_OPTIONAL_TYPE
 
-    struct NonCopyable {
-        NonCopyable() = default;
-        NonCopyable( NonCopyable const & ) = delete;
-        NonCopyable( NonCopyable && ) = delete;
-        NonCopyable &operator=( NonCopyable const & ) = delete;
-        NonCopyable &operator=( NonCopyable && ) = delete;
-    };
-
-    struct BoundRef : NonCopyable {
-        virtual ~BoundRef() = default;
-        virtual auto isContainer() const -> bool { return false; }
-        virtual auto isFlag() const -> bool { return false; }
-    };
-    struct BoundValueRefBase : BoundRef {
-        virtual auto setValue( std::string const &arg ) -> ParserResult = 0;
-    };
-    struct BoundFlagRefBase : BoundRef {
-        virtual auto setFlag( bool flag ) -> ParserResult = 0;
-        virtual auto isFlag() const -> bool { return true; }
-    };
-
-    template<typename T>
-    struct BoundValueRef : BoundValueRefBase {
-        T &m_ref;
-
-        explicit BoundValueRef( T &ref ) : m_ref( ref ) {}
-
-        auto setValue( std::string const &arg ) -> ParserResult override {
-            return convertInto( arg, m_ref );
-        }
-    };
-
-    template<typename T>
-    struct BoundValueRef<std::vector<T>> : BoundValueRefBase {
-        std::vector<T> &m_ref;
-
-        explicit BoundValueRef( std::vector<T> &ref ) : m_ref( ref ) {}
-
-        auto isContainer() const -> bool override { return true; }
-
-        auto setValue( std::string const &arg ) -> ParserResult override {
-            T temp;
-            auto result = convertInto( arg, temp );
-            if( result )
-                m_ref.push_back( temp );
-            return result;
-        }
-    };
-
-    struct BoundFlagRef : BoundFlagRefBase {
-        bool &m_ref;
-
-        explicit BoundFlagRef( bool &ref ) : m_ref( ref ) {}
-
-        auto setFlag( bool flag ) -> ParserResult override {
-            m_ref = flag;
-            return ParserResult::ok( ParseResultType::Matched );
-        }
-    };
-
-    template<typename ReturnType>
-    struct LambdaInvoker {
-        static_assert( std::is_same<ReturnType, ParserResult>::value, "Lambda must return void or clara::ParserResult" );
-
-        template<typename L, typename ArgType>
-        static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
-            return lambda( arg );
-        }
-    };
-
-    template<>
-    struct LambdaInvoker<void> {
-        template<typename L, typename ArgType>
-        static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
-            lambda( arg );
-            return ParserResult::ok( ParseResultType::Matched );
-        }
-    };
-
-    template<typename ArgType, typename L>
-    inline auto invokeLambda( L const &lambda, std::string const &arg ) -> ParserResult {
-        ArgType temp{};
-        auto result = convertInto( arg, temp );
-        return !result
-           ? result
-           : LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( lambda, temp );
-    }
-
-    template<typename L>
-    struct BoundLambda : BoundValueRefBase {
-        L m_lambda;
-
-        static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
-        explicit BoundLambda( L const &lambda ) : m_lambda( lambda ) {}
-
-        auto setValue( std::string const &arg ) -> ParserResult override {
-            return invokeLambda<typename UnaryLambdaTraits<L>::ArgType>( m_lambda, arg );
-        }
-    };
-
-    template<typename L>
-    struct BoundFlagLambda : BoundFlagRefBase {
-        L m_lambda;
-
-        static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
-        static_assert( std::is_same<typename UnaryLambdaTraits<L>::ArgType, bool>::value, "flags must be boolean" );
-
-        explicit BoundFlagLambda( L const &lambda ) : m_lambda( lambda ) {}
-
-        auto setFlag( bool flag ) -> ParserResult override {
-            return LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( m_lambda, flag );
-        }
-    };
-
-    enum class Optionality { Optional, Required };
-
-    struct Parser;
-
-    class ParserBase {
-    public:
-        virtual ~ParserBase() = default;
-        virtual auto validate() const -> Result { return Result::ok(); }
-        virtual auto parse( std::string const& exeName, TokenStream const &tokens) const -> InternalParseResult  = 0;
-        virtual auto cardinality() const -> size_t { return 1; }
-
-        auto parse( Args const &args ) const -> InternalParseResult {
-            return parse( args.exeName(), TokenStream( args ) );
-        }
-    };
-
-    template<typename DerivedT>
-    class ComposableParserImpl : public ParserBase {
-    public:
-        template<typename T>
-        auto operator|( T const &other ) const -> Parser;
-
-		template<typename T>
-        auto operator+( T const &other ) const -> Parser;
-    };
-
-    // Common code and state for Args and Opts
-    template<typename DerivedT>
-    class ParserRefImpl : public ComposableParserImpl<DerivedT> {
-    protected:
-        Optionality m_optionality = Optionality::Optional;
-        std::shared_ptr<BoundRef> m_ref;
-        std::string m_hint;
-        std::string m_description;
-
-        explicit ParserRefImpl( std::shared_ptr<BoundRef> const &ref ) : m_ref( ref ) {}
-
-    public:
-        template<typename T>
-        ParserRefImpl( T &ref, std::string const &hint )
-        :   m_ref( std::make_shared<BoundValueRef<T>>( ref ) ),
-            m_hint( hint )
-        {}
-
-        template<typename LambdaT>
-        ParserRefImpl( LambdaT const &ref, std::string const &hint )
-        :   m_ref( std::make_shared<BoundLambda<LambdaT>>( ref ) ),
-            m_hint(hint)
-        {}
-
-        auto operator()( std::string const &description ) -> DerivedT & {
-            m_description = description;
-            return static_cast<DerivedT &>( *this );
-        }
-
-        auto optional() -> DerivedT & {
-            m_optionality = Optionality::Optional;
-            return static_cast<DerivedT &>( *this );
-        };
-
-        auto required() -> DerivedT & {
-            m_optionality = Optionality::Required;
-            return static_cast<DerivedT &>( *this );
-        };
-
-        auto isOptional() const -> bool {
-            return m_optionality == Optionality::Optional;
-        }
-
-        auto cardinality() const -> size_t override {
-            if( m_ref->isContainer() )
-                return 0;
-            else
-                return 1;
-        }
-
-        auto hint() const -> std::string { return m_hint; }
-    };
-
-    class ExeName : public ComposableParserImpl<ExeName> {
-        std::shared_ptr<std::string> m_name;
-        std::shared_ptr<BoundValueRefBase> m_ref;
-
-        template<typename LambdaT>
-        static auto makeRef(LambdaT const &lambda) -> std::shared_ptr<BoundValueRefBase> {
-            return std::make_shared<BoundLambda<LambdaT>>( lambda) ;
-        }
-
-    public:
-        ExeName() : m_name( std::make_shared<std::string>( "<executable>" ) ) {}
-
-        explicit ExeName( std::string &ref ) : ExeName() {
-            m_ref = std::make_shared<BoundValueRef<std::string>>( ref );
-        }
-
-        template<typename LambdaT>
-        explicit ExeName( LambdaT const& lambda ) : ExeName() {
-            m_ref = std::make_shared<BoundLambda<LambdaT>>( lambda );
-        }
-
-        // The exe name is not parsed out of the normal tokens, but is handled specially
-        auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
-            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
-        }
-
-        auto name() const -> std::string { return *m_name; }
-        auto set( std::string const& newName ) -> ParserResult {
-
-            auto lastSlash = newName.find_last_of( "\\/" );
-            auto filename = ( lastSlash == std::string::npos )
-                    ? newName
-                    : newName.substr( lastSlash+1 );
-
-            *m_name = filename;
-            if( m_ref )
-                return m_ref->setValue( filename );
-            else
-                return ParserResult::ok( ParseResultType::Matched );
-        }
-    };
-
-    class Arg : public ParserRefImpl<Arg> {
-    public:
-        using ParserRefImpl::ParserRefImpl;
-
-        auto parse( std::string const &, TokenStream const &tokens ) const -> InternalParseResult override {
-            auto validationResult = validate();
-            if( !validationResult )
-                return InternalParseResult( validationResult );
-
-            auto remainingTokens = tokens;
-            auto const &token = *remainingTokens;
-            if( token.type != TokenType::Argument )
-                return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
-
-            assert( !m_ref->isFlag() );
-            auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
-
-            auto result = valueRef->setValue( remainingTokens->token );
-            if( !result )
-                return InternalParseResult( result );
-            else
-                return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
-        }
-    };
-
-    inline auto normaliseOpt( std::string const &optName ) -> std::string {
-#ifdef CATCH_PLATFORM_WINDOWS
-        if( optName[0] == '/' )
-            return "-" + optName.substr( 1 );
-        else
-#endif
-            return optName;
-    }
-
-    class Opt : public ParserRefImpl<Opt> {
-    protected:
-        std::vector<std::string> m_optNames;
-
-    public:
-        template<typename LambdaT>
-        explicit Opt( LambdaT const &ref ) : ParserRefImpl( std::make_shared<BoundFlagLambda<LambdaT>>( ref ) ) {}
-
-        explicit Opt( bool &ref ) : ParserRefImpl( std::make_shared<BoundFlagRef>( ref ) ) {}
-
-        template<typename LambdaT>
-        Opt( LambdaT const &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
-
-        template<typename T>
-        Opt( T &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
-
-        auto operator[]( std::string const &optName ) -> Opt & {
-            m_optNames.push_back( optName );
-            return *this;
-        }
-
-        auto getHelpColumns() const -> std::vector<HelpColumns> {
-            std::ostringstream oss;
-            bool first = true;
-            for( auto const &opt : m_optNames ) {
-                if (first)
-                    first = false;
-                else
-                    oss << ", ";
-                oss << opt;
-            }
-            if( !m_hint.empty() )
-                oss << " <" << m_hint << ">";
-            return { { oss.str(), m_description } };
-        }
-
-        auto isMatch( std::string const &optToken ) const -> bool {
-            auto normalisedToken = normaliseOpt( optToken );
-            for( auto const &name : m_optNames ) {
-                if( normaliseOpt( name ) == normalisedToken )
-                    return true;
-            }
-            return false;
-        }
-
-        using ParserBase::parse;
-
-        auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
-            auto validationResult = validate();
-            if( !validationResult )
-                return InternalParseResult( validationResult );
-
-            auto remainingTokens = tokens;
-            if( remainingTokens && remainingTokens->type == TokenType::Option ) {
-                auto const &token = *remainingTokens;
-                if( isMatch(token.token ) ) {
-                    if( m_ref->isFlag() ) {
-                        auto flagRef = static_cast<detail::BoundFlagRefBase*>( m_ref.get() );
-                        auto result = flagRef->setFlag( true );
-                        if( !result )
-                            return InternalParseResult( result );
-                        if( result.value() == ParseResultType::ShortCircuitAll )
-                            return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
-                    } else {
-                        auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
-                        ++remainingTokens;
-                        if( !remainingTokens )
-                            return InternalParseResult::runtimeError( "Expected argument following " + token.token );
-                        auto const &argToken = *remainingTokens;
-                        if( argToken.type != TokenType::Argument )
-                            return InternalParseResult::runtimeError( "Expected argument following " + token.token );
-                        auto result = valueRef->setValue( argToken.token );
-                        if( !result )
-                            return InternalParseResult( result );
-                        if( result.value() == ParseResultType::ShortCircuitAll )
-                            return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
-                    }
-                    return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
-                }
-            }
-            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
-        }
-
-        auto validate() const -> Result override {
-            if( m_optNames.empty() )
-                return Result::logicError( "No options supplied to Opt" );
-            for( auto const &name : m_optNames ) {
-                if( name.empty() )
-                    return Result::logicError( "Option name cannot be empty" );
-#ifdef CATCH_PLATFORM_WINDOWS
-                if( name[0] != '-' && name[0] != '/' )
-                    return Result::logicError( "Option name must begin with '-' or '/'" );
-#else
-                if( name[0] != '-' )
-                    return Result::logicError( "Option name must begin with '-'" );
-#endif
-            }
-            return ParserRefImpl::validate();
-        }
-    };
-
-    struct Help : Opt {
-        Help( bool &showHelpFlag )
-        :   Opt([&]( bool flag ) {
-                showHelpFlag = flag;
-                return ParserResult::ok( ParseResultType::ShortCircuitAll );
-            })
-        {
-            static_cast<Opt &>( *this )
-                    ("display usage information")
-                    ["-?"]["-h"]["--help"]
-                    .optional();
-        }
-    };
-
-    struct Parser : ParserBase {
-
-        mutable ExeName m_exeName;
-        std::vector<Opt> m_options;
-        std::vector<Arg> m_args;
-
-        auto operator|=( ExeName const &exeName ) -> Parser & {
-            m_exeName = exeName;
-            return *this;
-        }
-
-        auto operator|=( Arg const &arg ) -> Parser & {
-            m_args.push_back(arg);
-            return *this;
-        }
-
-        auto operator|=( Opt const &opt ) -> Parser & {
-            m_options.push_back(opt);
-            return *this;
-        }
-
-        auto operator|=( Parser const &other ) -> Parser & {
-            m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
-            m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
-            return *this;
-        }
-
-        template<typename T>
-        auto operator|( T const &other ) const -> Parser {
-            return Parser( *this ) |= other;
-        }
-
-        // Forward deprecated interface with '+' instead of '|'
-        template<typename T>
-        auto operator+=( T const &other ) -> Parser & { return operator|=( other ); }
-        template<typename T>
-        auto operator+( T const &other ) const -> Parser { return operator|( other ); }
-
-        auto getHelpColumns() const -> std::vector<HelpColumns> {
-            std::vector<HelpColumns> cols;
-            for (auto const &o : m_options) {
-                auto childCols = o.getHelpColumns();
-                cols.insert( cols.end(), childCols.begin(), childCols.end() );
-            }
-            return cols;
-        }
-
-        void writeToStream( std::ostream &os ) const {
-            if (!m_exeName.name().empty()) {
-                os << "usage:\n" << "  " << m_exeName.name() << " ";
-                bool required = true, first = true;
-                for( auto const &arg : m_args ) {
-                    if (first)
-                        first = false;
-                    else
-                        os << " ";
-                    if( arg.isOptional() && required ) {
-                        os << "[";
-                        required = false;
-                    }
-                    os << "<" << arg.hint() << ">";
-                    if( arg.cardinality() == 0 )
-                        os << " ... ";
-                }
-                if( !required )
-                    os << "]";
-                if( !m_options.empty() )
-                    os << " options";
-                os << "\n\nwhere options are:" << std::endl;
-            }
-
-            auto rows = getHelpColumns();
-            size_t consoleWidth = CATCH_CLARA_CONFIG_CONSOLE_WIDTH;
-            size_t optWidth = 0;
-            for( auto const &cols : rows )
-                optWidth = (std::max)(optWidth, cols.left.size() + 2);
-
-            optWidth = (std::min)(optWidth, consoleWidth/2);
-
-            for( auto const &cols : rows ) {
-                auto row =
-                        TextFlow::Column( cols.left ).width( optWidth ).indent( 2 ) +
-                        TextFlow::Spacer(4) +
-                        TextFlow::Column( cols.right ).width( consoleWidth - 7 - optWidth );
-                os << row << std::endl;
-            }
-        }
-
-        friend auto operator<<( std::ostream &os, Parser const &parser ) -> std::ostream& {
-            parser.writeToStream( os );
-            return os;
-        }
-
-        auto validate() const -> Result override {
-            for( auto const &opt : m_options ) {
-                auto result = opt.validate();
-                if( !result )
-                    return result;
-            }
-            for( auto const &arg : m_args ) {
-                auto result = arg.validate();
-                if( !result )
-                    return result;
-            }
-            return Result::ok();
-        }
-
-        using ParserBase::parse;
-
-        auto parse( std::string const& exeName, TokenStream const &tokens ) const -> InternalParseResult override {
-
-            struct ParserInfo {
-                ParserBase const* parser = nullptr;
-                size_t count = 0;
+            struct NonCopyable {
+                NonCopyable() = default;
+                NonCopyable(NonCopyable const&) = delete;
+                NonCopyable(NonCopyable&&) = delete;
+                NonCopyable& operator=(NonCopyable const&) = delete;
+                NonCopyable& operator=(NonCopyable&&) = delete;
             };
-            const size_t totalParsers = m_options.size() + m_args.size();
-            assert( totalParsers < 512 );
-            // ParserInfo parseInfos[totalParsers]; // <-- this is what we really want to do
-            ParserInfo parseInfos[512];
 
-            {
-                size_t i = 0;
-                for (auto const &opt : m_options) parseInfos[i++].parser = &opt;
-                for (auto const &arg : m_args) parseInfos[i++].parser = &arg;
+            struct BoundRef : NonCopyable {
+                virtual ~BoundRef() = default;
+                virtual auto isContainer() const -> bool { return false; }
+                virtual auto isFlag() const -> bool { return false; }
+            };
+            struct BoundValueRefBase : BoundRef {
+                virtual auto setValue(std::string const& arg) -> ParserResult = 0;
+            };
+            struct BoundFlagRefBase : BoundRef {
+                virtual auto setFlag(bool flag) -> ParserResult = 0;
+                virtual auto isFlag() const -> bool { return true; }
+            };
+
+            template<typename T>
+            struct BoundValueRef : BoundValueRefBase {
+                T& m_ref;
+
+                explicit BoundValueRef(T& ref) : m_ref(ref) {}
+
+                auto setValue(std::string const& arg) -> ParserResult override {
+                    return convertInto(arg, m_ref);
+                }
+            };
+
+            template<typename T>
+            struct BoundValueRef<std::vector<T>> : BoundValueRefBase {
+                std::vector<T>& m_ref;
+
+                explicit BoundValueRef(std::vector<T>& ref) : m_ref(ref) {}
+
+                auto isContainer() const -> bool override { return true; }
+
+                auto setValue(std::string const& arg) -> ParserResult override {
+                    T temp;
+                    auto result = convertInto(arg, temp);
+                    if (result)
+                        m_ref.push_back(temp);
+                    return result;
+                }
+            };
+
+            struct BoundFlagRef : BoundFlagRefBase {
+                bool& m_ref;
+
+                explicit BoundFlagRef(bool& ref) : m_ref(ref) {}
+
+                auto setFlag(bool flag) -> ParserResult override {
+                    m_ref = flag;
+                    return ParserResult::ok(ParseResultType::Matched);
+                }
+            };
+
+            template<typename ReturnType>
+            struct LambdaInvoker {
+                static_assert(std::is_same<ReturnType, ParserResult>::value, "Lambda must return void or clara::ParserResult");
+
+                template<typename L, typename ArgType>
+                static auto invoke(L const& lambda, ArgType const& arg) -> ParserResult {
+                    return lambda(arg);
+                }
+            };
+
+            template<>
+            struct LambdaInvoker<void> {
+                template<typename L, typename ArgType>
+                static auto invoke(L const& lambda, ArgType const& arg) -> ParserResult {
+                    lambda(arg);
+                    return ParserResult::ok(ParseResultType::Matched);
+                }
+            };
+
+            template<typename ArgType, typename L>
+            inline auto invokeLambda(L const& lambda, std::string const& arg) -> ParserResult {
+                ArgType temp{};
+                auto result = convertInto(arg, temp);
+                return !result
+                    ? result
+                    : LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke(lambda, temp);
             }
 
-            m_exeName.set( exeName );
+            template<typename L>
+            struct BoundLambda : BoundValueRefBase {
+                L m_lambda;
 
-            auto result = InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
-            while( result.value().remainingTokens() ) {
-                bool tokenParsed = false;
+                static_assert(UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument");
+                explicit BoundLambda(L const& lambda) : m_lambda(lambda) {}
 
-                for( size_t i = 0; i < totalParsers; ++i ) {
-                    auto&  parseInfo = parseInfos[i];
-                    if( parseInfo.parser->cardinality() == 0 || parseInfo.count < parseInfo.parser->cardinality() ) {
-                        result = parseInfo.parser->parse(exeName, result.value().remainingTokens());
-                        if (!result)
-                            return result;
-                        if (result.value().type() != ParseResultType::NoMatch) {
-                            tokenParsed = true;
-                            ++parseInfo.count;
-                            break;
+                auto setValue(std::string const& arg) -> ParserResult override {
+                    return invokeLambda<typename UnaryLambdaTraits<L>::ArgType>(m_lambda, arg);
+                }
+            };
+
+            template<typename L>
+            struct BoundFlagLambda : BoundFlagRefBase {
+                L m_lambda;
+
+                static_assert(UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument");
+                static_assert(std::is_same<typename UnaryLambdaTraits<L>::ArgType, bool>::value, "flags must be boolean");
+
+                explicit BoundFlagLambda(L const& lambda) : m_lambda(lambda) {}
+
+                auto setFlag(bool flag) -> ParserResult override {
+                    return LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke(m_lambda, flag);
+                }
+            };
+
+            enum class Optionality { Optional, Required };
+
+            struct Parser;
+
+            class ParserBase {
+            public:
+                virtual ~ParserBase() = default;
+                virtual auto validate() const -> Result { return Result::ok(); }
+                virtual auto parse(std::string const& exeName, TokenStream const& tokens) const->InternalParseResult = 0;
+                virtual auto cardinality() const -> size_t { return 1; }
+
+                auto parse(Args const& args) const -> InternalParseResult {
+                    return parse(args.exeName(), TokenStream(args));
+                }
+            };
+
+            template<typename DerivedT>
+            class ComposableParserImpl : public ParserBase {
+            public:
+                template<typename T>
+                auto operator|(T const& other) const->Parser;
+
+                template<typename T>
+                auto operator+(T const& other) const->Parser;
+            };
+
+            // Common code and state for Args and Opts
+            template<typename DerivedT>
+            class ParserRefImpl : public ComposableParserImpl<DerivedT> {
+            protected:
+                Optionality m_optionality = Optionality::Optional;
+                std::shared_ptr<BoundRef> m_ref;
+                std::string m_hint;
+                std::string m_description;
+
+                explicit ParserRefImpl(std::shared_ptr<BoundRef> const& ref) : m_ref(ref) {}
+
+            public:
+                template<typename T>
+                ParserRefImpl(T& ref, std::string const& hint)
+                    : m_ref(std::make_shared<BoundValueRef<T>>(ref)),
+                    m_hint(hint)
+                {}
+
+                template<typename LambdaT>
+                ParserRefImpl(LambdaT const& ref, std::string const& hint)
+                    : m_ref(std::make_shared<BoundLambda<LambdaT>>(ref)),
+                    m_hint(hint)
+                {}
+
+                auto operator()(std::string const& description) -> DerivedT& {
+                    m_description = description;
+                    return static_cast<DerivedT&>(*this);
+                }
+
+                auto optional() -> DerivedT& {
+                    m_optionality = Optionality::Optional;
+                    return static_cast<DerivedT&>(*this);
+                };
+
+                auto required() -> DerivedT& {
+                    m_optionality = Optionality::Required;
+                    return static_cast<DerivedT&>(*this);
+                };
+
+                auto isOptional() const -> bool {
+                    return m_optionality == Optionality::Optional;
+                }
+
+                auto cardinality() const -> size_t override {
+                    if (m_ref->isContainer())
+                        return 0;
+                    else
+                        return 1;
+                }
+
+                auto hint() const -> std::string { return m_hint; }
+            };
+
+            class ExeName : public ComposableParserImpl<ExeName> {
+                std::shared_ptr<std::string> m_name;
+                std::shared_ptr<BoundValueRefBase> m_ref;
+
+                template<typename LambdaT>
+                static auto makeRef(LambdaT const& lambda) -> std::shared_ptr<BoundValueRefBase> {
+                    return std::make_shared<BoundLambda<LambdaT>>(lambda);
+                }
+
+            public:
+                ExeName() : m_name(std::make_shared<std::string>("<executable>")) {}
+
+                explicit ExeName(std::string& ref) : ExeName() {
+                    m_ref = std::make_shared<BoundValueRef<std::string>>(ref);
+                }
+
+                template<typename LambdaT>
+                explicit ExeName(LambdaT const& lambda) : ExeName() {
+                    m_ref = std::make_shared<BoundLambda<LambdaT>>(lambda);
+                }
+
+                // The exe name is not parsed out of the normal tokens, but is handled specially
+                auto parse(std::string const&, TokenStream const& tokens) const -> InternalParseResult override {
+                    return InternalParseResult::ok(ParseState(ParseResultType::NoMatch, tokens));
+                }
+
+                auto name() const -> std::string { return *m_name; }
+                auto set(std::string const& newName) -> ParserResult {
+
+                    auto lastSlash = newName.find_last_of("\\/");
+                    auto filename = (lastSlash == std::string::npos)
+                        ? newName
+                        : newName.substr(lastSlash + 1);
+
+                    *m_name = filename;
+                    if (m_ref)
+                        return m_ref->setValue(filename);
+                    else
+                        return ParserResult::ok(ParseResultType::Matched);
+                }
+            };
+
+            class Arg : public ParserRefImpl<Arg> {
+            public:
+                using ParserRefImpl::ParserRefImpl;
+
+                auto parse(std::string const&, TokenStream const& tokens) const -> InternalParseResult override {
+                    auto validationResult = validate();
+                    if (!validationResult)
+                        return InternalParseResult(validationResult);
+
+                    auto remainingTokens = tokens;
+                    auto const& token = *remainingTokens;
+                    if (token.type != TokenType::Argument)
+                        return InternalParseResult::ok(ParseState(ParseResultType::NoMatch, remainingTokens));
+
+                    assert(!m_ref->isFlag());
+                    auto valueRef = static_cast<detail::BoundValueRefBase*>(m_ref.get());
+
+                    auto result = valueRef->setValue(remainingTokens->token);
+                    if (!result)
+                        return InternalParseResult(result);
+                    else
+                        return InternalParseResult::ok(ParseState(ParseResultType::Matched, ++remainingTokens));
+                }
+            };
+
+            inline auto normaliseOpt(std::string const& optName) -> std::string {
+#ifdef CATCH_PLATFORM_WINDOWS
+                if (optName[0] == '/')
+                    return "-" + optName.substr(1);
+                else
+#endif
+                    return optName;
+            }
+
+            class Opt : public ParserRefImpl<Opt> {
+            protected:
+                std::vector<std::string> m_optNames;
+
+            public:
+                template<typename LambdaT>
+                explicit Opt(LambdaT const& ref) : ParserRefImpl(std::make_shared<BoundFlagLambda<LambdaT>>(ref)) {}
+
+                explicit Opt(bool& ref) : ParserRefImpl(std::make_shared<BoundFlagRef>(ref)) {}
+
+                template<typename LambdaT>
+                Opt(LambdaT const& ref, std::string const& hint) : ParserRefImpl(ref, hint) {}
+
+                template<typename T>
+                Opt(T& ref, std::string const& hint) : ParserRefImpl(ref, hint) {}
+
+                auto operator[](std::string const& optName) -> Opt& {
+                    m_optNames.push_back(optName);
+                    return *this;
+                }
+
+                auto getHelpColumns() const -> std::vector<HelpColumns> {
+                    std::ostringstream oss;
+                    bool first = true;
+                    for (auto const& opt : m_optNames) {
+                        if (first)
+                            first = false;
+                        else
+                            oss << ", ";
+                        oss << opt;
+                    }
+                    if (!m_hint.empty())
+                        oss << " <" << m_hint << ">";
+                    return { { oss.str(), m_description } };
+                }
+
+                auto isMatch(std::string const& optToken) const -> bool {
+                    auto normalisedToken = normaliseOpt(optToken);
+                    for (auto const& name : m_optNames) {
+                        if (normaliseOpt(name) == normalisedToken)
+                            return true;
+                    }
+                    return false;
+                }
+
+                using ParserBase::parse;
+
+                auto parse(std::string const&, TokenStream const& tokens) const -> InternalParseResult override {
+                    auto validationResult = validate();
+                    if (!validationResult)
+                        return InternalParseResult(validationResult);
+
+                    auto remainingTokens = tokens;
+                    if (remainingTokens && remainingTokens->type == TokenType::Option) {
+                        auto const& token = *remainingTokens;
+                        if (isMatch(token.token)) {
+                            if (m_ref->isFlag()) {
+                                auto flagRef = static_cast<detail::BoundFlagRefBase*>(m_ref.get());
+                                auto result = flagRef->setFlag(true);
+                                if (!result)
+                                    return InternalParseResult(result);
+                                if (result.value() == ParseResultType::ShortCircuitAll)
+                                    return InternalParseResult::ok(ParseState(result.value(), remainingTokens));
+                            }
+                            else {
+                                auto valueRef = static_cast<detail::BoundValueRefBase*>(m_ref.get());
+                                ++remainingTokens;
+                                if (!remainingTokens)
+                                    return InternalParseResult::runtimeError("Expected argument following " + token.token);
+                                auto const& argToken = *remainingTokens;
+                                if (argToken.type != TokenType::Argument)
+                                    return InternalParseResult::runtimeError("Expected argument following " + token.token);
+                                auto result = valueRef->setValue(argToken.token);
+                                if (!result)
+                                    return InternalParseResult(result);
+                                if (result.value() == ParseResultType::ShortCircuitAll)
+                                    return InternalParseResult::ok(ParseState(result.value(), remainingTokens));
+                            }
+                            return InternalParseResult::ok(ParseState(ParseResultType::Matched, ++remainingTokens));
                         }
                     }
+                    return InternalParseResult::ok(ParseState(ParseResultType::NoMatch, remainingTokens));
                 }
 
-                if( result.value().type() == ParseResultType::ShortCircuitAll )
+                auto validate() const -> Result override {
+                    if (m_optNames.empty())
+                        return Result::logicError("No options supplied to Opt");
+                    for (auto const& name : m_optNames) {
+                        if (name.empty())
+                            return Result::logicError("Option name cannot be empty");
+#ifdef CATCH_PLATFORM_WINDOWS
+                        if (name[0] != '-' && name[0] != '/')
+                            return Result::logicError("Option name must begin with '-' or '/'");
+#else
+                        if (name[0] != '-')
+                            return Result::logicError("Option name must begin with '-'");
+#endif
+                    }
+                    return ParserRefImpl::validate();
+                }
+            };
+
+            struct Help : Opt {
+                Help(bool& showHelpFlag)
+                    : Opt([&](bool flag) {
+                    showHelpFlag = flag;
+                    return ParserResult::ok(ParseResultType::ShortCircuitAll);
+                        })
+                {
+                    static_cast<Opt&>(*this)
+                        ("display usage information")
+                        ["-?"]["-h"]["--help"]
+                        .optional();
+                }
+            };
+
+            struct Parser : ParserBase {
+
+                mutable ExeName m_exeName;
+                std::vector<Opt> m_options;
+                std::vector<Arg> m_args;
+
+                auto operator|=(ExeName const& exeName) -> Parser& {
+                    m_exeName = exeName;
+                    return *this;
+                }
+
+                auto operator|=(Arg const& arg) -> Parser& {
+                    m_args.push_back(arg);
+                    return *this;
+                }
+
+                auto operator|=(Opt const& opt) -> Parser& {
+                    m_options.push_back(opt);
+                    return *this;
+                }
+
+                auto operator|=(Parser const& other) -> Parser& {
+                    m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
+                    m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
+                    return *this;
+                }
+
+                template<typename T>
+                auto operator|(T const& other) const -> Parser {
+                    return Parser(*this) |= other;
+                }
+
+                // Forward deprecated interface with '+' instead of '|'
+                template<typename T>
+                auto operator+=(T const& other) -> Parser& { return operator|=(other); }
+                template<typename T>
+                auto operator+(T const& other) const -> Parser { return operator|(other); }
+
+                auto getHelpColumns() const -> std::vector<HelpColumns> {
+                    std::vector<HelpColumns> cols;
+                    for (auto const& o : m_options) {
+                        auto childCols = o.getHelpColumns();
+                        cols.insert(cols.end(), childCols.begin(), childCols.end());
+                    }
+                    return cols;
+                }
+
+                void writeToStream(std::ostream& os) const {
+                    if (!m_exeName.name().empty()) {
+                        os << "usage:\n" << "  " << m_exeName.name() << " ";
+                        bool required = true, first = true;
+                        for (auto const& arg : m_args) {
+                            if (first)
+                                first = false;
+                            else
+                                os << " ";
+                            if (arg.isOptional() && required) {
+                                os << "[";
+                                required = false;
+                            }
+                            os << "<" << arg.hint() << ">";
+                            if (arg.cardinality() == 0)
+                                os << " ... ";
+                        }
+                        if (!required)
+                            os << "]";
+                        if (!m_options.empty())
+                            os << " options";
+                        os << "\n\nwhere options are:" << std::endl;
+                    }
+
+                    auto rows = getHelpColumns();
+                    size_t consoleWidth = CATCH_CLARA_CONFIG_CONSOLE_WIDTH;
+                    size_t optWidth = 0;
+                    for (auto const& cols : rows)
+                        optWidth = (std::max)(optWidth, cols.left.size() + 2);
+
+                    optWidth = (std::min)(optWidth, consoleWidth / 2);
+
+                    for (auto const& cols : rows) {
+                        auto row =
+                            TextFlow::Column(cols.left).width(optWidth).indent(2) +
+                            TextFlow::Spacer(4) +
+                            TextFlow::Column(cols.right).width(consoleWidth - 7 - optWidth);
+                        os << row << std::endl;
+                    }
+                }
+
+                friend auto operator<<(std::ostream& os, Parser const& parser) -> std::ostream& {
+                    parser.writeToStream(os);
+                    return os;
+                }
+
+                auto validate() const -> Result override {
+                    for (auto const& opt : m_options) {
+                        auto result = opt.validate();
+                        if (!result)
+                            return result;
+                    }
+                    for (auto const& arg : m_args) {
+                        auto result = arg.validate();
+                        if (!result)
+                            return result;
+                    }
+                    return Result::ok();
+                }
+
+                using ParserBase::parse;
+
+                auto parse(std::string const& exeName, TokenStream const& tokens) const -> InternalParseResult override {
+
+                    struct ParserInfo {
+                        ParserBase const* parser = nullptr;
+                        size_t count = 0;
+                    };
+                    const size_t totalParsers = m_options.size() + m_args.size();
+                    assert(totalParsers < 512);
+                    // ParserInfo parseInfos[totalParsers]; // <-- this is what we really want to do
+                    ParserInfo parseInfos[512];
+
+                    {
+                        size_t i = 0;
+                        for (auto const& opt : m_options) parseInfos[i++].parser = &opt;
+                        for (auto const& arg : m_args) parseInfos[i++].parser = &arg;
+                    }
+
+                    m_exeName.set(exeName);
+
+                    auto result = InternalParseResult::ok(ParseState(ParseResultType::NoMatch, tokens));
+                    while (result.value().remainingTokens()) {
+                        bool tokenParsed = false;
+
+                        for (size_t i = 0; i < totalParsers; ++i) {
+                            auto& parseInfo = parseInfos[i];
+                            if (parseInfo.parser->cardinality() == 0 || parseInfo.count < parseInfo.parser->cardinality()) {
+                                result = parseInfo.parser->parse(exeName, result.value().remainingTokens());
+                                if (!result)
+                                    return result;
+                                if (result.value().type() != ParseResultType::NoMatch) {
+                                    tokenParsed = true;
+                                    ++parseInfo.count;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (result.value().type() == ParseResultType::ShortCircuitAll)
+                            return result;
+                        if (!tokenParsed)
+                            return InternalParseResult::runtimeError("Unrecognised token: " + result.value().remainingTokens()->token);
+                    }
+                    // !TBD Check missing required options
                     return result;
-                if( !tokenParsed )
-                    return InternalParseResult::runtimeError( "Unrecognised token: " + result.value().remainingTokens()->token );
+                }
+            };
+
+            template<typename DerivedT>
+            template<typename T>
+            auto ComposableParserImpl<DerivedT>::operator|(T const& other) const -> Parser {
+                return Parser() | static_cast<DerivedT const&>(*this) | other;
             }
-            // !TBD Check missing required options
-            return result;
-        }
-    };
+        } // namespace detail
 
-    template<typename DerivedT>
-    template<typename T>
-    auto ComposableParserImpl<DerivedT>::operator|( T const &other ) const -> Parser {
-        return Parser() | static_cast<DerivedT const &>( *this ) | other;
+        // A Combined parser
+        using detail::Parser;
+
+        // A parser for options
+        using detail::Opt;
+
+        // A parser for arguments
+        using detail::Arg;
+
+        // Wrapper for argc, argv from main()
+        using detail::Args;
+
+        // Specifies the name of the executable
+        using detail::ExeName;
+
+        // Convenience wrapper for option parser that specifies the help option
+        using detail::Help;
+
+        // enum of result types from a parse
+        using detail::ParseResultType;
+
+        // Result type for parser operation
+        using detail::ParserResult;
+
     }
-} // namespace detail
-
-// A Combined parser
-using detail::Parser;
-
-// A parser for options
-using detail::Opt;
-
-// A parser for arguments
-using detail::Arg;
-
-// Wrapper for argc, argv from main()
-using detail::Args;
-
-// Specifies the name of the executable
-using detail::ExeName;
-
-// Convenience wrapper for option parser that specifies the help option
-using detail::Help;
-
-// enum of result types from a parse
-using detail::ParseResultType;
-
-// Result type for parser operation
-using detail::ParserResult;
-
-}} // namespace Catch::clara
+} // namespace Catch::clara
 
 // end clara.hpp
 #ifdef __clang__
@@ -9702,7 +9722,7 @@ using detail::ParserResult;
 // end catch_clara.h
 namespace Catch {
 
-    clara::Parser makeCommandLineParser( ConfigData& config );
+    clara::Parser makeCommandLineParser(ConfigData& config);
 
 } // end namespace Catch
 
@@ -9712,211 +9732,211 @@ namespace Catch {
 
 namespace Catch {
 
-    clara::Parser makeCommandLineParser( ConfigData& config ) {
+    clara::Parser makeCommandLineParser(ConfigData& config) {
 
         using namespace clara;
 
-        auto const setWarning = [&]( std::string const& warning ) {
-                auto warningSet = [&]() {
-                    if( warning == "NoAssertions" )
-                        return WarnAbout::NoAssertions;
+        auto const setWarning = [&](std::string const& warning) {
+            auto warningSet = [&]() {
+                if (warning == "NoAssertions")
+                    return WarnAbout::NoAssertions;
 
-                    if ( warning == "NoTests" )
-                        return WarnAbout::NoTests;
+                if (warning == "NoTests")
+                    return WarnAbout::NoTests;
 
-                    return WarnAbout::Nothing;
+                return WarnAbout::Nothing;
                 }();
 
                 if (warningSet == WarnAbout::Nothing)
-                    return ParserResult::runtimeError( "Unrecognised warning: '" + warning + "'" );
-                config.warnings = static_cast<WarnAbout::What>( config.warnings | warningSet );
-                return ParserResult::ok( ParseResultType::Matched );
+                    return ParserResult::runtimeError("Unrecognised warning: '" + warning + "'");
+                config.warnings = static_cast<WarnAbout::What>(config.warnings | warningSet);
+                return ParserResult::ok(ParseResultType::Matched);
             };
-        auto const loadTestNamesFromFile = [&]( std::string const& filename ) {
-                std::ifstream f( filename.c_str() );
-                if( !f.is_open() )
-                    return ParserResult::runtimeError( "Unable to load input file: '" + filename + "'" );
+        auto const loadTestNamesFromFile = [&](std::string const& filename) {
+            std::ifstream f(filename.c_str());
+            if (!f.is_open())
+                return ParserResult::runtimeError("Unable to load input file: '" + filename + "'");
 
-                std::string line;
-                while( std::getline( f, line ) ) {
-                    line = trim(line);
-                    if( !line.empty() && !startsWith( line, '#' ) ) {
-                        if( !startsWith( line, '"' ) )
-                            line = '"' + line + '"';
-                        config.testsOrTags.push_back( line );
-                        config.testsOrTags.emplace_back( "," );
-                    }
+            std::string line;
+            while (std::getline(f, line)) {
+                line = trim(line);
+                if (!line.empty() && !startsWith(line, '#')) {
+                    if (!startsWith(line, '"'))
+                        line = '"' + line + '"';
+                    config.testsOrTags.push_back(line);
+                    config.testsOrTags.emplace_back(",");
                 }
-                //Remove comma in the end
-                if(!config.testsOrTags.empty())
-                    config.testsOrTags.erase( config.testsOrTags.end()-1 );
+            }
+            //Remove comma in the end
+            if (!config.testsOrTags.empty())
+                config.testsOrTags.erase(config.testsOrTags.end() - 1);
 
-                return ParserResult::ok( ParseResultType::Matched );
+            return ParserResult::ok(ParseResultType::Matched);
             };
-        auto const setTestOrder = [&]( std::string const& order ) {
-                if( startsWith( "declared", order ) )
-                    config.runOrder = RunTests::InDeclarationOrder;
-                else if( startsWith( "lexical", order ) )
-                    config.runOrder = RunTests::InLexicographicalOrder;
-                else if( startsWith( "random", order ) )
-                    config.runOrder = RunTests::InRandomOrder;
-                else
-                    return clara::ParserResult::runtimeError( "Unrecognised ordering: '" + order + "'" );
-                return ParserResult::ok( ParseResultType::Matched );
+        auto const setTestOrder = [&](std::string const& order) {
+            if (startsWith("declared", order))
+                config.runOrder = RunTests::InDeclarationOrder;
+            else if (startsWith("lexical", order))
+                config.runOrder = RunTests::InLexicographicalOrder;
+            else if (startsWith("random", order))
+                config.runOrder = RunTests::InRandomOrder;
+            else
+                return clara::ParserResult::runtimeError("Unrecognised ordering: '" + order + "'");
+            return ParserResult::ok(ParseResultType::Matched);
             };
-        auto const setRngSeed = [&]( std::string const& seed ) {
-                if( seed != "time" )
-                    return clara::detail::convertInto( seed, config.rngSeed );
-                config.rngSeed = static_cast<unsigned int>( std::time(nullptr) );
-                return ParserResult::ok( ParseResultType::Matched );
+        auto const setRngSeed = [&](std::string const& seed) {
+            if (seed != "time")
+                return clara::detail::convertInto(seed, config.rngSeed);
+            config.rngSeed = static_cast<unsigned int>(std::time(nullptr));
+            return ParserResult::ok(ParseResultType::Matched);
             };
-        auto const setColourUsage = [&]( std::string const& useColour ) {
-                    auto mode = toLower( useColour );
+        auto const setColourUsage = [&](std::string const& useColour) {
+            auto mode = toLower(useColour);
 
-                    if( mode == "yes" )
-                        config.useColour = UseColour::Yes;
-                    else if( mode == "no" )
-                        config.useColour = UseColour::No;
-                    else if( mode == "auto" )
-                        config.useColour = UseColour::Auto;
-                    else
-                        return ParserResult::runtimeError( "colour mode must be one of: auto, yes or no. '" + useColour + "' not recognised" );
-                return ParserResult::ok( ParseResultType::Matched );
+            if (mode == "yes")
+                config.useColour = UseColour::Yes;
+            else if (mode == "no")
+                config.useColour = UseColour::No;
+            else if (mode == "auto")
+                config.useColour = UseColour::Auto;
+            else
+                return ParserResult::runtimeError("colour mode must be one of: auto, yes or no. '" + useColour + "' not recognised");
+            return ParserResult::ok(ParseResultType::Matched);
             };
-        auto const setWaitForKeypress = [&]( std::string const& keypress ) {
-                auto keypressLc = toLower( keypress );
-                if (keypressLc == "never")
-                    config.waitForKeypress = WaitForKeypress::Never;
-                else if( keypressLc == "start" )
-                    config.waitForKeypress = WaitForKeypress::BeforeStart;
-                else if( keypressLc == "exit" )
-                    config.waitForKeypress = WaitForKeypress::BeforeExit;
-                else if( keypressLc == "both" )
-                    config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
-                else
-                    return ParserResult::runtimeError( "keypress argument must be one of: never, start, exit or both. '" + keypress + "' not recognised" );
-            return ParserResult::ok( ParseResultType::Matched );
+        auto const setWaitForKeypress = [&](std::string const& keypress) {
+            auto keypressLc = toLower(keypress);
+            if (keypressLc == "never")
+                config.waitForKeypress = WaitForKeypress::Never;
+            else if (keypressLc == "start")
+                config.waitForKeypress = WaitForKeypress::BeforeStart;
+            else if (keypressLc == "exit")
+                config.waitForKeypress = WaitForKeypress::BeforeExit;
+            else if (keypressLc == "both")
+                config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
+            else
+                return ParserResult::runtimeError("keypress argument must be one of: never, start, exit or both. '" + keypress + "' not recognised");
+            return ParserResult::ok(ParseResultType::Matched);
             };
-        auto const setVerbosity = [&]( std::string const& verbosity ) {
-            auto lcVerbosity = toLower( verbosity );
-            if( lcVerbosity == "quiet" )
+        auto const setVerbosity = [&](std::string const& verbosity) {
+            auto lcVerbosity = toLower(verbosity);
+            if (lcVerbosity == "quiet")
                 config.verbosity = Verbosity::Quiet;
-            else if( lcVerbosity == "normal" )
+            else if (lcVerbosity == "normal")
                 config.verbosity = Verbosity::Normal;
-            else if( lcVerbosity == "high" )
+            else if (lcVerbosity == "high")
                 config.verbosity = Verbosity::High;
             else
-                return ParserResult::runtimeError( "Unrecognised verbosity, '" + verbosity + "'" );
-            return ParserResult::ok( ParseResultType::Matched );
-        };
-        auto const setReporter = [&]( std::string const& reporter ) {
+                return ParserResult::runtimeError("Unrecognised verbosity, '" + verbosity + "'");
+            return ParserResult::ok(ParseResultType::Matched);
+            };
+        auto const setReporter = [&](std::string const& reporter) {
             IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
 
-            auto lcReporter = toLower( reporter );
-            auto result = factories.find( lcReporter );
+            auto lcReporter = toLower(reporter);
+            auto result = factories.find(lcReporter);
 
-            if( factories.end() != result )
+            if (factories.end() != result)
                 config.reporterName = lcReporter;
             else
-                return ParserResult::runtimeError( "Unrecognized reporter, '" + reporter + "'. Check available with --list-reporters" );
-            return ParserResult::ok( ParseResultType::Matched );
-        };
+                return ParserResult::runtimeError("Unrecognized reporter, '" + reporter + "'. Check available with --list-reporters");
+            return ParserResult::ok(ParseResultType::Matched);
+            };
 
         auto cli
-            = ExeName( config.processName )
-            | Help( config.showHelp )
-            | Opt( config.listTests )
-                ["-l"]["--list-tests"]
-                ( "list all/matching test cases" )
-            | Opt( config.listTags )
-                ["-t"]["--list-tags"]
-                ( "list all/matching tags" )
-            | Opt( config.showSuccessfulTests )
-                ["-s"]["--success"]
-                ( "include successful tests in output" )
-            | Opt( config.shouldDebugBreak )
-                ["-b"]["--break"]
-                ( "break into debugger on failure" )
-            | Opt( config.noThrow )
-                ["-e"]["--nothrow"]
-                ( "skip exception tests" )
-            | Opt( config.showInvisibles )
-                ["-i"]["--invisibles"]
-                ( "show invisibles (tabs, newlines)" )
-            | Opt( config.outputFilename, "filename" )
-                ["-o"]["--out"]
-                ( "output filename" )
-            | Opt( setReporter, "name" )
-                ["-r"]["--reporter"]
-                ( "reporter to use (defaults to console)" )
-            | Opt( config.name, "name" )
-                ["-n"]["--name"]
-                ( "suite name" )
-            | Opt( [&]( bool ){ config.abortAfter = 1; } )
-                ["-a"]["--abort"]
-                ( "abort at first failure" )
-            | Opt( [&]( int x ){ config.abortAfter = x; }, "no. failures" )
-                ["-x"]["--abortx"]
-                ( "abort after x failures" )
-            | Opt( setWarning, "warning name" )
-                ["-w"]["--warn"]
-                ( "enable warnings" )
-            | Opt( [&]( bool flag ) { config.showDurations = flag ? ShowDurations::Always : ShowDurations::Never; }, "yes|no" )
-                ["-d"]["--durations"]
-                ( "show test durations" )
-            | Opt( config.minDuration, "seconds" )
-                ["-D"]["--min-duration"]
-                ( "show test durations for tests taking at least the given number of seconds" )
-            | Opt( loadTestNamesFromFile, "filename" )
-                ["-f"]["--input-file"]
-                ( "load test names to run from a file" )
-            | Opt( config.filenamesAsTags )
-                ["-#"]["--filenames-as-tags"]
-                ( "adds a tag for the filename" )
-            | Opt( config.sectionsToRun, "section name" )
-                ["-c"]["--section"]
-                ( "specify section to run" )
-            | Opt( setVerbosity, "quiet|normal|high" )
-                ["-v"]["--verbosity"]
-                ( "set output verbosity" )
-            | Opt( config.listTestNamesOnly )
-                ["--list-test-names-only"]
-                ( "list all/matching test cases names only" )
-            | Opt( config.listReporters )
-                ["--list-reporters"]
-                ( "list all reporters" )
-            | Opt( setTestOrder, "decl|lex|rand" )
-                ["--order"]
-                ( "test case order (defaults to decl)" )
-            | Opt( setRngSeed, "'time'|number" )
-                ["--rng-seed"]
-                ( "set a specific seed for random numbers" )
-            | Opt( setColourUsage, "yes|no" )
-                ["--use-colour"]
-                ( "should output be colourised" )
-            | Opt( config.libIdentify )
-                ["--libidentify"]
-                ( "report name and version according to libidentify standard" )
-            | Opt( setWaitForKeypress, "never|start|exit|both" )
-                ["--wait-for-keypress"]
-                ( "waits for a keypress before exiting" )
-            | Opt( config.benchmarkSamples, "samples" )
-                ["--benchmark-samples"]
-                ( "number of samples to collect (default: 100)" )
-            | Opt( config.benchmarkResamples, "resamples" )
-                ["--benchmark-resamples"]
-                ( "number of resamples for the bootstrap (default: 100000)" )
-            | Opt( config.benchmarkConfidenceInterval, "confidence interval" )
-                ["--benchmark-confidence-interval"]
-                ( "confidence interval for the bootstrap (between 0 and 1, default: 0.95)" )
-            | Opt( config.benchmarkNoAnalysis )
-                ["--benchmark-no-analysis"]
-                ( "perform only measurements; do not perform any analysis" )
-            | Opt( config.benchmarkWarmupTime, "benchmarkWarmupTime" )
-                ["--benchmark-warmup-time"]
-                ( "amount of time in milliseconds spent on warming up each test (default: 100)" )
-            | Arg( config.testsOrTags, "test name|pattern|tags" )
-                ( "which test or tests to use" );
+            = ExeName(config.processName)
+            | Help(config.showHelp)
+            | Opt(config.listTests)
+            ["-l"]["--list-tests"]
+            ("list all/matching test cases")
+            | Opt(config.listTags)
+            ["-t"]["--list-tags"]
+            ("list all/matching tags")
+            | Opt(config.showSuccessfulTests)
+            ["-s"]["--success"]
+            ("include successful tests in output")
+            | Opt(config.shouldDebugBreak)
+            ["-b"]["--break"]
+            ("break into debugger on failure")
+            | Opt(config.noThrow)
+            ["-e"]["--nothrow"]
+            ("skip exception tests")
+            | Opt(config.showInvisibles)
+            ["-i"]["--invisibles"]
+            ("show invisibles (tabs, newlines)")
+            | Opt(config.outputFilename, "filename")
+            ["-o"]["--out"]
+            ("output filename")
+            | Opt(setReporter, "name")
+            ["-r"]["--reporter"]
+            ("reporter to use (defaults to console)")
+            | Opt(config.name, "name")
+            ["-n"]["--name"]
+            ("suite name")
+            | Opt([&](bool) { config.abortAfter = 1; })
+            ["-a"]["--abort"]
+            ("abort at first failure")
+            | Opt([&](int x) { config.abortAfter = x; }, "no. failures")
+            ["-x"]["--abortx"]
+            ("abort after x failures")
+            | Opt(setWarning, "warning name")
+            ["-w"]["--warn"]
+            ("enable warnings")
+            | Opt([&](bool flag) { config.showDurations = flag ? ShowDurations::Always : ShowDurations::Never; }, "yes|no")
+            ["-d"]["--durations"]
+            ("show test durations")
+            | Opt(config.minDuration, "seconds")
+            ["-D"]["--min-duration"]
+            ("show test durations for tests taking at least the given number of seconds")
+            | Opt(loadTestNamesFromFile, "filename")
+            ["-f"]["--input-file"]
+            ("load test names to run from a file")
+            | Opt(config.filenamesAsTags)
+            ["-#"]["--filenames-as-tags"]
+            ("adds a tag for the filename")
+            | Opt(config.sectionsToRun, "section name")
+            ["-c"]["--section"]
+            ("specify section to run")
+            | Opt(setVerbosity, "quiet|normal|high")
+            ["-v"]["--verbosity"]
+            ("set output verbosity")
+            | Opt(config.listTestNamesOnly)
+            ["--list-test-names-only"]
+            ("list all/matching test cases names only")
+            | Opt(config.listReporters)
+            ["--list-reporters"]
+            ("list all reporters")
+            | Opt(setTestOrder, "decl|lex|rand")
+            ["--order"]
+            ("test case order (defaults to decl)")
+            | Opt(setRngSeed, "'time'|number")
+            ["--rng-seed"]
+            ("set a specific seed for random numbers")
+            | Opt(setColourUsage, "yes|no")
+            ["--use-colour"]
+            ("should output be colourised")
+            | Opt(config.libIdentify)
+            ["--libidentify"]
+            ("report name and version according to libidentify standard")
+            | Opt(setWaitForKeypress, "never|start|exit|both")
+            ["--wait-for-keypress"]
+            ("waits for a keypress before exiting")
+            | Opt(config.benchmarkSamples, "samples")
+            ["--benchmark-samples"]
+            ("number of samples to collect (default: 100)")
+            | Opt(config.benchmarkResamples, "resamples")
+            ["--benchmark-resamples"]
+            ("number of resamples for the bootstrap (default: 100000)")
+            | Opt(config.benchmarkConfidenceInterval, "confidence interval")
+            ["--benchmark-confidence-interval"]
+            ("confidence interval for the bootstrap (between 0 and 1, default: 0.95)")
+            | Opt(config.benchmarkNoAnalysis)
+            ["--benchmark-no-analysis"]
+            ("perform only measurements; do not perform any analysis")
+            | Opt(config.benchmarkWarmupTime, "benchmarkWarmupTime")
+            ["--benchmark-warmup-time"]
+            ("amount of time in milliseconds spent on warming up each test (default: 100)")
+            | Arg(config.testsOrTags, "test name|pattern|tags")
+            ("which test or tests to use");
 
         return cli;
     }
@@ -9930,16 +9950,16 @@ namespace Catch {
 
 namespace Catch {
 
-    bool SourceLineInfo::operator == ( SourceLineInfo const& other ) const noexcept {
+    bool SourceLineInfo::operator == (SourceLineInfo const& other) const noexcept {
         return line == other.line && (file == other.file || std::strcmp(file, other.file) == 0);
     }
-    bool SourceLineInfo::operator < ( SourceLineInfo const& other ) const noexcept {
+    bool SourceLineInfo::operator < (SourceLineInfo const& other) const noexcept {
         // We can assume that the same file will usually have the same pointer.
         // Thus, if the pointers are the same, there is no point in calling the strcmp
-        return line < other.line || ( line == other.line && file != other.file && (std::strcmp(file, other.file) < 0));
+        return line < other.line || (line == other.line && file != other.file && (std::strcmp(file, other.file) < 0));
     }
 
-    std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info ) {
+    std::ostream& operator << (std::ostream& os, SourceLineInfo const& info) {
 #ifndef __GNUG__
         os << info.file << '(' << info.line << ')';
 #else
@@ -9961,9 +9981,9 @@ namespace Catch {
 
 namespace Catch {
 
-    Config::Config( ConfigData const& data )
-    :   m_data( data ),
-        m_stream( openStream() )
+    Config::Config(ConfigData const& data)
+        : m_data(data),
+        m_stream(openStream())
     {
         // We need to trim filter specs to avoid trouble with superfluous
         // whitespace (esp. important for bdd macros, as those are manually
@@ -9987,13 +10007,13 @@ namespace Catch {
     }
 
     std::string const& Config::getFilename() const {
-        return m_data.outputFilename ;
+        return m_data.outputFilename;
     }
 
-    bool Config::listTests() const          { return m_data.listTests; }
-    bool Config::listTestNamesOnly() const  { return m_data.listTestNamesOnly; }
-    bool Config::listTags() const           { return m_data.listTags; }
-    bool Config::listReporters() const      { return m_data.listReporters; }
+    bool Config::listTests() const { return m_data.listTests; }
+    bool Config::listTestNamesOnly() const { return m_data.listTestNamesOnly; }
+    bool Config::listTags() const { return m_data.listTags; }
+    bool Config::listReporters() const { return m_data.listReporters; }
 
     std::string Config::getProcessName() const { return m_data.processName; }
     std::string const& Config::getReporterName() const { return m_data.reporterName; }
@@ -10007,26 +10027,26 @@ namespace Catch {
     bool Config::showHelp() const { return m_data.showHelp; }
 
     // IConfig interface
-    bool Config::allowThrows() const                   { return !m_data.noThrow; }
-    std::ostream& Config::stream() const               { return m_stream->stream(); }
-    std::string Config::name() const                   { return m_data.name.empty() ? m_data.processName : m_data.name; }
-    bool Config::includeSuccessfulResults() const      { return m_data.showSuccessfulTests; }
-    bool Config::warnAboutMissingAssertions() const    { return !!(m_data.warnings & WarnAbout::NoAssertions); }
-    bool Config::warnAboutNoTests() const              { return !!(m_data.warnings & WarnAbout::NoTests); }
+    bool Config::allowThrows() const { return !m_data.noThrow; }
+    std::ostream& Config::stream() const { return m_stream->stream(); }
+    std::string Config::name() const { return m_data.name.empty() ? m_data.processName : m_data.name; }
+    bool Config::includeSuccessfulResults() const { return m_data.showSuccessfulTests; }
+    bool Config::warnAboutMissingAssertions() const { return !!(m_data.warnings & WarnAbout::NoAssertions); }
+    bool Config::warnAboutNoTests() const { return !!(m_data.warnings & WarnAbout::NoTests); }
     ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
-    double Config::minDuration() const                 { return m_data.minDuration; }
-    RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
-    unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
-    UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }
-    bool Config::shouldDebugBreak() const              { return m_data.shouldDebugBreak; }
-    int Config::abortAfter() const                     { return m_data.abortAfter; }
-    bool Config::showInvisibles() const                { return m_data.showInvisibles; }
-    Verbosity Config::verbosity() const                { return m_data.verbosity; }
+    double Config::minDuration() const { return m_data.minDuration; }
+    RunTests::InWhatOrder Config::runOrder() const { return m_data.runOrder; }
+    unsigned int Config::rngSeed() const { return m_data.rngSeed; }
+    UseColour::YesOrNo Config::useColour() const { return m_data.useColour; }
+    bool Config::shouldDebugBreak() const { return m_data.shouldDebugBreak; }
+    int Config::abortAfter() const { return m_data.abortAfter; }
+    bool Config::showInvisibles() const { return m_data.showInvisibles; }
+    Verbosity Config::verbosity() const { return m_data.verbosity; }
 
-    bool Config::benchmarkNoAnalysis() const                      { return m_data.benchmarkNoAnalysis; }
-    int Config::benchmarkSamples() const                          { return m_data.benchmarkSamples; }
-    double Config::benchmarkConfidenceInterval() const            { return m_data.benchmarkConfidenceInterval; }
-    unsigned int Config::benchmarkResamples() const               { return m_data.benchmarkResamples; }
+    bool Config::benchmarkNoAnalysis() const { return m_data.benchmarkNoAnalysis; }
+    int Config::benchmarkSamples() const { return m_data.benchmarkSamples; }
+    double Config::benchmarkConfidenceInterval() const { return m_data.benchmarkConfidenceInterval; }
+    unsigned int Config::benchmarkResamples() const { return m_data.benchmarkResamples; }
     std::chrono::milliseconds Config::benchmarkWarmupTime() const { return std::chrono::milliseconds(m_data.benchmarkWarmupTime); }
 
     IStream const* Config::openStream() {
@@ -10057,6 +10077,36 @@ namespace Catch {
 }
 
 // end catch_errno_guard.h
+// start catch_windows_h_proxy.h
+
+
+#if defined(CATCH_PLATFORM_WINDOWS)
+
+#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
+#  define CATCH_DEFINED_NOMINMAX
+#  define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
+#  define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef __AFXDLL
+#include <AfxWin.h>
+#else
+#include <windows.h>
+#endif
+
+#ifdef CATCH_DEFINED_NOMINMAX
+#  undef NOMINMAX
+#endif
+#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#  undef WIN32_LEAN_AND_MEAN
+#endif
+
+#endif // defined(CATCH_PLATFORM_WINDOWS)
+
+// end catch_windows_h_proxy.h
 #include <sstream>
 
 namespace Catch {
@@ -10064,11 +10114,11 @@ namespace Catch {
 
         struct IColourImpl {
             virtual ~IColourImpl() = default;
-            virtual void use( Colour::Code _colourCode ) = 0;
+            virtual void use(Colour::Code _colourCode) = 0;
         };
 
         struct NoColourImpl : IColourImpl {
-            void use( Colour::Code ) override {}
+            void use(Colour::Code) override {}
 
             static IColourImpl* instance() {
                 static NoColourImpl s_instance;
@@ -10090,66 +10140,66 @@ namespace Catch {
 #if defined ( CATCH_CONFIG_COLOUR_WINDOWS ) /////////////////////////////////////////
 
 namespace Catch {
-namespace {
+    namespace {
 
-    class Win32ColourImpl : public IColourImpl {
-    public:
-        Win32ColourImpl() : stdoutHandle( GetStdHandle(STD_OUTPUT_HANDLE) )
-        {
-            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-            GetConsoleScreenBufferInfo( stdoutHandle, &csbiInfo );
-            originalForegroundAttributes = csbiInfo.wAttributes & ~( BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY );
-            originalBackgroundAttributes = csbiInfo.wAttributes & ~( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY );
-        }
+        class Win32ColourImpl : public IColourImpl {
+        public:
+            Win32ColourImpl() : stdoutHandle(GetStdHandle(STD_OUTPUT_HANDLE))
+            {
+                CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+                GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
+                originalForegroundAttributes = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+                originalBackgroundAttributes = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+            }
 
-        void use( Colour::Code _colourCode ) override {
-            switch( _colourCode ) {
-                case Colour::None:      return setTextAttribute( originalForegroundAttributes );
-                case Colour::White:     return setTextAttribute( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
-                case Colour::Red:       return setTextAttribute( FOREGROUND_RED );
-                case Colour::Green:     return setTextAttribute( FOREGROUND_GREEN );
-                case Colour::Blue:      return setTextAttribute( FOREGROUND_BLUE );
-                case Colour::Cyan:      return setTextAttribute( FOREGROUND_BLUE | FOREGROUND_GREEN );
-                case Colour::Yellow:    return setTextAttribute( FOREGROUND_RED | FOREGROUND_GREEN );
-                case Colour::Grey:      return setTextAttribute( 0 );
+            void use(Colour::Code _colourCode) override {
+                switch (_colourCode) {
+                case Colour::None:      return setTextAttribute(originalForegroundAttributes);
+                case Colour::White:     return setTextAttribute(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE);
+                case Colour::Red:       return setTextAttribute(FOREGROUND_RED);
+                case Colour::Green:     return setTextAttribute(FOREGROUND_GREEN);
+                case Colour::Blue:      return setTextAttribute(FOREGROUND_BLUE);
+                case Colour::Cyan:      return setTextAttribute(FOREGROUND_BLUE | FOREGROUND_GREEN);
+                case Colour::Yellow:    return setTextAttribute(FOREGROUND_RED | FOREGROUND_GREEN);
+                case Colour::Grey:      return setTextAttribute(0);
 
-                case Colour::LightGrey:     return setTextAttribute( FOREGROUND_INTENSITY );
-                case Colour::BrightRed:     return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED );
-                case Colour::BrightGreen:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN );
-                case Colour::BrightWhite:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
-                case Colour::BrightYellow:  return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN );
+                case Colour::LightGrey:     return setTextAttribute(FOREGROUND_INTENSITY);
+                case Colour::BrightRed:     return setTextAttribute(FOREGROUND_INTENSITY | FOREGROUND_RED);
+                case Colour::BrightGreen:   return setTextAttribute(FOREGROUND_INTENSITY | FOREGROUND_GREEN);
+                case Colour::BrightWhite:   return setTextAttribute(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE);
+                case Colour::BrightYellow:  return setTextAttribute(FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN);
 
-                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
+                case Colour::Bright: CATCH_INTERNAL_ERROR("not a colour");
 
                 default:
-                    CATCH_ERROR( "Unknown colour requested" );
+                    CATCH_ERROR("Unknown colour requested");
+                }
             }
+
+        private:
+            void setTextAttribute(WORD _textAttribute) {
+                SetConsoleTextAttribute(stdoutHandle, _textAttribute | originalBackgroundAttributes);
+            }
+            HANDLE stdoutHandle;
+            WORD originalForegroundAttributes;
+            WORD originalBackgroundAttributes;
+        };
+
+        IColourImpl* platformColourInstance() {
+            static Win32ColourImpl s_instance;
+
+            IConfigPtr config = getCurrentContext().getConfig();
+            UseColour::YesOrNo colourMode = config
+                ? config->useColour()
+                : UseColour::Auto;
+            if (colourMode == UseColour::Auto)
+                colourMode = UseColour::Yes;
+            return colourMode == UseColour::Yes
+                ? &s_instance
+                : NoColourImpl::instance();
         }
 
-    private:
-        void setTextAttribute( WORD _textAttribute ) {
-            SetConsoleTextAttribute( stdoutHandle, _textAttribute | originalBackgroundAttributes );
-        }
-        HANDLE stdoutHandle;
-        WORD originalForegroundAttributes;
-        WORD originalBackgroundAttributes;
-    };
-
-    IColourImpl* platformColourInstance() {
-        static Win32ColourImpl s_instance;
-
-        IConfigPtr config = getCurrentContext().getConfig();
-        UseColour::YesOrNo colourMode = config
-            ? config->useColour()
-            : UseColour::Auto;
-        if( colourMode == UseColour::Auto )
-            colourMode = UseColour::Yes;
-        return colourMode == UseColour::Yes
-            ? &s_instance
-            : NoColourImpl::instance();
-    }
-
-} // end anon namespace
+    } // end anon namespace
 } // end namespace Catch
 
 #elif defined( CATCH_CONFIG_COLOUR_ANSI ) //////////////////////////////////////
@@ -10157,75 +10207,75 @@ namespace {
 #include <unistd.h>
 
 namespace Catch {
-namespace {
+    namespace {
 
-    // use POSIX/ ANSI console terminal codes
-    // Thanks to Adam Strzelecki for original contribution
-    // (http://github.com/nanoant)
-    // https://github.com/philsquared/Catch/pull/131
-    class PosixColourImpl : public IColourImpl {
-    public:
-        void use( Colour::Code _colourCode ) override {
-            switch( _colourCode ) {
+        // use POSIX/ ANSI console terminal codes
+        // Thanks to Adam Strzelecki for original contribution
+        // (http://github.com/nanoant)
+        // https://github.com/philsquared/Catch/pull/131
+        class PosixColourImpl : public IColourImpl {
+        public:
+            void use(Colour::Code _colourCode) override {
+                switch (_colourCode) {
                 case Colour::None:
-                case Colour::White:     return setColour( "[0m" );
-                case Colour::Red:       return setColour( "[0;31m" );
-                case Colour::Green:     return setColour( "[0;32m" );
-                case Colour::Blue:      return setColour( "[0;34m" );
-                case Colour::Cyan:      return setColour( "[0;36m" );
-                case Colour::Yellow:    return setColour( "[0;33m" );
-                case Colour::Grey:      return setColour( "[1;30m" );
+                case Colour::White:     return setColour("[0m");
+                case Colour::Red:       return setColour("[0;31m");
+                case Colour::Green:     return setColour("[0;32m");
+                case Colour::Blue:      return setColour("[0;34m");
+                case Colour::Cyan:      return setColour("[0;36m");
+                case Colour::Yellow:    return setColour("[0;33m");
+                case Colour::Grey:      return setColour("[1;30m");
 
-                case Colour::LightGrey:     return setColour( "[0;37m" );
-                case Colour::BrightRed:     return setColour( "[1;31m" );
-                case Colour::BrightGreen:   return setColour( "[1;32m" );
-                case Colour::BrightWhite:   return setColour( "[1;37m" );
-                case Colour::BrightYellow:  return setColour( "[1;33m" );
+                case Colour::LightGrey:     return setColour("[0;37m");
+                case Colour::BrightRed:     return setColour("[1;31m");
+                case Colour::BrightGreen:   return setColour("[1;32m");
+                case Colour::BrightWhite:   return setColour("[1;37m");
+                case Colour::BrightYellow:  return setColour("[1;33m");
 
-                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
-                default: CATCH_INTERNAL_ERROR( "Unknown colour requested" );
+                case Colour::Bright: CATCH_INTERNAL_ERROR("not a colour");
+                default: CATCH_INTERNAL_ERROR("Unknown colour requested");
+                }
             }
-        }
-        static IColourImpl* instance() {
-            static PosixColourImpl s_instance;
-            return &s_instance;
-        }
+            static IColourImpl* instance() {
+                static PosixColourImpl s_instance;
+                return &s_instance;
+            }
 
-    private:
-        void setColour( const char* _escapeCode ) {
-            getCurrentContext().getConfig()->stream()
-                << '\033' << _escapeCode;
-        }
-    };
+        private:
+            void setColour(const char* _escapeCode) {
+                getCurrentContext().getConfig()->stream()
+                    << '\033' << _escapeCode;
+            }
+        };
 
-    bool useColourOnPlatform() {
-        return
+        bool useColourOnPlatform() {
+            return
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
-            !isDebuggerActive() &&
+                !isDebuggerActive() &&
 #endif
 #if !(defined(__DJGPP__) && defined(__STRICT_ANSI__))
-            isatty(STDOUT_FILENO)
+                isatty(STDOUT_FILENO)
 #else
-            false
+                false
 #endif
-            ;
-    }
-    IColourImpl* platformColourInstance() {
-        ErrnoGuard guard;
-        IConfigPtr config = getCurrentContext().getConfig();
-        UseColour::YesOrNo colourMode = config
-            ? config->useColour()
-            : UseColour::Auto;
-        if( colourMode == UseColour::Auto )
-            colourMode = useColourOnPlatform()
+                ;
+        }
+        IColourImpl* platformColourInstance() {
+            ErrnoGuard guard;
+            IConfigPtr config = getCurrentContext().getConfig();
+            UseColour::YesOrNo colourMode = config
+                ? config->useColour()
+                : UseColour::Auto;
+            if (colourMode == UseColour::Auto)
+                colourMode = useColourOnPlatform()
                 ? UseColour::Yes
                 : UseColour::No;
-        return colourMode == UseColour::Yes
-            ? PosixColourImpl::instance()
-            : NoColourImpl::instance();
-    }
+            return colourMode == UseColour::Yes
+                ? PosixColourImpl::instance()
+                : NoColourImpl::instance();
+        }
 
-} // end anon namespace
+    } // end anon namespace
 } // end namespace Catch
 
 #else  // not Windows or ANSI ///////////////////////////////////////////////
@@ -10240,31 +10290,31 @@ namespace Catch {
 
 namespace Catch {
 
-    Colour::Colour( Code _colourCode ) { use( _colourCode ); }
-    Colour::Colour( Colour&& other ) noexcept {
+    Colour::Colour(Code _colourCode) { use(_colourCode); }
+    Colour::Colour(Colour&& other) noexcept {
         m_moved = other.m_moved;
         other.m_moved = true;
     }
-    Colour& Colour::operator=( Colour&& other ) noexcept {
+    Colour& Colour::operator=(Colour&& other) noexcept {
         m_moved = other.m_moved;
-        other.m_moved  = true;
+        other.m_moved = true;
         return *this;
     }
 
-    Colour::~Colour(){ if( !m_moved ) use( None ); }
+    Colour::~Colour() { if (!m_moved) use(None); }
 
-    void Colour::use( Code _colourCode ) {
+    void Colour::use(Code _colourCode) {
         static IColourImpl* impl = platformColourInstance();
         // Strictly speaking, this cannot possibly happen.
         // However, under some conditions it does happen (see #1626),
         // and this change is small enough that we can let practicality
         // triumph over purity in this case.
         if (impl != nullptr) {
-            impl->use( _colourCode );
+            impl->use(_colourCode);
         }
     }
 
-    std::ostream& operator << ( std::ostream& os, Colour const& ) {
+    std::ostream& operator << (std::ostream& os, Colour const&) {
         return os;
     }
 
@@ -10296,13 +10346,13 @@ namespace Catch {
         ~Context() override;
 
     public: // IMutableContext
-        void setResultCapture( IResultCapture* resultCapture ) override {
+        void setResultCapture(IResultCapture* resultCapture) override {
             m_resultCapture = resultCapture;
         }
-        void setRunner( IRunner* runner ) override {
+        void setRunner(IRunner* runner) override {
             m_runner = runner;
         }
-        void setConfig( IConfigPtr const& config ) override {
+        void setConfig(IConfigPtr const& config) override {
             m_config = config;
         }
 
@@ -10314,7 +10364,7 @@ namespace Catch {
         IResultCapture* m_resultCapture = nullptr;
     };
 
-    IMutableContext *IMutableContext::currentContext = nullptr;
+    IMutableContext* IMutableContext::currentContext = nullptr;
 
     void IMutableContext::createContext()
     {
@@ -10343,35 +10393,35 @@ namespace Catch {
 #include <string>
 
 namespace Catch {
-    void writeToDebugConsole( std::string const& text );
+    void writeToDebugConsole(std::string const& text);
 }
 
 // end catch_debug_console.h
 #if defined(CATCH_CONFIG_ANDROID_LOGWRITE)
 #include <android/log.h>
 
-    namespace Catch {
-        void writeToDebugConsole( std::string const& text ) {
-            __android_log_write( ANDROID_LOG_DEBUG, "Catch", text.c_str() );
-        }
+namespace Catch {
+    void writeToDebugConsole(std::string const& text) {
+        __android_log_write(ANDROID_LOG_DEBUG, "Catch", text.c_str());
     }
+}
 
 #elif defined(CATCH_PLATFORM_WINDOWS)
 
-    namespace Catch {
-        void writeToDebugConsole( std::string const& text ) {
-            ::OutputDebugStringA( text.c_str() );
-        }
+namespace Catch {
+    void writeToDebugConsole(std::string const& text) {
+        ::OutputDebugStringA(text.c_str());
     }
+}
 
 #else
 
-    namespace Catch {
-        void writeToDebugConsole( std::string const& text ) {
-            // !TBD: Need a version for Mac/ XCode and other IDEs
-            Catch::cout() << text;
-        }
+namespace Catch {
+    void writeToDebugConsole(std::string const& text) {
+        // !TBD: Need a version for Mac/ XCode and other IDEs
+        Catch::cout() << text;
     }
+}
 
 #endif // Platform
 // end catch_debug_console.cpp
@@ -10391,99 +10441,99 @@ namespace Catch {
 #  include <sys/sysctl.h>
 #endif
 
-    namespace Catch {
-        #ifdef __apple_build_version__
-        // The following function is taken directly from the following technical note:
-        // https://developer.apple.com/library/archive/qa/qa1361/_index.html
+namespace Catch {
+#ifdef __apple_build_version__
+    // The following function is taken directly from the following technical note:
+    // https://developer.apple.com/library/archive/qa/qa1361/_index.html
 
-        // Returns true if the current process is being debugged (either
-        // running under the debugger or has a debugger attached post facto).
-        bool isDebuggerActive(){
-            int                 mib[4];
-            struct kinfo_proc   info;
-            std::size_t         size;
+    // Returns true if the current process is being debugged (either
+    // running under the debugger or has a debugger attached post facto).
+    bool isDebuggerActive() {
+        int                 mib[4];
+        struct kinfo_proc   info;
+        std::size_t         size;
 
-            // Initialize the flags so that, if sysctl fails for some bizarre
-            // reason, we get a predictable result.
+        // Initialize the flags so that, if sysctl fails for some bizarre
+        // reason, we get a predictable result.
 
-            info.kp_proc.p_flag = 0;
+        info.kp_proc.p_flag = 0;
 
-            // Initialize mib, which tells sysctl the info we want, in this case
-            // we're looking for information about a specific process ID.
+        // Initialize mib, which tells sysctl the info we want, in this case
+        // we're looking for information about a specific process ID.
 
-            mib[0] = CTL_KERN;
-            mib[1] = KERN_PROC;
-            mib[2] = KERN_PROC_PID;
-            mib[3] = getpid();
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_PROC;
+        mib[2] = KERN_PROC_PID;
+        mib[3] = getpid();
 
-            // Call sysctl.
+        // Call sysctl.
 
-            size = sizeof(info);
-            if( sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0) != 0 ) {
-                Catch::cerr() << "\n** Call to sysctl failed - unable to determine if debugger is active **\n" << std::endl;
-                return false;
-            }
-
-            // We're being debugged if the P_TRACED flag is set.
-
-            return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
-        }
-        #else
-        bool isDebuggerActive() {
-            // We need to find another way to determine this for non-appleclang compilers on macOS
+        size = sizeof(info);
+        if (sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0) != 0) {
+            Catch::cerr() << "\n** Call to sysctl failed - unable to determine if debugger is active **\n" << std::endl;
             return false;
         }
-        #endif
-    } // namespace Catch
 
-#elif defined(CATCH_PLATFORM_LINUX)
-    #include <fstream>
-    #include <string>
+        // We're being debugged if the P_TRACED flag is set.
 
-    namespace Catch{
-        // The standard POSIX way of detecting a debugger is to attempt to
-        // ptrace() the process, but this needs to be done from a child and not
-        // this process itself to still allow attaching to this process later
-        // if wanted, so is rather heavy. Under Linux we have the PID of the
-        // "debugger" (which doesn't need to be gdb, of course, it could also
-        // be strace, for example) in /proc/$PID/status, so just get it from
-        // there instead.
-        bool isDebuggerActive(){
-            // Libstdc++ has a bug, where std::ifstream sets errno to 0
-            // This way our users can properly assert over errno values
-            ErrnoGuard guard;
-            std::ifstream in("/proc/self/status");
-            for( std::string line; std::getline(in, line); ) {
-                static const int PREFIX_LEN = 11;
-                if( line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0 ) {
-                    // We're traced if the PID is not 0 and no other PID starts
-                    // with 0 digit, so it's enough to check for just a single
-                    // character.
-                    return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
-                }
-            }
-
-            return false;
-        }
-    } // namespace Catch
-#elif defined(_MSC_VER)
-    extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
-    namespace Catch {
-        bool isDebuggerActive() {
-            return IsDebuggerPresent() != 0;
-        }
-    }
-#elif defined(__MINGW32__)
-    extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
-    namespace Catch {
-        bool isDebuggerActive() {
-            return IsDebuggerPresent() != 0;
-        }
+        return ((info.kp_proc.p_flag & P_TRACED) != 0);
     }
 #else
-    namespace Catch {
-       bool isDebuggerActive() { return false; }
+    bool isDebuggerActive() {
+        // We need to find another way to determine this for non-appleclang compilers on macOS
+        return false;
     }
+#endif
+} // namespace Catch
+
+#elif defined(CATCH_PLATFORM_LINUX)
+#include <fstream>
+#include <string>
+
+namespace Catch {
+    // The standard POSIX way of detecting a debugger is to attempt to
+    // ptrace() the process, but this needs to be done from a child and not
+    // this process itself to still allow attaching to this process later
+    // if wanted, so is rather heavy. Under Linux we have the PID of the
+    // "debugger" (which doesn't need to be gdb, of course, it could also
+    // be strace, for example) in /proc/$PID/status, so just get it from
+    // there instead.
+    bool isDebuggerActive() {
+        // Libstdc++ has a bug, where std::ifstream sets errno to 0
+        // This way our users can properly assert over errno values
+        ErrnoGuard guard;
+        std::ifstream in("/proc/self/status");
+        for (std::string line; std::getline(in, line); ) {
+            static const int PREFIX_LEN = 11;
+            if (line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
+                // We're traced if the PID is not 0 and no other PID starts
+                // with 0 digit, so it's enough to check for just a single
+                // character.
+                return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+            }
+        }
+
+        return false;
+    }
+} // namespace Catch
+#elif defined(_MSC_VER)
+extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
+namespace Catch {
+    bool isDebuggerActive() {
+        return IsDebuggerPresent() != 0;
+    }
+}
+#elif defined(__MINGW32__)
+extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
+namespace Catch {
+    bool isDebuggerActive() {
+        return IsDebuggerPresent() != 0;
+    }
+}
+#else
+namespace Catch {
+    bool isDebuggerActive() { return false; }
+}
 #endif // Platform
 // end catch_debugger.cpp
 // start catch_decomposer.cpp
@@ -10492,10 +10542,10 @@ namespace Catch {
 
     ITransientExpression::~ITransientExpression() = default;
 
-    void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs ) {
-        if( lhs.size() + rhs.size() < 40 &&
-                lhs.find('\n') == std::string::npos &&
-                rhs.find('\n') == std::string::npos )
+    void formatReconstructedExpression(std::ostream& os, std::string const& lhs, StringRef op, std::string const& rhs) {
+        if (lhs.size() + rhs.size() < 40 &&
+            lhs.find('\n') == std::string::npos &&
+            rhs.find('\n') == std::string::npos)
             os << lhs << " " << op << " " << rhs;
         else
             os << lhs << "\n" << op << "\n" << rhs;
@@ -10509,27 +10559,27 @@ namespace Catch {
 namespace Catch {
 #if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS) && !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS_CUSTOM_HANDLER)
     [[noreturn]]
-    void throw_exception(std::exception const& e) {
-        Catch::cerr() << "Catch will terminate because it needed to throw an exception.\n"
-                      << "The message was: " << e.what() << '\n';
-        std::terminate();
-    }
+void throw_exception(std::exception const& e) {
+    Catch::cerr() << "Catch will terminate because it needed to throw an exception.\n"
+        << "The message was: " << e.what() << '\n';
+    std::terminate();
+}
 #endif
 
-    [[noreturn]]
-    void throw_logic_error(std::string const& msg) {
-        throw_exception(std::logic_error(msg));
-    }
+[[noreturn]]
+void throw_logic_error(std::string const& msg) {
+    throw_exception(std::logic_error(msg));
+}
 
-    [[noreturn]]
-    void throw_domain_error(std::string const& msg) {
-        throw_exception(std::domain_error(msg));
-    }
+[[noreturn]]
+void throw_domain_error(std::string const& msg) {
+    throw_exception(std::domain_error(msg));
+}
 
-    [[noreturn]]
-    void throw_runtime_error(std::string const& msg) {
-        throw_exception(std::runtime_error(msg));
-    }
+[[noreturn]]
+void throw_runtime_error(std::string const& msg) {
+    throw_exception(std::runtime_error(msg));
+}
 
 } // namespace Catch;
 // end catch_enforce.cpp
@@ -10543,16 +10593,16 @@ namespace Catch {
 
     namespace Detail {
 
-        std::unique_ptr<EnumInfo> makeEnumInfo( StringRef enumName, StringRef allValueNames, std::vector<int> const& values );
+        std::unique_ptr<EnumInfo> makeEnumInfo(StringRef enumName, StringRef allValueNames, std::vector<int> const& values);
 
         class EnumValuesRegistry : public IMutableEnumValuesRegistry {
 
             std::vector<std::unique_ptr<EnumInfo>> m_enumInfos;
 
-            EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values) override;
+            EnumInfo const& registerEnum(StringRef enumName, StringRef allEnums, std::vector<int> const& values) override;
         };
 
-        std::vector<StringRef> parseEnums( StringRef enums );
+        std::vector<StringRef> parseEnums(StringRef enums);
 
     } // Detail
 
@@ -10573,7 +10623,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;
@@ -10582,11 +10632,11 @@ namespace Catch {
             }
         }
 
-        std::vector<StringRef> parseEnums( StringRef enums ) {
-            auto enumValues = splitStringRef( enums, ',' );
+        std::vector<StringRef> parseEnums(StringRef enums) {
+            auto enumValues = splitStringRef(enums, ',');
             std::vector<StringRef> parsed;
-            parsed.reserve( enumValues.size() );
-            for( auto const& enumValue : enumValues ) {
+            parsed.reserve(enumValues.size());
+            for (auto const& enumValue : enumValues) {
                 parsed.push_back(trim(extractInstanceName(enumValue)));
             }
             return parsed;
@@ -10594,29 +10644,29 @@ namespace Catch {
 
         EnumInfo::~EnumInfo() {}
 
-        StringRef EnumInfo::lookup( int value ) const {
-            for( auto const& valueToName : m_values ) {
-                if( valueToName.first == value )
+        StringRef EnumInfo::lookup(int value) const {
+            for (auto const& valueToName : m_values) {
+                if (valueToName.first == value)
                     return valueToName.second;
             }
             return "{** unexpected enum value **}"_sr;
         }
 
-        std::unique_ptr<EnumInfo> makeEnumInfo( StringRef enumName, StringRef allValueNames, std::vector<int> const& values ) {
-            std::unique_ptr<EnumInfo> enumInfo( new EnumInfo );
+        std::unique_ptr<EnumInfo> makeEnumInfo(StringRef enumName, StringRef allValueNames, std::vector<int> const& values) {
+            std::unique_ptr<EnumInfo> enumInfo(new EnumInfo);
             enumInfo->m_name = enumName;
-            enumInfo->m_values.reserve( values.size() );
+            enumInfo->m_values.reserve(values.size());
 
-            const auto valueNames = Catch::Detail::parseEnums( allValueNames );
-            assert( valueNames.size() == values.size() );
+            const auto valueNames = Catch::Detail::parseEnums(allValueNames);
+            assert(valueNames.size() == values.size());
             std::size_t i = 0;
-            for( auto value : values )
+            for (auto value : values)
                 enumInfo->m_values.emplace_back(value, valueNames[i++]);
 
             return enumInfo;
         }
 
-        EnumInfo const& EnumValuesRegistry::registerEnum( StringRef enumName, StringRef allValueNames, std::vector<int> const& values ) {
+        EnumInfo const& EnumValuesRegistry::registerEnum(StringRef enumName, StringRef allValueNames, std::vector<int> const& values) {
             m_enumInfos.push_back(makeEnumInfo(enumName, allValueNames, values));
             return *m_enumInfos.back();
         }
@@ -10630,8 +10680,8 @@ namespace Catch {
 #include <cerrno>
 
 namespace Catch {
-        ErrnoGuard::ErrnoGuard():m_oldErrno(errno){}
-        ErrnoGuard::~ErrnoGuard() { errno = m_oldErrno; }
+    ErrnoGuard::ErrnoGuard() :m_oldErrno(errno) {}
+    ErrnoGuard::~ErrnoGuard() { errno = m_oldErrno; }
 }
 // end catch_errno_guard.cpp
 // start catch_exception_translator_registry.cpp
@@ -10647,7 +10697,7 @@ namespace Catch {
     class ExceptionTranslatorRegistry : public IExceptionTranslatorRegistry {
     public:
         ~ExceptionTranslatorRegistry();
-        virtual void registerTranslator( const IExceptionTranslator* translator );
+        virtual void registerTranslator(const IExceptionTranslator* translator);
         std::string translateActiveException() const override;
         std::string tryTranslators() const;
 
@@ -10666,8 +10716,8 @@ namespace Catch {
     ExceptionTranslatorRegistry::~ExceptionTranslatorRegistry() {
     }
 
-    void ExceptionTranslatorRegistry::registerTranslator( const IExceptionTranslator* translator ) {
-        m_translators.push_back( std::unique_ptr<const IExceptionTranslator>( translator ) );
+    void ExceptionTranslatorRegistry::registerTranslator(const IExceptionTranslator* translator) {
+        m_translators.push_back(std::unique_ptr<const IExceptionTranslator>(translator));
     }
 
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
@@ -10678,8 +10728,8 @@ namespace Catch {
             @try {
                 return tryTranslators();
             }
-            @catch (NSException *exception) {
-                return Catch::Detail::stringify( [exception description] );
+            @catch (NSException* exception) {
+                return Catch::Detail::stringify([exception description]);
             }
 #else
             // Compiling a mixed mode project with MSVC means that CLR
@@ -10696,19 +10746,19 @@ namespace Catch {
             return tryTranslators();
 #endif
         }
-        catch( TestFailureException& ) {
+        catch (TestFailureException&) {
             std::rethrow_exception(std::current_exception());
         }
-        catch( std::exception& ex ) {
+        catch (std::exception& ex) {
             return ex.what();
         }
-        catch( std::string& msg ) {
+        catch (std::string& msg) {
             return msg;
         }
-        catch( const char* msg ) {
+        catch (const char* msg) {
             return msg;
         }
-        catch(...) {
+        catch (...) {
             return "Unknown exception";
         }
     }
@@ -10716,7 +10766,8 @@ namespace Catch {
     std::string ExceptionTranslatorRegistry::tryTranslators() const {
         if (m_translators.empty()) {
             std::rethrow_exception(std::current_exception());
-        } else {
+        }
+        else {
             return m_translators[0]->translate(m_translators.begin() + 1, m_translators.end());
         }
     }
@@ -10735,25 +10786,47 @@ namespace Catch {
 // end catch_exception_translator_registry.cpp
 // start catch_fatal_condition.cpp
 
-#if defined(__GNUC__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
+#include <algorithm>
+
+#if !defined( CATCH_CONFIG_WINDOWS_SEH ) && !defined( CATCH_CONFIG_POSIX_SIGNALS )
+
+namespace Catch {
+
+    // If neither SEH nor signal handling is required, the handler impls
+    // do not have to do anything, and can be empty.
+    void FatalConditionHandler::engage_platform() {}
+    void FatalConditionHandler::disengage_platform() {}
+    FatalConditionHandler::FatalConditionHandler() = default;
+    FatalConditionHandler::~FatalConditionHandler() = default;
+
+} // end namespace Catch
+
+#endif // !CATCH_CONFIG_WINDOWS_SEH && !CATCH_CONFIG_POSIX_SIGNALS
+
+#if defined( CATCH_CONFIG_WINDOWS_SEH ) && defined( CATCH_CONFIG_POSIX_SIGNALS )
+#error "Inconsistent configuration: Windows' SEH handling and POSIX signals cannot be enabled at the same time"
+#endif // CATCH_CONFIG_WINDOWS_SEH && CATCH_CONFIG_POSIX_SIGNALS
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH ) || defined( CATCH_CONFIG_POSIX_SIGNALS )
 
 namespace {
-    // Report the error condition
-    void reportFatal( char const * const message ) {
-        Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
+    //! Signals fatal error message to the run context
+    void reportFatal(char const* const message) {
+        Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition(message);
     }
-}
 
-#endif // signals/SEH handling
+    //! Minimal size Catch2 needs for its own fatal error handling.
+    //! Picked anecdotally, so it might not be sufficient on all
+    //! platforms, and for all configurations.
+    constexpr std::size_t minStackSizeForErrors = 32 * 1024;
+} // end unnamed namespace
+
+#endif // CATCH_CONFIG_WINDOWS_SEH || CATCH_CONFIG_POSIX_SIGNALS
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH )
 
 namespace Catch {
+
     struct SignalDefs { DWORD id; const char* name; };
 
     // There is no 1-1 mapping between signals and windows exceptions.
@@ -10766,7 +10839,7 @@ namespace Catch {
         { static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error" },
     };
 
-    LONG CALLBACK FatalConditionHandler::handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
+    static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
         for (auto const& def : signalDefs) {
             if (ExceptionInfo->ExceptionRecord->ExceptionCode == def.id) {
                 reportFatal(def.name);
@@ -10777,38 +10850,50 @@ namespace Catch {
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
-    FatalConditionHandler::FatalConditionHandler() {
-        isSet = true;
-        // 32k seems enough for Catch to handle stack overflow,
-        // but the value was found experimentally, so there is no strong guarantee
-        guaranteeSize = 32 * 1024;
-        exceptionHandlerHandle = nullptr;
-        // Register as first handler in current chain
-        exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
-        // Pass in guarantee size to be filled
-        SetThreadStackGuarantee(&guaranteeSize);
-    }
+    // Since we do not support multiple instantiations, we put these
+    // into global variables and rely on cleaning them up in outlined
+    // constructors/destructors
+    static PVOID exceptionHandlerHandle = nullptr;
 
-    void FatalConditionHandler::reset() {
-        if (isSet) {
-            RemoveVectoredExceptionHandler(exceptionHandlerHandle);
-            SetThreadStackGuarantee(&guaranteeSize);
-            exceptionHandlerHandle = nullptr;
-            isSet = false;
+    // For MSVC, we reserve part of the stack memory for handling
+    // memory overflow structured exception.
+    FatalConditionHandler::FatalConditionHandler() {
+        ULONG guaranteeSize = static_cast<ULONG>(minStackSizeForErrors);
+        if (!SetThreadStackGuarantee(&guaranteeSize)) {
+            // We do not want to fully error out, because needing
+            // the stack reserve should be rare enough anyway.
+            Catch::cerr()
+                << "Failed to reserve piece of stack."
+                << " Stack overflows will not be reported successfully.";
         }
     }
 
-    FatalConditionHandler::~FatalConditionHandler() {
-        reset();
+    // We do not attempt to unset the stack guarantee, because
+    // Windows does not support lowering the stack size guarantee.
+    FatalConditionHandler::~FatalConditionHandler() = default;
+
+    void FatalConditionHandler::engage_platform() {
+        // Register as first handler in current chain
+        exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+        if (!exceptionHandlerHandle) {
+            CATCH_RUNTIME_ERROR("Could not register vectored exception handler");
+        }
     }
 
-bool FatalConditionHandler::isSet = false;
-ULONG FatalConditionHandler::guaranteeSize = 0;
-PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+    void FatalConditionHandler::disengage_platform() {
+        if (!RemoveVectoredExceptionHandler(exceptionHandlerHandle)) {
+            CATCH_RUNTIME_ERROR("Could not unregister vectored exception handler");
+        }
+        exceptionHandlerHandle = nullptr;
+    }
 
-} // namespace Catch
+} // end namespace Catch
 
-#elif defined( CATCH_CONFIG_POSIX_SIGNALS )
+#endif // CATCH_CONFIG_WINDOWS_SEH
+
+#if defined( CATCH_CONFIG_POSIX_SIGNALS )
+
+#include <signal.h>
 
 namespace Catch {
 
@@ -10816,10 +10901,6 @@ namespace Catch {
         int id;
         const char* name;
     };
-
-    // 32kb for the alternate stack seems to be sufficient. However, this value
-    // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },
@@ -10830,69 +10911,88 @@ namespace Catch {
         { SIGABRT, "SIGABRT - Abort (abnormal termination) signal" }
     };
 
-    void FatalConditionHandler::handleSignal( int sig ) {
-        char const * name = "<unknown signal>";
+    // Older GCCs trigger -Wmissing-field-initializers for T foo = {}
+    // which is zero initialization, but not explicit. We want to avoid
+    // that.
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+    static char* altStackMem = nullptr;
+    static std::size_t altStackSize = 0;
+    static stack_t oldSigStack{};
+    static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)]{};
+
+    static void restorePreviousSignalHandlers() {
+        // We set signal handlers back to the previous ones. Hopefully
+        // nobody overwrote them in the meantime, and doesn't expect
+        // their signal handlers to live past ours given that they
+        // installed them after ours..
+        for (std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
+            sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
+        }
+        // Return the old stack
+        sigaltstack(&oldSigStack, nullptr);
+    }
+
+    static void handleSignal(int sig) {
+        char const* name = "<unknown signal>";
         for (auto const& def : signalDefs) {
             if (sig == def.id) {
                 name = def.name;
                 break;
             }
         }
-        reset();
+        // We need to restore previous signal handlers and let them do
+        // their thing, so that the users can have the debugger break
+        // when a signal is raised, and so on.
+        restorePreviousSignalHandlers();
         reportFatal(name);
-        raise( sig );
+        raise(sig);
     }
 
     FatalConditionHandler::FatalConditionHandler() {
-        isSet = true;
+        assert(!altStackMem && "Cannot initialize POSIX signal handler when one already exists");
+        if (altStackSize == 0) {
+            altStackSize = std::max(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
+        }
+        altStackMem = new char[altStackSize]();
+    }
+
+    FatalConditionHandler::~FatalConditionHandler() {
+        delete[] altStackMem;
+        // We signal that another instance can be constructed by zeroing
+        // out the pointer.
+        altStackMem = nullptr;
+    }
+
+    void FatalConditionHandler::engage_platform() {
         stack_t sigStack;
         sigStack.ss_sp = altStackMem;
-        sigStack.ss_size = sigStackSize;
+        sigStack.ss_size = altStackSize;
         sigStack.ss_flags = 0;
         sigaltstack(&sigStack, &oldSigStack);
         struct sigaction sa = { };
 
         sa.sa_handler = handleSignal;
         sa.sa_flags = SA_ONSTACK;
-        for (std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i) {
+        for (std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
             sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
         }
     }
 
-    FatalConditionHandler::~FatalConditionHandler() {
-        reset();
-    }
-
-    void FatalConditionHandler::reset() {
-        if( isSet ) {
-            // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-            for( std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i ) {
-                sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
-            }
-            // Return the old stack
-            sigaltstack(&oldSigStack, nullptr);
-            isSet = false;
-        }
-    }
-
-    bool FatalConditionHandler::isSet = false;
-    struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
-    stack_t FatalConditionHandler::oldSigStack = {};
-    char FatalConditionHandler::altStackMem[sigStackSize] = {};
-
-} // namespace Catch
-
-#else
-
-namespace Catch {
-    void FatalConditionHandler::reset() {}
-}
-
-#endif // signals/SEH handling
-
 #if defined(__GNUC__)
 #    pragma GCC diagnostic pop
 #endif
+
+    void FatalConditionHandler::disengage_platform() {
+        restorePreviousSignalHandlers();
+    }
+
+} // end namespace Catch
+
+#endif // CATCH_CONFIG_POSIX_SIGNALS
 // end catch_fatal_condition.cpp
 // start catch_generators.cpp
 
@@ -10901,21 +11001,21 @@ namespace Catch {
 
 namespace Catch {
 
-IGeneratorTracker::~IGeneratorTracker() {}
+    IGeneratorTracker::~IGeneratorTracker() {}
 
-const char* GeneratorException::what() const noexcept {
-    return m_msg;
-}
-
-namespace Generators {
-
-    GeneratorUntypedBase::~GeneratorUntypedBase() {}
-
-    auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& {
-        return getResultCapture().acquireGeneratorTracker( generatorName, lineInfo );
+    const char* GeneratorException::what() const noexcept {
+        return m_msg;
     }
 
-} // namespace Generators
+    namespace Generators {
+
+        GeneratorUntypedBase::~GeneratorUntypedBase() {}
+
+        auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const& lineInfo) -> IGeneratorTracker& {
+            return getResultCapture().acquireGeneratorTracker(generatorName, lineInfo);
+        }
+
+    } // namespace Generators
 } // namespace Catch
 // end catch_generators.cpp
 // start catch_interfaces_capture.cpp
@@ -10959,40 +11059,40 @@ namespace Catch {
     public:
         ListeningReporter();
 
-        void addListener( IStreamingReporterPtr&& listener );
-        void addReporter( IStreamingReporterPtr&& reporter );
+        void addListener(IStreamingReporterPtr&& listener);
+        void addReporter(IStreamingReporterPtr&& reporter);
 
     public: // IStreamingReporter
 
         ReporterPreferences getPreferences() const override;
 
-        void noMatchingTestCases( std::string const& spec ) override;
+        void noMatchingTestCases(std::string const& spec) override;
 
-        void reportInvalidArguments(std::string const&arg) override;
+        void reportInvalidArguments(std::string const& arg) override;
 
         static std::set<Verbosity> getSupportedVerbosities();
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
         void benchmarkPreparing(std::string const& name) override;
-        void benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) override;
-        void benchmarkEnded( BenchmarkStats<> const& benchmarkStats ) override;
+        void benchmarkStarting(BenchmarkInfo const& benchmarkInfo) override;
+        void benchmarkEnded(BenchmarkStats<> const& benchmarkStats) override;
         void benchmarkFailed(std::string const&) override;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-        void testRunStarting( TestRunInfo const& testRunInfo ) override;
-        void testGroupStarting( GroupInfo const& groupInfo ) override;
-        void testCaseStarting( TestCaseInfo const& testInfo ) override;
-        void sectionStarting( SectionInfo const& sectionInfo ) override;
-        void assertionStarting( AssertionInfo const& assertionInfo ) override;
+        void testRunStarting(TestRunInfo const& testRunInfo) override;
+        void testGroupStarting(GroupInfo const& groupInfo) override;
+        void testCaseStarting(TestCaseInfo const& testInfo) override;
+        void sectionStarting(SectionInfo const& sectionInfo) override;
+        void assertionStarting(AssertionInfo const& assertionInfo) override;
 
         // The return value indicates if the messages buffer should be cleared:
-        bool assertionEnded( AssertionStats const& assertionStats ) override;
-        void sectionEnded( SectionStats const& sectionStats ) override;
-        void testCaseEnded( TestCaseStats const& testCaseStats ) override;
-        void testGroupEnded( TestGroupStats const& testGroupStats ) override;
-        void testRunEnded( TestRunStats const& testRunStats ) override;
+        bool assertionEnded(AssertionStats const& assertionStats) override;
+        void sectionEnded(SectionStats const& sectionStats) override;
+        void testCaseEnded(TestCaseStats const& testCaseStats) override;
+        void testGroupEnded(TestGroupStats const& testGroupStats) override;
+        void testRunEnded(TestRunStats const& testRunStats) override;
 
-        void skipTest( TestCaseInfo const& testInfo ) override;
+        void skipTest(TestCaseInfo const& testInfo) override;
         bool isMulti() const override;
 
     };
@@ -11002,99 +11102,99 @@ namespace Catch {
 // end catch_reporter_listening.h
 namespace Catch {
 
-    ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig )
-    :   m_stream( &_fullConfig->stream() ), m_fullConfig( _fullConfig ) {}
+    ReporterConfig::ReporterConfig(IConfigPtr const& _fullConfig)
+        : m_stream(&_fullConfig->stream()), m_fullConfig(_fullConfig) {}
 
-    ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream )
-    :   m_stream( &_stream ), m_fullConfig( _fullConfig ) {}
+    ReporterConfig::ReporterConfig(IConfigPtr const& _fullConfig, std::ostream& _stream)
+        : m_stream(&_stream), m_fullConfig(_fullConfig) {}
 
     std::ostream& ReporterConfig::stream() const { return *m_stream; }
     IConfigPtr ReporterConfig::fullConfig() const { return m_fullConfig; }
 
-    TestRunInfo::TestRunInfo( std::string const& _name ) : name( _name ) {}
+    TestRunInfo::TestRunInfo(std::string const& _name) : name(_name) {}
 
-    GroupInfo::GroupInfo(  std::string const& _name,
-                           std::size_t _groupIndex,
-                           std::size_t _groupsCount )
-    :   name( _name ),
-        groupIndex( _groupIndex ),
-        groupsCounts( _groupsCount )
+    GroupInfo::GroupInfo(std::string const& _name,
+        std::size_t _groupIndex,
+        std::size_t _groupsCount)
+        : name(_name),
+        groupIndex(_groupIndex),
+        groupsCounts(_groupsCount)
     {}
 
-     AssertionStats::AssertionStats( AssertionResult const& _assertionResult,
-                                     std::vector<MessageInfo> const& _infoMessages,
-                                     Totals const& _totals )
-    :   assertionResult( _assertionResult ),
-        infoMessages( _infoMessages ),
-        totals( _totals )
+    AssertionStats::AssertionStats(AssertionResult const& _assertionResult,
+        std::vector<MessageInfo> const& _infoMessages,
+        Totals const& _totals)
+        : assertionResult(_assertionResult),
+        infoMessages(_infoMessages),
+        totals(_totals)
     {
         assertionResult.m_resultData.lazyExpression.m_transientExpression = _assertionResult.m_resultData.lazyExpression.m_transientExpression;
 
-        if( assertionResult.hasMessage() ) {
+        if (assertionResult.hasMessage()) {
             // Copy message into messages list.
             // !TBD This should have been done earlier, somewhere
-            MessageBuilder builder( assertionResult.getTestMacroName(), assertionResult.getSourceInfo(), assertionResult.getResultType() );
+            MessageBuilder builder(assertionResult.getTestMacroName(), assertionResult.getSourceInfo(), assertionResult.getResultType());
             builder << assertionResult.getMessage();
             builder.m_info.message = builder.m_stream.str();
 
-            infoMessages.push_back( builder.m_info );
+            infoMessages.push_back(builder.m_info);
         }
     }
 
-     AssertionStats::~AssertionStats() = default;
+    AssertionStats::~AssertionStats() = default;
 
-    SectionStats::SectionStats(  SectionInfo const& _sectionInfo,
-                                 Counts const& _assertions,
-                                 double _durationInSeconds,
-                                 bool _missingAssertions )
-    :   sectionInfo( _sectionInfo ),
-        assertions( _assertions ),
-        durationInSeconds( _durationInSeconds ),
-        missingAssertions( _missingAssertions )
+    SectionStats::SectionStats(SectionInfo const& _sectionInfo,
+        Counts const& _assertions,
+        double _durationInSeconds,
+        bool _missingAssertions)
+        : sectionInfo(_sectionInfo),
+        assertions(_assertions),
+        durationInSeconds(_durationInSeconds),
+        missingAssertions(_missingAssertions)
     {}
 
     SectionStats::~SectionStats() = default;
 
-    TestCaseStats::TestCaseStats(  TestCaseInfo const& _testInfo,
-                                   Totals const& _totals,
-                                   std::string const& _stdOut,
-                                   std::string const& _stdErr,
-                                   bool _aborting )
-    : testInfo( _testInfo ),
-        totals( _totals ),
-        stdOut( _stdOut ),
-        stdErr( _stdErr ),
-        aborting( _aborting )
+    TestCaseStats::TestCaseStats(TestCaseInfo const& _testInfo,
+        Totals const& _totals,
+        std::string const& _stdOut,
+        std::string const& _stdErr,
+        bool _aborting)
+        : testInfo(_testInfo),
+        totals(_totals),
+        stdOut(_stdOut),
+        stdErr(_stdErr),
+        aborting(_aborting)
     {}
 
     TestCaseStats::~TestCaseStats() = default;
 
-    TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo,
-                                    Totals const& _totals,
-                                    bool _aborting )
-    :   groupInfo( _groupInfo ),
-        totals( _totals ),
-        aborting( _aborting )
+    TestGroupStats::TestGroupStats(GroupInfo const& _groupInfo,
+        Totals const& _totals,
+        bool _aborting)
+        : groupInfo(_groupInfo),
+        totals(_totals),
+        aborting(_aborting)
     {}
 
-    TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo )
-    :   groupInfo( _groupInfo ),
-        aborting( false )
+    TestGroupStats::TestGroupStats(GroupInfo const& _groupInfo)
+        : groupInfo(_groupInfo),
+        aborting(false)
     {}
 
     TestGroupStats::~TestGroupStats() = default;
 
-    TestRunStats::TestRunStats(   TestRunInfo const& _runInfo,
-                    Totals const& _totals,
-                    bool _aborting )
-    :   runInfo( _runInfo ),
-        totals( _totals ),
-        aborting( _aborting )
+    TestRunStats::TestRunStats(TestRunInfo const& _runInfo,
+        Totals const& _totals,
+        bool _aborting)
+        : runInfo(_runInfo),
+        totals(_totals),
+        aborting(_aborting)
     {}
 
     TestRunStats::~TestRunStats() = default;
 
-    void IStreamingReporter::fatalErrorEncountered( StringRef ) {}
+    void IStreamingReporter::fatalErrorEncountered(StringRef) {}
     bool IStreamingReporter::isMulti() const { return false; }
 
     IReporterFactory::~IReporterFactory() = default;
@@ -11136,7 +11236,7 @@ namespace Catch {
 
 #else
 
-    Catch::LeakDetector::LeakDetector() {}
+Catch::LeakDetector::LeakDetector() {}
 
 #endif
 
@@ -11152,23 +11252,23 @@ Catch::LeakDetector::~LeakDetector() {
 
 namespace Catch {
 
-    std::size_t listTests( Config const& config );
+    std::size_t listTests(Config const& config);
 
-    std::size_t listTestsNamesOnly( Config const& config );
+    std::size_t listTestsNamesOnly(Config const& config);
 
     struct TagInfo {
-        void add( std::string const& spelling );
+        void add(std::string const& spelling);
         std::string all() const;
 
         std::set<std::string> spellings;
         std::size_t count = 0;
     };
 
-    std::size_t listTags( Config const& config );
+    std::size_t listTags(Config const& config);
 
     std::size_t listReporters();
 
-    Option<std::size_t> list( std::shared_ptr<Config> const& config );
+    Option<std::size_t> list(std::shared_ptr<Config> const& config);
 
 } // end namespace Catch
 
@@ -11186,60 +11286,60 @@ namespace Catch {
 
 namespace Catch {
 
-    std::size_t listTests( Config const& config ) {
+    std::size_t listTests(Config const& config) {
         TestSpec const& testSpec = config.testSpec();
-        if( config.hasTestFilters() )
+        if (config.hasTestFilters())
             Catch::cout() << "Matching test cases:\n";
         else {
             Catch::cout() << "All available test cases:\n";
         }
 
-        auto matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-        for( auto const& testCaseInfo : matchedTestCases ) {
+        auto matchedTestCases = filterTests(getAllTestCasesSorted(config), testSpec, config);
+        for (auto const& testCaseInfo : matchedTestCases) {
             Colour::Code colour = testCaseInfo.isHidden()
                 ? Colour::SecondaryText
                 : Colour::None;
-            Colour colourGuard( colour );
+            Colour colourGuard(colour);
 
-            Catch::cout() << Column( testCaseInfo.name ).initialIndent( 2 ).indent( 4 ) << "\n";
-            if( config.verbosity() >= Verbosity::High ) {
-                Catch::cout() << Column( Catch::Detail::stringify( testCaseInfo.lineInfo ) ).indent(4) << std::endl;
+            Catch::cout() << Column(testCaseInfo.name).initialIndent(2).indent(4) << "\n";
+            if (config.verbosity() >= Verbosity::High) {
+                Catch::cout() << Column(Catch::Detail::stringify(testCaseInfo.lineInfo)).indent(4) << std::endl;
                 std::string description = testCaseInfo.description;
-                if( description.empty() )
+                if (description.empty())
                     description = "(NO DESCRIPTION)";
-                Catch::cout() << Column( description ).indent(4) << std::endl;
+                Catch::cout() << Column(description).indent(4) << std::endl;
             }
-            if( !testCaseInfo.tags.empty() )
-                Catch::cout() << Column( testCaseInfo.tagsAsString() ).indent( 6 ) << "\n";
+            if (!testCaseInfo.tags.empty())
+                Catch::cout() << Column(testCaseInfo.tagsAsString()).indent(6) << "\n";
         }
 
-        if( !config.hasTestFilters() )
-            Catch::cout() << pluralise( matchedTestCases.size(), "test case" ) << '\n' << std::endl;
+        if (!config.hasTestFilters())
+            Catch::cout() << pluralise(matchedTestCases.size(), "test case") << '\n' << std::endl;
         else
-            Catch::cout() << pluralise( matchedTestCases.size(), "matching test case" ) << '\n' << std::endl;
+            Catch::cout() << pluralise(matchedTestCases.size(), "matching test case") << '\n' << std::endl;
         return matchedTestCases.size();
     }
 
-    std::size_t listTestsNamesOnly( Config const& config ) {
+    std::size_t listTestsNamesOnly(Config const& config) {
         TestSpec const& testSpec = config.testSpec();
         std::size_t matchedTests = 0;
-        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-        for( auto const& testCaseInfo : matchedTestCases ) {
+        std::vector<TestCase> matchedTestCases = filterTests(getAllTestCasesSorted(config), testSpec, config);
+        for (auto const& testCaseInfo : matchedTestCases) {
             matchedTests++;
-            if( startsWith( testCaseInfo.name, '#' ) )
-               Catch::cout() << '"' << testCaseInfo.name << '"';
+            if (startsWith(testCaseInfo.name, '#'))
+                Catch::cout() << '"' << testCaseInfo.name << '"';
             else
-               Catch::cout() << testCaseInfo.name;
-            if ( config.verbosity() >= Verbosity::High )
+                Catch::cout() << testCaseInfo.name;
+            if (config.verbosity() >= Verbosity::High)
                 Catch::cout() << "\t@" << testCaseInfo.lineInfo;
             Catch::cout() << std::endl;
         }
         return matchedTests;
     }
 
-    void TagInfo::add( std::string const& spelling ) {
+    void TagInfo::add(std::string const& spelling) {
         ++count;
-        spellings.insert( spelling );
+        spellings.insert(spelling);
     }
 
     std::string TagInfo::all() const {
@@ -11258,9 +11358,9 @@ namespace Catch {
         return out;
     }
 
-    std::size_t listTags( Config const& config ) {
+    std::size_t listTags(Config const& config) {
         TestSpec const& testSpec = config.testSpec();
-        if( config.hasTestFilters() )
+        if (config.hasTestFilters())
             Catch::cout() << "Tags for matching test cases:\n";
         else {
             Catch::cout() << "All available tags:\n";
@@ -11268,28 +11368,28 @@ namespace Catch {
 
         std::map<std::string, TagInfo> tagCounts;
 
-        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-        for( auto const& testCase : matchedTestCases ) {
-            for( auto const& tagName : testCase.getTestCaseInfo().tags ) {
-                std::string lcaseTagName = toLower( tagName );
-                auto countIt = tagCounts.find( lcaseTagName );
-                if( countIt == tagCounts.end() )
-                    countIt = tagCounts.insert( std::make_pair( lcaseTagName, TagInfo() ) ).first;
-                countIt->second.add( tagName );
+        std::vector<TestCase> matchedTestCases = filterTests(getAllTestCasesSorted(config), testSpec, config);
+        for (auto const& testCase : matchedTestCases) {
+            for (auto const& tagName : testCase.getTestCaseInfo().tags) {
+                std::string lcaseTagName = toLower(tagName);
+                auto countIt = tagCounts.find(lcaseTagName);
+                if (countIt == tagCounts.end())
+                    countIt = tagCounts.insert(std::make_pair(lcaseTagName, TagInfo())).first;
+                countIt->second.add(tagName);
             }
         }
 
-        for( auto const& tagCount : tagCounts ) {
+        for (auto const& tagCount : tagCounts) {
             ReusableStringStream rss;
             rss << "  " << std::setw(2) << tagCount.second.count << "  ";
             auto str = rss.str();
-            auto wrapper = Column( tagCount.second.all() )
-                                                    .initialIndent( 0 )
-                                                    .indent( str.size() )
-                                                    .width( CATCH_CONFIG_CONSOLE_WIDTH-10 );
+            auto wrapper = Column(tagCount.second.all())
+                .initialIndent(0)
+                .indent(str.size())
+                .width(CATCH_CONFIG_CONSOLE_WIDTH - 10);
             Catch::cout() << str << wrapper << '\n';
         }
-        Catch::cout() << pluralise( tagCounts.size(), "tag" ) << '\n' << std::endl;
+        Catch::cout() << pluralise(tagCounts.size(), "tag") << '\n' << std::endl;
         return tagCounts.size();
     }
 
@@ -11297,34 +11397,34 @@ namespace Catch {
         Catch::cout() << "Available reporters:\n";
         IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
         std::size_t maxNameLen = 0;
-        for( auto const& factoryKvp : factories )
-            maxNameLen = (std::max)( maxNameLen, factoryKvp.first.size() );
+        for (auto const& factoryKvp : factories)
+            maxNameLen = (std::max)(maxNameLen, factoryKvp.first.size());
 
-        for( auto const& factoryKvp : factories ) {
+        for (auto const& factoryKvp : factories) {
             Catch::cout()
-                    << Column( factoryKvp.first + ":" )
-                            .indent(2)
-                            .width( 5+maxNameLen )
-                    +  Column( factoryKvp.second->getDescription() )
-                            .initialIndent(0)
-                            .indent(2)
-                            .width( CATCH_CONFIG_CONSOLE_WIDTH - maxNameLen-8 )
-                    << "\n";
+                << Column(factoryKvp.first + ":")
+                .indent(2)
+                .width(5 + maxNameLen)
+                + Column(factoryKvp.second->getDescription())
+                .initialIndent(0)
+                .indent(2)
+                .width(CATCH_CONFIG_CONSOLE_WIDTH - maxNameLen - 8)
+                << "\n";
         }
         Catch::cout() << std::endl;
         return factories.size();
     }
 
-    Option<std::size_t> list( std::shared_ptr<Config> const& config ) {
+    Option<std::size_t> list(std::shared_ptr<Config> const& config) {
         Option<std::size_t> listedCount;
-        getCurrentMutableContext().setConfig( config );
-        if( config->listTests() )
-            listedCount = listedCount.valueOr(0) + listTests( *config );
-        if( config->listTestNamesOnly() )
-            listedCount = listedCount.valueOr(0) + listTestsNamesOnly( *config );
-        if( config->listTags() )
-            listedCount = listedCount.valueOr(0) + listTags( *config );
-        if( config->listReporters() )
+        getCurrentMutableContext().setConfig(config);
+        if (config->listTests())
+            listedCount = listedCount.valueOr(0) + listTests(*config);
+        if (config->listTestNamesOnly())
+            listedCount = listedCount.valueOr(0) + listTestsNamesOnly(*config);
+        if (config->listTags())
+            listedCount = listedCount.valueOr(0) + listTags(*config);
+        if (config->listReporters())
             listedCount = listedCount.valueOr(0) + listReporters();
         return listedCount;
     }
@@ -11334,46 +11434,46 @@ namespace Catch {
 // start catch_matchers.cpp
 
 namespace Catch {
-namespace Matchers {
-    namespace Impl {
+    namespace Matchers {
+        namespace Impl {
 
-        std::string MatcherUntypedBase::toString() const {
-            if( m_cachedToString.empty() )
-                m_cachedToString = describe();
-            return m_cachedToString;
-        }
+            std::string MatcherUntypedBase::toString() const {
+                if (m_cachedToString.empty())
+                    m_cachedToString = describe();
+                return m_cachedToString;
+            }
 
-        MatcherUntypedBase::~MatcherUntypedBase() = default;
+            MatcherUntypedBase::~MatcherUntypedBase() = default;
 
-    } // namespace Impl
-} // namespace Matchers
+        } // namespace Impl
+    } // namespace Matchers
 
-using namespace Matchers;
-using Matchers::Impl::MatcherBase;
+    using namespace Matchers;
+    using Matchers::Impl::MatcherBase;
 
 } // namespace Catch
 // end catch_matchers.cpp
 // start catch_matchers_exception.cpp
 
 namespace Catch {
-namespace Matchers {
-namespace Exception {
+    namespace Matchers {
+        namespace Exception {
 
-bool ExceptionMessageMatcher::match(std::exception const& ex) const {
-    return ex.what() == m_message;
-}
+            bool ExceptionMessageMatcher::match(std::exception const& ex) const {
+                return ex.what() == m_message;
+            }
 
-std::string ExceptionMessageMatcher::describe() const {
-    return "exception message matches \"" + m_message + "\"";
-}
+            std::string ExceptionMessageMatcher::describe() const {
+                return "exception message matches \"" + m_message + "\"";
+            }
 
-}
-Exception::ExceptionMessageMatcher Message(std::string const& message) {
-    return Exception::ExceptionMessageMatcher(message);
-}
+        }
+        Exception::ExceptionMessageMatcher Message(std::string const& message) {
+            return Exception::ExceptionMessageMatcher(message);
+        }
 
-// namespace Exception
-} // namespace Matchers
+        // namespace Exception
+    } // namespace Matchers
 } // namespace Catch
 // end catch_matchers_exception.cpp
 // start catch_matchers_floating.cpp
@@ -11415,220 +11515,223 @@ namespace Catch {
 #include <limits>
 
 namespace Catch {
-namespace {
+    namespace {
 
-    int32_t convert(float f) {
-        static_assert(sizeof(float) == sizeof(int32_t), "Important ULP matcher assumption violated");
-        int32_t i;
-        std::memcpy(&i, &f, sizeof(f));
-        return i;
-    }
-
-    int64_t convert(double d) {
-        static_assert(sizeof(double) == sizeof(int64_t), "Important ULP matcher assumption violated");
-        int64_t i;
-        std::memcpy(&i, &d, sizeof(d));
-        return i;
-    }
-
-    template <typename FP>
-    bool almostEqualUlps(FP lhs, FP rhs, uint64_t maxUlpDiff) {
-        // Comparison with NaN should always be false.
-        // This way we can rule it out before getting into the ugly details
-        if (Catch::isnan(lhs) || Catch::isnan(rhs)) {
-            return false;
+        int32_t convert(float f) {
+            static_assert(sizeof(float) == sizeof(int32_t), "Important ULP matcher assumption violated");
+            int32_t i;
+            std::memcpy(&i, &f, sizeof(f));
+            return i;
         }
 
-        auto lc = convert(lhs);
-        auto rc = convert(rhs);
-
-        if ((lc < 0) != (rc < 0)) {
-            // Potentially we can have +0 and -0
-            return lhs == rhs;
+        int64_t convert(double d) {
+            static_assert(sizeof(double) == sizeof(int64_t), "Important ULP matcher assumption violated");
+            int64_t i;
+            std::memcpy(&i, &d, sizeof(d));
+            return i;
         }
 
-        auto ulpDiff = std::abs(lc - rc);
-        return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
-    }
+        template <typename FP>
+        bool almostEqualUlps(FP lhs, FP rhs, uint64_t maxUlpDiff) {
+            // Comparison with NaN should always be false.
+            // This way we can rule it out before getting into the ugly details
+            if (Catch::isnan(lhs) || Catch::isnan(rhs)) {
+                return false;
+            }
+
+            auto lc = convert(lhs);
+            auto rc = convert(rhs);
+
+            if ((lc < 0) != (rc < 0)) {
+                // Potentially we can have +0 and -0
+                return lhs == rhs;
+            }
+
+            // static cast as a workaround for IBM XLC
+            auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
+            return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
+        }
 
 #if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
 
-    float nextafter(float x, float y) {
-        return ::nextafterf(x, y);
-    }
+        float nextafter(float x, float y) {
+            return ::nextafterf(x, y);
+        }
 
-    double nextafter(double x, double y) {
-        return ::nextafter(x, y);
-    }
+        double nextafter(double x, double y) {
+            return ::nextafter(x, y);
+        }
 
 #endif // ^^^ CATCH_CONFIG_GLOBAL_NEXTAFTER ^^^
 
-template <typename FP>
-FP step(FP start, FP direction, uint64_t steps) {
-    for (uint64_t i = 0; i < steps; ++i) {
+        template <typename FP>
+        FP step(FP start, FP direction, uint64_t steps) {
+            for (uint64_t i = 0; i < steps; ++i) {
 #if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
-        start = Catch::nextafter(start, direction);
+                start = Catch::nextafter(start, direction);
 #else
-        start = std::nextafter(start, direction);
+                start = std::nextafter(start, direction);
 #endif
-    }
-    return start;
-}
+            }
+            return start;
+        }
 
-// Performs equivalent check of std::fabs(lhs - rhs) <= margin
-// But without the subtraction to allow for INFINITY in comparison
-bool marginComparison(double lhs, double rhs, double margin) {
-    return (lhs + margin >= rhs) && (rhs + margin >= lhs);
-}
+        // Performs equivalent check of std::fabs(lhs - rhs) <= margin
+        // But without the subtraction to allow for INFINITY in comparison
+        bool marginComparison(double lhs, double rhs, double margin) {
+            return (lhs + margin >= rhs) && (rhs + margin >= lhs);
+        }
 
-template <typename FloatingPoint>
-void write(std::ostream& out, FloatingPoint num) {
-    out << std::scientific
-        << std::setprecision(std::numeric_limits<FloatingPoint>::max_digits10 - 1)
-        << num;
-}
+        template <typename FloatingPoint>
+        void write(std::ostream& out, FloatingPoint num) {
+            out << std::scientific
+                << std::setprecision(std::numeric_limits<FloatingPoint>::max_digits10 - 1)
+                << num;
+        }
 
-} // end anonymous namespace
+    } // end anonymous namespace
 
-namespace Matchers {
-namespace Floating {
+    namespace Matchers {
+        namespace Floating {
 
-    enum class FloatingPointKind : uint8_t {
-        Float,
-        Double
-    };
+            enum class FloatingPointKind : uint8_t {
+                Float,
+                Double
+            };
 
-    WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
-        :m_target{ target }, m_margin{ margin } {
-        CATCH_ENFORCE(margin >= 0, "Invalid margin: " << margin << '.'
-            << " Margin has to be non-negative.");
-    }
+            WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
+                :m_target{ target }, m_margin{ margin } {
+                CATCH_ENFORCE(margin >= 0, "Invalid margin: " << margin << '.'
+                    << " Margin has to be non-negative.");
+            }
 
-    // Performs equivalent check of std::fabs(lhs - rhs) <= margin
-    // But without the subtraction to allow for INFINITY in comparison
-    bool WithinAbsMatcher::match(double const& matchee) const {
-        return (matchee + m_margin >= m_target) && (m_target + m_margin >= matchee);
-    }
+            // Performs equivalent check of std::fabs(lhs - rhs) <= margin
+            // But without the subtraction to allow for INFINITY in comparison
+            bool WithinAbsMatcher::match(double const& matchee) const {
+                return (matchee + m_margin >= m_target) && (m_target + m_margin >= matchee);
+            }
 
-    std::string WithinAbsMatcher::describe() const {
-        return "is within " + ::Catch::Detail::stringify(m_margin) + " of " + ::Catch::Detail::stringify(m_target);
-    }
+            std::string WithinAbsMatcher::describe() const {
+                return "is within " + ::Catch::Detail::stringify(m_margin) + " of " + ::Catch::Detail::stringify(m_target);
+            }
 
-    WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType)
-        :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
-        CATCH_ENFORCE(m_type == FloatingPointKind::Double
-                   || m_ulps < (std::numeric_limits<uint32_t>::max)(),
-            "Provided ULP is impossibly large for a float comparison.");
-    }
+            WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType)
+                :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
+                CATCH_ENFORCE(m_type == FloatingPointKind::Double
+                    || m_ulps < (std::numeric_limits<uint32_t>::max)(),
+                    "Provided ULP is impossibly large for a float comparison.");
+            }
 
 #if defined(__clang__)
 #pragma clang diagnostic push
-// Clang <3.5 reports on the default branch in the switch below
+            // Clang <3.5 reports on the default branch in the switch below
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
 
-    bool WithinUlpsMatcher::match(double const& matchee) const {
-        switch (m_type) {
-        case FloatingPointKind::Float:
-            return almostEqualUlps<float>(static_cast<float>(matchee), static_cast<float>(m_target), m_ulps);
-        case FloatingPointKind::Double:
-            return almostEqualUlps<double>(matchee, m_target, m_ulps);
-        default:
-            CATCH_INTERNAL_ERROR( "Unknown FloatingPointKind value" );
-        }
-    }
+            bool WithinUlpsMatcher::match(double const& matchee) const {
+                switch (m_type) {
+                case FloatingPointKind::Float:
+                    return almostEqualUlps<float>(static_cast<float>(matchee), static_cast<float>(m_target), m_ulps);
+                case FloatingPointKind::Double:
+                    return almostEqualUlps<double>(matchee, m_target, m_ulps);
+                default:
+                    CATCH_INTERNAL_ERROR("Unknown FloatingPointKind value");
+                }
+            }
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
-    std::string WithinUlpsMatcher::describe() const {
-        std::stringstream ret;
+            std::string WithinUlpsMatcher::describe() const {
+                std::stringstream ret;
 
-        ret << "is within " << m_ulps << " ULPs of ";
+                ret << "is within " << m_ulps << " ULPs of ";
 
-        if (m_type == FloatingPointKind::Float) {
-            write(ret, static_cast<float>(m_target));
-            ret << 'f';
-        } else {
-            write(ret, m_target);
+                if (m_type == FloatingPointKind::Float) {
+                    write(ret, static_cast<float>(m_target));
+                    ret << 'f';
+                }
+                else {
+                    write(ret, m_target);
+                }
+
+                ret << " ([";
+                if (m_type == FloatingPointKind::Double) {
+                    write(ret, step(m_target, static_cast<double>(-INFINITY), m_ulps));
+                    ret << ", ";
+                    write(ret, step(m_target, static_cast<double>(INFINITY), m_ulps));
+                }
+                else {
+                    // We have to cast INFINITY to float because of MinGW, see #1782
+                    write(ret, step(static_cast<float>(m_target), static_cast<float>(-INFINITY), m_ulps));
+                    ret << ", ";
+                    write(ret, step(static_cast<float>(m_target), static_cast<float>(INFINITY), m_ulps));
+                }
+                ret << "])";
+
+                return ret.str();
+            }
+
+            WithinRelMatcher::WithinRelMatcher(double target, double epsilon) :
+                m_target(target),
+                m_epsilon(epsilon) {
+                CATCH_ENFORCE(m_epsilon >= 0., "Relative comparison with epsilon <  0 does not make sense.");
+                CATCH_ENFORCE(m_epsilon < 1., "Relative comparison with epsilon >= 1 does not make sense.");
+            }
+
+            bool WithinRelMatcher::match(double const& matchee) const {
+                const auto relMargin = m_epsilon * (std::max)(std::fabs(matchee), std::fabs(m_target));
+                return marginComparison(matchee, m_target,
+                    std::isinf(relMargin) ? 0 : relMargin);
+            }
+
+            std::string WithinRelMatcher::describe() const {
+                Catch::ReusableStringStream sstr;
+                sstr << "and " << m_target << " are within " << m_epsilon * 100. << "% of each other";
+                return sstr.str();
+            }
+
+        }// namespace Floating
+
+        Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff) {
+            return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Double);
         }
 
-        ret << " ([";
-        if (m_type == FloatingPointKind::Double) {
-            write(ret, step(m_target, static_cast<double>(-INFINITY), m_ulps));
-            ret << ", ";
-            write(ret, step(m_target, static_cast<double>( INFINITY), m_ulps));
-        } else {
-            // We have to cast INFINITY to float because of MinGW, see #1782
-            write(ret, step(static_cast<float>(m_target), static_cast<float>(-INFINITY), m_ulps));
-            ret << ", ";
-            write(ret, step(static_cast<float>(m_target), static_cast<float>( INFINITY), m_ulps));
+        Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff) {
+            return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Float);
         }
-        ret << "])";
 
-        return ret.str();
-    }
+        Floating::WithinAbsMatcher WithinAbs(double target, double margin) {
+            return Floating::WithinAbsMatcher(target, margin);
+        }
 
-    WithinRelMatcher::WithinRelMatcher(double target, double epsilon):
-        m_target(target),
-        m_epsilon(epsilon){
-        CATCH_ENFORCE(m_epsilon >= 0., "Relative comparison with epsilon <  0 does not make sense.");
-        CATCH_ENFORCE(m_epsilon  < 1., "Relative comparison with epsilon >= 1 does not make sense.");
-    }
+        Floating::WithinRelMatcher WithinRel(double target, double eps) {
+            return Floating::WithinRelMatcher(target, eps);
+        }
 
-    bool WithinRelMatcher::match(double const& matchee) const {
-        const auto relMargin = m_epsilon * (std::max)(std::fabs(matchee), std::fabs(m_target));
-        return marginComparison(matchee, m_target,
-                                std::isinf(relMargin)? 0 : relMargin);
-    }
+        Floating::WithinRelMatcher WithinRel(double target) {
+            return Floating::WithinRelMatcher(target, std::numeric_limits<double>::epsilon() * 100);
+        }
 
-    std::string WithinRelMatcher::describe() const {
-        Catch::ReusableStringStream sstr;
-        sstr << "and " << m_target << " are within " << m_epsilon * 100. << "% of each other";
-        return sstr.str();
-    }
+        Floating::WithinRelMatcher WithinRel(float target, float eps) {
+            return Floating::WithinRelMatcher(target, eps);
+        }
 
-}// namespace Floating
+        Floating::WithinRelMatcher WithinRel(float target) {
+            return Floating::WithinRelMatcher(target, std::numeric_limits<float>::epsilon() * 100);
+        }
 
-Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff) {
-    return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Double);
-}
-
-Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff) {
-    return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Float);
-}
-
-Floating::WithinAbsMatcher WithinAbs(double target, double margin) {
-    return Floating::WithinAbsMatcher(target, margin);
-}
-
-Floating::WithinRelMatcher WithinRel(double target, double eps) {
-    return Floating::WithinRelMatcher(target, eps);
-}
-
-Floating::WithinRelMatcher WithinRel(double target) {
-    return Floating::WithinRelMatcher(target, std::numeric_limits<double>::epsilon() * 100);
-}
-
-Floating::WithinRelMatcher WithinRel(float target, float eps) {
-    return Floating::WithinRelMatcher(target, eps);
-}
-
-Floating::WithinRelMatcher WithinRel(float target) {
-    return Floating::WithinRelMatcher(target, std::numeric_limits<float>::epsilon() * 100);
-}
-
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
-
 // end catch_matchers_floating.cpp
 // start catch_matchers_generic.cpp
 
 std::string Catch::Matchers::Generic::Detail::finalizeDescription(const std::string& desc) {
     if (desc.empty()) {
         return "matches undescribed predicate";
-    } else {
+    }
+    else {
         return "matches predicate: \"" + desc + '"';
     }
 }
@@ -11638,101 +11741,101 @@ std::string Catch::Matchers::Generic::Detail::finalizeDescription(const std::str
 #include <regex>
 
 namespace Catch {
-namespace Matchers {
+    namespace Matchers {
 
-    namespace StdString {
+        namespace StdString {
 
-        CasedString::CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity )
-        :   m_caseSensitivity( caseSensitivity ),
-            m_str( adjustString( str ) )
-        {}
-        std::string CasedString::adjustString( std::string const& str ) const {
-            return m_caseSensitivity == CaseSensitive::No
-                   ? toLower( str )
-                   : str;
-        }
-        std::string CasedString::caseSensitivitySuffix() const {
-            return m_caseSensitivity == CaseSensitive::No
-                   ? " (case insensitive)"
-                   : std::string();
-        }
-
-        StringMatcherBase::StringMatcherBase( std::string const& operation, CasedString const& comparator )
-        : m_comparator( comparator ),
-          m_operation( operation ) {
-        }
-
-        std::string StringMatcherBase::describe() const {
-            std::string description;
-            description.reserve(5 + m_operation.size() + m_comparator.m_str.size() +
-                                        m_comparator.caseSensitivitySuffix().size());
-            description += m_operation;
-            description += ": \"";
-            description += m_comparator.m_str;
-            description += "\"";
-            description += m_comparator.caseSensitivitySuffix();
-            return description;
-        }
-
-        EqualsMatcher::EqualsMatcher( CasedString const& comparator ) : StringMatcherBase( "equals", comparator ) {}
-
-        bool EqualsMatcher::match( std::string const& source ) const {
-            return m_comparator.adjustString( source ) == m_comparator.m_str;
-        }
-
-        ContainsMatcher::ContainsMatcher( CasedString const& comparator ) : StringMatcherBase( "contains", comparator ) {}
-
-        bool ContainsMatcher::match( std::string const& source ) const {
-            return contains( m_comparator.adjustString( source ), m_comparator.m_str );
-        }
-
-        StartsWithMatcher::StartsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "starts with", comparator ) {}
-
-        bool StartsWithMatcher::match( std::string const& source ) const {
-            return startsWith( m_comparator.adjustString( source ), m_comparator.m_str );
-        }
-
-        EndsWithMatcher::EndsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "ends with", comparator ) {}
-
-        bool EndsWithMatcher::match( std::string const& source ) const {
-            return endsWith( m_comparator.adjustString( source ), m_comparator.m_str );
-        }
-
-        RegexMatcher::RegexMatcher(std::string regex, CaseSensitive::Choice caseSensitivity): m_regex(std::move(regex)), m_caseSensitivity(caseSensitivity) {}
-
-        bool RegexMatcher::match(std::string const& matchee) const {
-            auto flags = std::regex::ECMAScript; // ECMAScript is the default syntax option anyway
-            if (m_caseSensitivity == CaseSensitive::Choice::No) {
-                flags |= std::regex::icase;
+            CasedString::CasedString(std::string const& str, CaseSensitive::Choice caseSensitivity)
+                : m_caseSensitivity(caseSensitivity),
+                m_str(adjustString(str))
+            {}
+            std::string CasedString::adjustString(std::string const& str) const {
+                return m_caseSensitivity == CaseSensitive::No
+                    ? toLower(str)
+                    : str;
             }
-            auto reg = std::regex(m_regex, flags);
-            return std::regex_match(matchee, reg);
+            std::string CasedString::caseSensitivitySuffix() const {
+                return m_caseSensitivity == CaseSensitive::No
+                    ? " (case insensitive)"
+                    : std::string();
+            }
+
+            StringMatcherBase::StringMatcherBase(std::string const& operation, CasedString const& comparator)
+                : m_comparator(comparator),
+                m_operation(operation) {
+            }
+
+            std::string StringMatcherBase::describe() const {
+                std::string description;
+                description.reserve(5 + m_operation.size() + m_comparator.m_str.size() +
+                    m_comparator.caseSensitivitySuffix().size());
+                description += m_operation;
+                description += ": \"";
+                description += m_comparator.m_str;
+                description += "\"";
+                description += m_comparator.caseSensitivitySuffix();
+                return description;
+            }
+
+            EqualsMatcher::EqualsMatcher(CasedString const& comparator) : StringMatcherBase("equals", comparator) {}
+
+            bool EqualsMatcher::match(std::string const& source) const {
+                return m_comparator.adjustString(source) == m_comparator.m_str;
+            }
+
+            ContainsMatcher::ContainsMatcher(CasedString const& comparator) : StringMatcherBase("contains", comparator) {}
+
+            bool ContainsMatcher::match(std::string const& source) const {
+                return contains(m_comparator.adjustString(source), m_comparator.m_str);
+            }
+
+            StartsWithMatcher::StartsWithMatcher(CasedString const& comparator) : StringMatcherBase("starts with", comparator) {}
+
+            bool StartsWithMatcher::match(std::string const& source) const {
+                return startsWith(m_comparator.adjustString(source), m_comparator.m_str);
+            }
+
+            EndsWithMatcher::EndsWithMatcher(CasedString const& comparator) : StringMatcherBase("ends with", comparator) {}
+
+            bool EndsWithMatcher::match(std::string const& source) const {
+                return endsWith(m_comparator.adjustString(source), m_comparator.m_str);
+            }
+
+            RegexMatcher::RegexMatcher(std::string regex, CaseSensitive::Choice caseSensitivity) : m_regex(std::move(regex)), m_caseSensitivity(caseSensitivity) {}
+
+            bool RegexMatcher::match(std::string const& matchee) const {
+                auto flags = std::regex::ECMAScript; // ECMAScript is the default syntax option anyway
+                if (m_caseSensitivity == CaseSensitive::Choice::No) {
+                    flags |= std::regex::icase;
+                }
+                auto reg = std::regex(m_regex, flags);
+                return std::regex_match(matchee, reg);
+            }
+
+            std::string RegexMatcher::describe() const {
+                return "matches " + ::Catch::Detail::stringify(m_regex) + ((m_caseSensitivity == CaseSensitive::Choice::Yes) ? " case sensitively" : " case insensitively");
+            }
+
+        } // namespace StdString
+
+        StdString::EqualsMatcher Equals(std::string const& str, CaseSensitive::Choice caseSensitivity) {
+            return StdString::EqualsMatcher(StdString::CasedString(str, caseSensitivity));
+        }
+        StdString::ContainsMatcher Contains(std::string const& str, CaseSensitive::Choice caseSensitivity) {
+            return StdString::ContainsMatcher(StdString::CasedString(str, caseSensitivity));
+        }
+        StdString::EndsWithMatcher EndsWith(std::string const& str, CaseSensitive::Choice caseSensitivity) {
+            return StdString::EndsWithMatcher(StdString::CasedString(str, caseSensitivity));
+        }
+        StdString::StartsWithMatcher StartsWith(std::string const& str, CaseSensitive::Choice caseSensitivity) {
+            return StdString::StartsWithMatcher(StdString::CasedString(str, caseSensitivity));
         }
 
-        std::string RegexMatcher::describe() const {
-            return "matches " + ::Catch::Detail::stringify(m_regex) + ((m_caseSensitivity == CaseSensitive::Choice::Yes)? " case sensitively" : " case insensitively");
+        StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice caseSensitivity) {
+            return StdString::RegexMatcher(regex, caseSensitivity);
         }
 
-    } // namespace StdString
-
-    StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-        return StdString::EqualsMatcher( StdString::CasedString( str, caseSensitivity) );
-    }
-    StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-        return StdString::ContainsMatcher( StdString::CasedString( str, caseSensitivity) );
-    }
-    StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-        return StdString::EndsWithMatcher( StdString::CasedString( str, caseSensitivity) );
-    }
-    StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-        return StdString::StartsWithMatcher( StdString::CasedString( str, caseSensitivity) );
-    }
-
-    StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice caseSensitivity) {
-        return StdString::RegexMatcher(regex, caseSensitivity);
-    }
-
-} // namespace Matchers
+    } // namespace Matchers
 } // namespace Catch
 // end catch_matchers_string.cpp
 // start catch_message.cpp
@@ -11749,20 +11852,20 @@ namespace Catch {
 
 namespace Catch {
 
-    MessageInfo::MessageInfo(   StringRef const& _macroName,
-                                SourceLineInfo const& _lineInfo,
-                                ResultWas::OfType _type )
-    :   macroName( _macroName ),
-        lineInfo( _lineInfo ),
-        type( _type ),
-        sequence( ++globalCount )
+    MessageInfo::MessageInfo(StringRef const& _macroName,
+        SourceLineInfo const& _lineInfo,
+        ResultWas::OfType _type)
+        : macroName(_macroName),
+        lineInfo(_lineInfo),
+        type(_type),
+        sequence(++globalCount)
     {}
 
-    bool MessageInfo::operator==( MessageInfo const& other ) const {
+    bool MessageInfo::operator==(MessageInfo const& other) const {
         return sequence == other.sequence;
     }
 
-    bool MessageInfo::operator<( MessageInfo const& other ) const {
+    bool MessageInfo::operator<(MessageInfo const& other) const {
         return sequence < other.sequence;
     }
 
@@ -11771,34 +11874,34 @@ namespace Catch {
 
     ////////////////////////////////////////////////////////////////////////////
 
-    Catch::MessageBuilder::MessageBuilder( StringRef const& macroName,
-                                           SourceLineInfo const& lineInfo,
-                                           ResultWas::OfType type )
+    Catch::MessageBuilder::MessageBuilder(StringRef const& macroName,
+        SourceLineInfo const& lineInfo,
+        ResultWas::OfType type)
         :m_info(macroName, lineInfo, type) {}
 
     ////////////////////////////////////////////////////////////////////////////
 
-    ScopedMessage::ScopedMessage( MessageBuilder const& builder )
-    : m_info( builder.m_info ), m_moved()
+    ScopedMessage::ScopedMessage(MessageBuilder const& builder)
+        : m_info(builder.m_info), m_moved()
     {
         m_info.message = builder.m_stream.str();
-        getResultCapture().pushScopedMessage( m_info );
+        getResultCapture().pushScopedMessage(m_info);
     }
 
-    ScopedMessage::ScopedMessage( ScopedMessage&& old )
-    : m_info( old.m_info ), m_moved()
+    ScopedMessage::ScopedMessage(ScopedMessage&& old)
+        : m_info(old.m_info), m_moved()
     {
         old.m_moved = true;
     }
 
     ScopedMessage::~ScopedMessage() {
-        if ( !uncaught_exceptions() && !m_moved ){
+        if (!uncaught_exceptions() && !m_moved) {
             getResultCapture().popScopedMessage(m_info);
         }
     }
 
-    Capturer::Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names ) {
-        auto trimmed = [&] (size_t start, size_t end) {
+    Capturer::Capturer(StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names) {
+        auto trimmed = [&](size_t start, size_t end) {
             while (names[start] == ',' || isspace(static_cast<unsigned char>(names[start]))) {
                 ++start;
             }
@@ -11806,16 +11909,16 @@ namespace Catch {
                 --end;
             }
             return names.substr(start, end - start + 1);
-        };
-        auto skipq = [&] (size_t start, char quote) {
-            for (auto i = start + 1; i < names.size() ; ++i) {
+            };
+        auto skipq = [&](size_t start, char quote) {
+            for (auto i = start + 1; i < names.size(); ++i) {
                 if (names[i] == quote)
                     return i;
                 if (names[i] == '\\')
                     ++i;
             }
             CATCH_INTERNAL_ERROR("CAPTURE parsing encountered unmatched quote");
-        };
+            };
 
         size_t start = 0;
         std::stack<char> openings;
@@ -11825,15 +11928,15 @@ namespace Catch {
             case '[':
             case '{':
             case '(':
-            // It is basically impossible to disambiguate between
-            // comparison and start of template args in this context
-//            case '<':
+                // It is basically impossible to disambiguate between
+                // comparison and start of template args in this context
+    //            case '<':
                 openings.push(c);
                 break;
             case ']':
             case '}':
             case ')':
-//           case '>':
+                //           case '>':
                 openings.pop();
                 break;
             case '"':
@@ -11855,17 +11958,17 @@ namespace Catch {
         m_messages.back().message += " := ";
     }
     Capturer::~Capturer() {
-        if ( !uncaught_exceptions() ){
-            assert( m_captured == m_messages.size() );
-            for( size_t i = 0; i < m_captured; ++i  )
-                m_resultCapture.popScopedMessage( m_messages[i] );
+        if (!uncaught_exceptions()) {
+            assert(m_captured == m_messages.size());
+            for (size_t i = 0; i < m_captured; ++i)
+                m_resultCapture.popScopedMessage(m_messages[i]);
         }
     }
 
-    void Capturer::captureValue( size_t index, std::string const& value ) {
-        assert( index < m_messages.size() );
+    void Capturer::captureValue(size_t index, std::string const& value) {
+        assert(index < m_messages.size());
         m_messages[index].message += value;
-        m_resultCapture.pushScopedMessage( m_messages[index] );
+        m_resultCapture.pushScopedMessage(m_messages[index]);
         m_captured++;
     }
 
@@ -11889,7 +11992,7 @@ namespace Catch {
         std::streambuf* m_prevBuf;
 
     public:
-        RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream );
+        RedirectedStream(std::ostream& originalStream, std::ostream& redirectionStream);
         ~RedirectedStream();
     };
 
@@ -11898,7 +12001,7 @@ namespace Catch {
         RedirectedStream m_cout;
     public:
         RedirectedStdOut();
-        auto str() const -> std::string;
+        auto str() const->std::string;
     };
 
     // StdErr has two constituent streams in C++, std::cerr and std::clog
@@ -11910,7 +12013,7 @@ namespace Catch {
         RedirectedStream m_clog;
     public:
         RedirectedStdErr();
-        auto str() const -> std::string;
+        auto str() const->std::string;
     };
 
     class RedirectedStreams {
@@ -11950,9 +12053,9 @@ namespace Catch {
 
     private:
         std::FILE* m_file = nullptr;
-    #if defined(_MSC_VER)
+#if defined(_MSC_VER)
         char m_buffer[L_tmpnam] = { 0 };
-    #endif
+#endif
     };
 
     class OutputRedirect {
@@ -11987,41 +12090,41 @@ namespace Catch {
 #include <stdexcept>
 
 #if defined(CATCH_CONFIG_NEW_CAPTURE)
-    #if defined(_MSC_VER)
-    #include <io.h>      //_dup and _dup2
-    #define dup _dup
-    #define dup2 _dup2
-    #define fileno _fileno
-    #else
-    #include <unistd.h>  // dup and dup2
-    #endif
+#if defined(_MSC_VER)
+#include <io.h>      //_dup and _dup2
+#define dup _dup
+#define dup2 _dup2
+#define fileno _fileno
+#else
+#include <unistd.h>  // dup and dup2
+#endif
 #endif
 
 namespace Catch {
 
-    RedirectedStream::RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream )
-    :   m_originalStream( originalStream ),
-        m_redirectionStream( redirectionStream ),
-        m_prevBuf( m_originalStream.rdbuf() )
+    RedirectedStream::RedirectedStream(std::ostream& originalStream, std::ostream& redirectionStream)
+        : m_originalStream(originalStream),
+        m_redirectionStream(redirectionStream),
+        m_prevBuf(m_originalStream.rdbuf())
     {
-        m_originalStream.rdbuf( m_redirectionStream.rdbuf() );
+        m_originalStream.rdbuf(m_redirectionStream.rdbuf());
     }
 
     RedirectedStream::~RedirectedStream() {
-        m_originalStream.rdbuf( m_prevBuf );
+        m_originalStream.rdbuf(m_prevBuf);
     }
 
-    RedirectedStdOut::RedirectedStdOut() : m_cout( Catch::cout(), m_rss.get() ) {}
+    RedirectedStdOut::RedirectedStdOut() : m_cout(Catch::cout(), m_rss.get()) {}
     auto RedirectedStdOut::str() const -> std::string { return m_rss.str(); }
 
     RedirectedStdErr::RedirectedStdErr()
-    :   m_cerr( Catch::cerr(), m_rss.get() ),
-        m_clog( Catch::clog(), m_rss.get() )
+        : m_cerr(Catch::cerr(), m_rss.get()),
+        m_clog(Catch::clog(), m_rss.get())
     {}
     auto RedirectedStdErr::str() const -> std::string { return m_rss.str(); }
 
     RedirectedStreams::RedirectedStreams(std::string& redirectedCout, std::string& redirectedCerr)
-    :   m_redirectedCout(redirectedCout),
+        : m_redirectedCout(redirectedCout),
         m_redirectedCerr(redirectedCerr)
     {}
 
@@ -12056,12 +12159,12 @@ namespace Catch {
 #endif
 
     TempFile::~TempFile() {
-         // TBD: What to do about errors here?
-         std::fclose(m_file);
-         // We manually create the file on Windows only, on Linux
-         // it will be autodeleted
+        // TBD: What to do about errors here?
+        std::fclose(m_file);
+        // We manually create the file on Windows only, on Linux
+        // it will be autodeleted
 #if defined(_MSC_VER)
-         std::remove(m_buffer);
+        std::remove(m_buffer);
 #endif
     }
 
@@ -12109,11 +12212,11 @@ namespace Catch {
 } // namespace Catch
 
 #if defined(CATCH_CONFIG_NEW_CAPTURE)
-    #if defined(_MSC_VER)
-    #undef dup
-    #undef dup2
-    #undef fileno
-    #endif
+#if defined(_MSC_VER)
+#undef dup
+#undef dup2
+#undef fileno
+#endif
 #endif
 // end catch_output_redirect.cpp
 // start catch_polyfills.cpp
@@ -12145,7 +12248,7 @@ namespace Catch {
 
 namespace Catch {
 
-namespace {
+    namespace {
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -12162,7 +12265,7 @@ namespace {
 #pragma warning(pop)
 #endif
 
-}
+    }
 
     SimplePcg32::SimplePcg32(result_type seed_) {
         seed(seed_);
@@ -12217,24 +12320,24 @@ namespace Catch {
     class TestCase;
     struct IConfig;
 
-    std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases );
+    std::vector<TestCase> sortTests(IConfig const& config, std::vector<TestCase> const& unsortedTestCases);
 
-    bool isThrowSafe( TestCase const& testCase, IConfig const& config );
-    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
+    bool isThrowSafe(TestCase const& testCase, IConfig const& config);
+    bool matchTest(TestCase const& testCase, TestSpec const& testSpec, IConfig const& config);
 
-    void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions );
+    void enforceNoDuplicateTestCases(std::vector<TestCase> const& functions);
 
-    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
-    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+    std::vector<TestCase> filterTests(std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config);
+    std::vector<TestCase> const& getAllTestCasesSorted(IConfig const& config);
 
     class TestRegistry : public ITestCaseRegistry {
     public:
         virtual ~TestRegistry() = default;
 
-        virtual void registerTest( TestCase const& testCase );
+        virtual void registerTest(TestCase const& testCase);
 
         std::vector<TestCase> const& getAllTests() const override;
-        std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const override;
+        std::vector<TestCase> const& getAllTestsSorted(IConfig const& config) const override;
 
     private:
         std::vector<TestCase> m_functions;
@@ -12249,12 +12352,12 @@ namespace Catch {
     class TestInvokerAsFunction : public ITestInvoker {
         void(*m_testAsFunction)();
     public:
-        TestInvokerAsFunction( void(*testAsFunction)() ) noexcept;
+        TestInvokerAsFunction(void(*testAsFunction)()) noexcept;
 
         void invoke() const override;
     };
 
-    std::string extractClassName( StringRef const& classOrQualifiedMethodName );
+    std::string extractClassName(StringRef const& classOrQualifiedMethodName);
 
     ///////////////////////////////////////////////////////////////////////////
 
@@ -12273,10 +12376,10 @@ namespace Catch {
 
         ~ReporterRegistry() override;
 
-        IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const override;
+        IStreamingReporterPtr create(std::string const& name, IConfigPtr const& config) const override;
 
-        void registerReporter( std::string const& name, IReporterFactoryPtr const& factory );
-        void registerListener( IReporterFactoryPtr const& factory );
+        void registerReporter(std::string const& name, IReporterFactoryPtr const& factory);
+        void registerListener(IReporterFactoryPtr const& factory);
 
         FactoryMap const& getFactories() const override;
         Listeners const& getListeners() const override;
@@ -12313,9 +12416,9 @@ namespace Catch {
     class TagAliasRegistry : public ITagAliasRegistry {
     public:
         ~TagAliasRegistry() override;
-        TagAlias const* find( std::string const& alias ) const override;
-        std::string expandAliases( std::string const& unexpandedTestSpec ) const override;
-        void add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo );
+        TagAlias const* find(std::string const& alias) const override;
+        std::string expandAliases(std::string const& unexpandedTestSpec) const override;
+        void add(std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo);
 
     private:
         std::map<std::string, TagAlias> m_registry;
@@ -12352,7 +12455,7 @@ namespace Catch {
         virtual ~ISingleton();
     };
 
-    void addSingleton( ISingleton* singleton );
+    void addSingleton(ISingleton* singleton);
     void cleanupSingletons();
 
     template<typename SingletonImplT, typename InterfaceT = SingletonImplT, typename MutableInterfaceT = InterfaceT>
@@ -12360,9 +12463,9 @@ namespace Catch {
 
         static auto getInternal() -> Singleton* {
             static Singleton* s_instance = nullptr;
-            if( !s_instance ) {
+            if (!s_instance) {
                 s_instance = new Singleton;
-                addSingleton( s_instance );
+                addSingleton(s_instance);
             }
             return s_instance;
         }
@@ -12384,7 +12487,7 @@ namespace Catch {
     namespace {
 
         class RegistryHub : public IRegistryHub, public IMutableRegistryHub,
-                            private NonCopyable {
+            private NonCopyable {
 
         public: // IRegistryHub
             RegistryHub() = default;
@@ -12405,20 +12508,20 @@ namespace Catch {
             }
 
         public: // IMutableRegistryHub
-            void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) override {
-                m_reporterRegistry.registerReporter( name, factory );
+            void registerReporter(std::string const& name, IReporterFactoryPtr const& factory) override {
+                m_reporterRegistry.registerReporter(name, factory);
             }
-            void registerListener( IReporterFactoryPtr const& factory ) override {
-                m_reporterRegistry.registerListener( factory );
+            void registerListener(IReporterFactoryPtr const& factory) override {
+                m_reporterRegistry.registerListener(factory);
             }
-            void registerTest( TestCase const& testInfo ) override {
-                m_testCaseRegistry.registerTest( testInfo );
+            void registerTest(TestCase const& testInfo) override {
+                m_testCaseRegistry.registerTest(testInfo);
             }
-            void registerTranslator( const IExceptionTranslator* translator ) override {
-                m_exceptionTranslatorRegistry.registerTranslator( translator );
+            void registerTranslator(const IExceptionTranslator* translator) override {
+                m_exceptionTranslatorRegistry.registerTranslator(translator);
             }
-            void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) override {
-                m_tagAliasRegistry.add( alias, tag, lineInfo );
+            void registerTagAlias(std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo) override {
+                m_tagAliasRegistry.add(alias, tag, lineInfo);
             }
             void registerStartupException() noexcept override {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
@@ -12465,18 +12568,18 @@ namespace Catch {
 
     ReporterRegistry::~ReporterRegistry() = default;
 
-    IStreamingReporterPtr ReporterRegistry::create( std::string const& name, IConfigPtr const& config ) const {
-        auto it =  m_factories.find( name );
-        if( it == m_factories.end() )
+    IStreamingReporterPtr ReporterRegistry::create(std::string const& name, IConfigPtr const& config) const {
+        auto it = m_factories.find(name);
+        if (it == m_factories.end())
             return nullptr;
-        return it->second->create( ReporterConfig( config ) );
+        return it->second->create(ReporterConfig(config));
     }
 
-    void ReporterRegistry::registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) {
+    void ReporterRegistry::registerReporter(std::string const& name, IReporterFactoryPtr const& factory) {
         m_factories.emplace(name, factory);
     }
-    void ReporterRegistry::registerListener( IReporterFactoryPtr const& factory ) {
-        m_listeners.push_back( factory );
+    void ReporterRegistry::registerListener(IReporterFactoryPtr const& factory) {
+        m_listeners.push_back(factory);
     }
 
     IReporterRegistry::FactoryMap const& ReporterRegistry::getFactories() const {
@@ -12492,19 +12595,19 @@ namespace Catch {
 
 namespace Catch {
 
-    bool isOk( ResultWas::OfType resultType ) {
-        return ( resultType & ResultWas::FailureBit ) == 0;
+    bool isOk(ResultWas::OfType resultType) {
+        return (resultType & ResultWas::FailureBit) == 0;
     }
-    bool isJustInfo( int flags ) {
+    bool isJustInfo(int flags) {
         return flags == ResultWas::Info;
     }
 
-    ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs ) {
-        return static_cast<ResultDisposition::Flags>( static_cast<int>( lhs ) | static_cast<int>( rhs ) );
+    ResultDisposition::Flags operator | (ResultDisposition::Flags lhs, ResultDisposition::Flags rhs) {
+        return static_cast<ResultDisposition::Flags>(static_cast<int>(lhs) | static_cast<int>(rhs));
     }
 
-    bool shouldContinueOnFailure( int flags )    { return ( flags & ResultDisposition::ContinueOnFailure ) != 0; }
-    bool shouldSuppressFailure( int flags )      { return ( flags & ResultDisposition::SuppressFail ) != 0; }
+    bool shouldContinueOnFailure(int flags) { return (flags & ResultDisposition::ContinueOnFailure) != 0; }
+    bool shouldSuppressFailure(int flags) { return (flags & ResultDisposition::SuppressFail) != 0; }
 
 } // end namespace Catch
 // end catch_result_type.cpp
@@ -12520,12 +12623,12 @@ namespace Catch {
         struct GeneratorTracker : TestCaseTracking::TrackerBase, IGeneratorTracker {
             GeneratorBasePtr m_generator;
 
-            GeneratorTracker( TestCaseTracking::NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
-            :   TrackerBase( nameAndLocation, ctx, parent )
+            GeneratorTracker(TestCaseTracking::NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent)
+                : TrackerBase(nameAndLocation, ctx, parent)
             {}
             ~GeneratorTracker();
 
-            static GeneratorTracker& acquire( TrackerContext& ctx, TestCaseTracking::NameAndLocation const& nameAndLocation ) {
+            static GeneratorTracker& acquire(TrackerContext& ctx, TestCaseTracking::NameAndLocation const& nameAndLocation) {
                 std::shared_ptr<GeneratorTracker> tracker;
 
                 ITracker& currentTracker = ctx.currentTracker();
@@ -12545,16 +12648,18 @@ namespace Catch {
                     assert(thisTracker);
                     assert(thisTracker->isGeneratorTracker());
                     tracker = std::static_pointer_cast<GeneratorTracker>(thisTracker);
-                } else if ( TestCaseTracking::ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
-                    assert( childTracker );
-                    assert( childTracker->isGeneratorTracker() );
-                    tracker = std::static_pointer_cast<GeneratorTracker>( childTracker );
-                } else {
-                    tracker = std::make_shared<GeneratorTracker>( nameAndLocation, ctx, &currentTracker );
-                    currentTracker.addChild( tracker );
+                }
+                else if (TestCaseTracking::ITrackerPtr childTracker = currentTracker.findChild(nameAndLocation)) {
+                    assert(childTracker);
+                    assert(childTracker->isGeneratorTracker());
+                    tracker = std::static_pointer_cast<GeneratorTracker>(childTracker);
+                }
+                else {
+                    tracker = std::make_shared<GeneratorTracker>(nameAndLocation, ctx, &currentTracker);
+                    currentTracker.addChild(tracker);
                 }
 
-                if( !tracker->isComplete() ) {
+                if (!tracker->isComplete()) {
                     tracker->open();
                 }
 
@@ -12577,16 +12682,16 @@ namespace Catch {
                 // doing so would break `GENERATE` _not_ followed by `SECTION`s.
                 const bool should_wait_for_child = [&]() {
                     // No children -> nobody to wait for
-                    if ( m_children.empty() ) {
+                    if (m_children.empty()) {
                         return false;
                     }
                     // If at least one child started executing, don't wait
-                    if ( std::find_if(
-                             m_children.begin(),
-                             m_children.end(),
-                             []( TestCaseTracking::ITrackerPtr tracker ) {
-                                 return tracker->hasStarted();
-                             } ) != m_children.end() ) {
+                    if (std::find_if(
+                        m_children.begin(),
+                        m_children.end(),
+                        [](TestCaseTracking::ITrackerPtr tracker) {
+                            return tracker->hasStarted();
+                        }) != m_children.end()) {
                         return false;
                     }
 
@@ -12596,63 +12701,63 @@ namespace Catch {
                     auto* parent = m_parent;
                     // This is safe: there is always at least one section
                     // tracker in a test case tracking tree
-                    while ( !parent->isSectionTracker() ) {
-                        parent = &( parent->parent() );
+                    while (!parent->isSectionTracker()) {
+                        parent = &(parent->parent());
                     }
-                    assert( parent &&
-                            "Missing root (test case) level section" );
+                    assert(parent &&
+                        "Missing root (test case) level section");
 
                     auto const& parentSection =
-                        static_cast<SectionTracker&>( *parent );
+                        static_cast<SectionTracker&>(*parent);
                     auto const& filters = parentSection.getFilters();
                     // No filters -> no restrictions on running sections
-                    if ( filters.empty() ) {
+                    if (filters.empty()) {
                         return true;
                     }
 
-                    for ( auto const& child : m_children ) {
-                        if ( child->isSectionTracker() &&
-                             std::find( filters.begin(),
-                                        filters.end(),
-                                        static_cast<SectionTracker&>( *child )
-                                            .trimmedName() ) !=
-                                 filters.end() ) {
+                    for (auto const& child : m_children) {
+                        if (child->isSectionTracker() &&
+                            std::find(filters.begin(),
+                                filters.end(),
+                                static_cast<SectionTracker&>(*child)
+                                .trimmedName()) !=
+                            filters.end()) {
                             return true;
                         }
                     }
                     return false;
-                }();
+                    }();
 
-                // This check is a bit tricky, because m_generator->next()
-                // has a side-effect, where it consumes generator's current
-                // value, but we do not want to invoke the side-effect if
-                // this generator is still waiting for any child to start.
-                if ( should_wait_for_child ||
-                     ( m_runState == CompletedSuccessfully &&
-                       m_generator->next() ) ) {
-                    m_children.clear();
-                    m_runState = Executing;
-                }
+                    // This check is a bit tricky, because m_generator->next()
+                    // has a side-effect, where it consumes generator's current
+                    // value, but we do not want to invoke the side-effect if
+                    // this generator is still waiting for any child to start.
+                    if (should_wait_for_child ||
+                        (m_runState == CompletedSuccessfully &&
+                            m_generator->next())) {
+                        m_children.clear();
+                        m_runState = Executing;
+                    }
             }
 
             // IGeneratorTracker interface
             auto getGenerator() const -> GeneratorBasePtr const& override {
                 return m_generator;
             }
-            void setGenerator( GeneratorBasePtr&& generator ) override {
-                m_generator = std::move( generator );
+            void setGenerator(GeneratorBasePtr&& generator) override {
+                m_generator = std::move(generator);
             }
         };
         GeneratorTracker::~GeneratorTracker() {}
     }
 
     RunContext::RunContext(IConfigPtr const& _config, IStreamingReporterPtr&& reporter)
-    :   m_runInfo(_config->name()),
+        : m_runInfo(_config->name()),
         m_context(getCurrentMutableContext()),
         m_config(_config),
         m_reporter(std::move(reporter)),
         m_lastAssertionInfo{ StringRef(), SourceLineInfo("",0), StringRef(), ResultDisposition::Normal },
-        m_includeSuccessfulResults( m_config->includeSuccessfulResults() || m_reporter->getPreferences().shouldReportAllAssertions )
+        m_includeSuccessfulResults(m_config->includeSuccessfulResults() || m_reporter->getPreferences().shouldReportAllAssertions)
     {
         m_context.setRunner(this);
         m_context.setConfig(m_config);
@@ -12701,10 +12806,10 @@ namespace Catch {
         }
         m_totals.testCases += deltaTotals.testCases;
         m_reporter->testCaseEnded(TestCaseStats(testInfo,
-                                  deltaTotals,
-                                  redirectedCout,
-                                  redirectedCerr,
-                                  aborting()));
+            deltaTotals,
+            redirectedCout,
+            redirectedCerr,
+            aborting()));
 
         m_activeTestCase = nullptr;
         m_testCaseTracker = nullptr;
@@ -12720,13 +12825,14 @@ namespace Catch {
         return *m_reporter;
     }
 
-    void RunContext::assertionEnded(AssertionResult const & result) {
+    void RunContext::assertionEnded(AssertionResult const& result) {
         if (result.getResultType() == ResultWas::Ok) {
             m_totals.assertions.passed++;
             m_lastAssertionPassed = true;
-        } else if (!result.isOk()) {
+        }
+        else if (!result.isOk()) {
             m_lastAssertionPassed = false;
-            if( m_activeTestCase->getTestCaseInfo().okToFail() )
+            if (m_activeTestCase->getTestCaseInfo().okToFail())
                 m_totals.assertions.failedButOk++;
             else
                 m_totals.assertions.failed++;
@@ -12751,7 +12857,7 @@ namespace Catch {
         m_lastAssertionInfo.capturedExpression = "{Unknown expression after the reported line}"_sr;
     }
 
-    bool RunContext::sectionStarted(SectionInfo const & sectionInfo, Counts & assertions) {
+    bool RunContext::sectionStarted(SectionInfo const& sectionInfo, Counts& assertions) {
         ITracker& sectionTracker = SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(sectionInfo.name, sectionInfo.lineInfo));
         if (!sectionTracker.isOpen())
             return false;
@@ -12765,10 +12871,10 @@ namespace Catch {
 
         return true;
     }
-    auto RunContext::acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& {
+    auto RunContext::acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const& lineInfo) -> IGeneratorTracker& {
         using namespace Generators;
         GeneratorTracker& tracker = GeneratorTracker::acquire(m_trackerContext,
-                                                              TestCaseTracking::NameAndLocation( static_cast<std::string>(generatorName), lineInfo ) );
+            TestCaseTracking::NameAndLocation(static_cast<std::string>(generatorName), lineInfo));
         m_lastAssertionInfo.lineInfo = lineInfo;
         return tracker;
     }
@@ -12785,7 +12891,7 @@ namespace Catch {
         return true;
     }
 
-    void RunContext::sectionEnded(SectionEndInfo const & endInfo) {
+    void RunContext::sectionEnded(SectionEndInfo const& endInfo) {
         Counts assertions = m_totals.assertions - endInfo.prevAssertions;
         bool missingAssertions = testForMissingAssertions(assertions);
 
@@ -12799,7 +12905,7 @@ namespace Catch {
         m_messageScopes.clear();
     }
 
-    void RunContext::sectionEndedEarly(SectionEndInfo const & endInfo) {
+    void RunContext::sectionEndedEarly(SectionEndInfo const& endInfo) {
         if (m_unfinishedSections.empty())
             m_activeSections.back()->fail();
         else
@@ -12813,27 +12919,27 @@ namespace Catch {
     void RunContext::benchmarkPreparing(std::string const& name) {
         m_reporter->benchmarkPreparing(name);
     }
-    void RunContext::benchmarkStarting( BenchmarkInfo const& info ) {
-        m_reporter->benchmarkStarting( info );
+    void RunContext::benchmarkStarting(BenchmarkInfo const& info) {
+        m_reporter->benchmarkStarting(info);
     }
-    void RunContext::benchmarkEnded( BenchmarkStats<> const& stats ) {
-        m_reporter->benchmarkEnded( stats );
+    void RunContext::benchmarkEnded(BenchmarkStats<> const& stats) {
+        m_reporter->benchmarkEnded(stats);
     }
-    void RunContext::benchmarkFailed(std::string const & error) {
+    void RunContext::benchmarkFailed(std::string const& error) {
         m_reporter->benchmarkFailed(error);
     }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    void RunContext::pushScopedMessage(MessageInfo const & message) {
+    void RunContext::pushScopedMessage(MessageInfo const& message) {
         m_messages.push_back(message);
     }
 
-    void RunContext::popScopedMessage(MessageInfo const & message) {
+    void RunContext::popScopedMessage(MessageInfo const& message) {
         m_messages.erase(std::remove(m_messages.begin(), m_messages.end(), message), m_messages.end());
     }
 
-    void RunContext::emplaceUnscopedMessage( MessageBuilder const& builder ) {
-        m_messageScopes.emplace_back( builder );
+    void RunContext::emplaceUnscopedMessage(MessageBuilder const& builder) {
+        m_messageScopes.emplace_back(builder);
     }
 
     std::string RunContext::getCurrentTestName() const {
@@ -12842,7 +12948,7 @@ namespace Catch {
             : std::string();
     }
 
-    const AssertionResult * RunContext::getLastResult() const {
+    const AssertionResult* RunContext::getLastResult() const {
         return &(*m_lastResult);
     }
 
@@ -12850,13 +12956,13 @@ namespace Catch {
         m_shouldReportUnexpected = false;
     }
 
-    void RunContext::handleFatalErrorCondition( StringRef message ) {
+    void RunContext::handleFatalErrorCondition(StringRef message) {
         // First notify reporter that bad things happened
         m_reporter->fatalErrorEncountered(message);
 
         // Don't rebuild the result -- the stringification itself can cause more fatal errors
         // Instead, fake a result data.
-        AssertionResultData tempResult( ResultWas::FatalErrorCondition, { false } );
+        AssertionResultData tempResult(ResultWas::FatalErrorCondition, { false });
         tempResult.message = static_cast<std::string>(message);
         AssertionResult result(m_lastAssertionInfo, tempResult);
 
@@ -12879,17 +12985,17 @@ namespace Catch {
         deltaTotals.testCases.failed = 1;
         deltaTotals.assertions.failed = 1;
         m_reporter->testCaseEnded(TestCaseStats(testInfo,
-                                  deltaTotals,
-                                  std::string(),
-                                  std::string(),
-                                  false));
+            deltaTotals,
+            std::string(),
+            std::string(),
+            false));
         m_totals.testCases.failed++;
         testGroupEnded(std::string(), m_totals, 1, 1);
         m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, false));
     }
 
     bool RunContext::lastAssertionPassed() {
-         return m_lastAssertionPassed;
+        return m_lastAssertionPassed;
     }
 
     void RunContext::assertionPassed() {
@@ -12903,7 +13009,7 @@ namespace Catch {
         return m_totals.assertions.failed >= static_cast<std::size_t>(m_config->abortAfter());
     }
 
-    void RunContext::runCurrentTest(std::string & redirectedCout, std::string & redirectedCerr) {
+    void RunContext::runCurrentTest(std::string& redirectedCout, std::string& redirectedCerr) {
         auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
         SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name);
         m_reporter->sectionStarting(testCaseSection);
@@ -12915,7 +13021,7 @@ namespace Catch {
         seedRng(*m_config);
 
         Timer timer;
-        CATCH_TRY {
+        CATCH_TRY{
             if (m_reporter->getPreferences().shouldRedirectStdOut) {
 #if !defined(CATCH_CONFIG_EXPERIMENTAL_REDIRECT)
                 RedirectedStreams redirectedStreams(redirectedCout, redirectedCerr);
@@ -12927,20 +13033,21 @@ namespace Catch {
                 timer.start();
                 invokeActiveTestCase();
 #endif
-            } else {
-                timer.start();
-                invokeActiveTestCase();
             }
-            duration = timer.getElapsedSeconds();
-        } CATCH_CATCH_ANON (TestFailureException&) {
+ else {
+  timer.start();
+  invokeActiveTestCase();
+}
+duration = timer.getElapsedSeconds();
+        } CATCH_CATCH_ANON(TestFailureException&) {
             // This just means the test was aborted due to failure
-        } CATCH_CATCH_ALL {
-            // Under CATCH_CONFIG_FAST_COMPILE, unexpected exceptions under REQUIRE assertions
-            // are reported without translation at the point of origin.
-            if( m_shouldReportUnexpected ) {
-                AssertionReaction dummyReaction;
-                handleUnexpectedInflightException( m_lastAssertionInfo, translateActiveException(), dummyReaction );
-            }
+        } CATCH_CATCH_ALL{
+                // Under CATCH_CONFIG_FAST_COMPILE, unexpected exceptions under REQUIRE assertions
+                // are reported without translation at the point of origin.
+                if (m_shouldReportUnexpected) {
+                    AssertionReaction dummyReaction;
+                    handleUnexpectedInflightException(m_lastAssertionInfo, translateActiveException(), dummyReaction);
+                }
         }
         Counts assertions = m_totals.assertions - prevAssertions;
         bool missingAssertions = testForMissingAssertions(assertions);
@@ -12955,18 +13062,17 @@ namespace Catch {
     }
 
     void RunContext::invokeActiveTestCase() {
-        FatalConditionHandler fatalConditionHandler; // Handle signals
+        FatalConditionHandlerGuard _(&m_fatalConditionhandler);
         m_activeTestCase->invoke();
-        fatalConditionHandler.reset();
     }
 
     void RunContext::handleUnfinishedSections() {
         // If sections ended prematurely due to an exception we stored their
         // infos here so we can tear them down outside the unwind process.
         for (auto it = m_unfinishedSections.rbegin(),
-             itEnd = m_unfinishedSections.rend();
-             it != itEnd;
-             ++it)
+            itEnd = m_unfinishedSections.rend();
+            it != itEnd;
+            ++it)
             sectionEnded(*it);
         m_unfinishedSections.clear();
     }
@@ -12976,12 +13082,12 @@ namespace Catch {
         ITransientExpression const& expr,
         AssertionReaction& reaction
     ) {
-        m_reporter->assertionStarting( info );
+        m_reporter->assertionStarting(info);
 
-        bool negated = isFalseTest( info.resultDisposition );
+        bool negated = isFalseTest(info.resultDisposition);
         bool result = expr.getResult() != negated;
 
-        if( result ) {
+        if (result) {
             if (!m_includeSuccessfulResults) {
                 assertionPassed();
             }
@@ -12990,91 +13096,91 @@ namespace Catch {
             }
         }
         else {
-            reportExpr(info, ResultWas::ExpressionFailed, &expr, negated );
-            populateReaction( reaction );
+            reportExpr(info, ResultWas::ExpressionFailed, &expr, negated);
+            populateReaction(reaction);
         }
     }
     void RunContext::reportExpr(
-            AssertionInfo const &info,
-            ResultWas::OfType resultType,
-            ITransientExpression const *expr,
-            bool negated ) {
+        AssertionInfo const& info,
+        ResultWas::OfType resultType,
+        ITransientExpression const* expr,
+        bool negated) {
 
         m_lastAssertionInfo = info;
-        AssertionResultData data( resultType, LazyExpression( negated ) );
+        AssertionResultData data(resultType, LazyExpression(negated));
 
         AssertionResult assertionResult{ info, data };
         assertionResult.m_resultData.lazyExpression.m_transientExpression = expr;
 
-        assertionEnded( assertionResult );
+        assertionEnded(assertionResult);
     }
 
     void RunContext::handleMessage(
-            AssertionInfo const& info,
-            ResultWas::OfType resultType,
-            StringRef const& message,
-            AssertionReaction& reaction
+        AssertionInfo const& info,
+        ResultWas::OfType resultType,
+        StringRef const& message,
+        AssertionReaction& reaction
     ) {
-        m_reporter->assertionStarting( info );
+        m_reporter->assertionStarting(info);
 
         m_lastAssertionInfo = info;
 
-        AssertionResultData data( resultType, LazyExpression( false ) );
+        AssertionResultData data(resultType, LazyExpression(false));
         data.message = static_cast<std::string>(message);
         AssertionResult assertionResult{ m_lastAssertionInfo, data };
-        assertionEnded( assertionResult );
-        if( !assertionResult.isOk() )
-            populateReaction( reaction );
+        assertionEnded(assertionResult);
+        if (!assertionResult.isOk())
+            populateReaction(reaction);
     }
     void RunContext::handleUnexpectedExceptionNotThrown(
-            AssertionInfo const& info,
-            AssertionReaction& reaction
+        AssertionInfo const& info,
+        AssertionReaction& reaction
     ) {
         handleNonExpr(info, Catch::ResultWas::DidntThrowException, reaction);
     }
 
     void RunContext::handleUnexpectedInflightException(
-            AssertionInfo const& info,
-            std::string const& message,
-            AssertionReaction& reaction
+        AssertionInfo const& info,
+        std::string const& message,
+        AssertionReaction& reaction
     ) {
         m_lastAssertionInfo = info;
 
-        AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
+        AssertionResultData data(ResultWas::ThrewException, LazyExpression(false));
         data.message = message;
         AssertionResult assertionResult{ info, data };
-        assertionEnded( assertionResult );
-        populateReaction( reaction );
+        assertionEnded(assertionResult);
+        populateReaction(reaction);
     }
 
-    void RunContext::populateReaction( AssertionReaction& reaction ) {
+    void RunContext::populateReaction(AssertionReaction& reaction) {
         reaction.shouldDebugBreak = m_config->shouldDebugBreak();
         reaction.shouldThrow = aborting() || (m_lastAssertionInfo.resultDisposition & ResultDisposition::Normal);
     }
 
     void RunContext::handleIncomplete(
-            AssertionInfo const& info
+        AssertionInfo const& info
     ) {
         m_lastAssertionInfo = info;
 
-        AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
+        AssertionResultData data(ResultWas::ThrewException, LazyExpression(false));
         data.message = "Exception translation was disabled by CATCH_CONFIG_FAST_COMPILE";
         AssertionResult assertionResult{ info, data };
-        assertionEnded( assertionResult );
+        assertionEnded(assertionResult);
     }
     void RunContext::handleNonExpr(
-            AssertionInfo const &info,
-            ResultWas::OfType resultType,
-            AssertionReaction &reaction
+        AssertionInfo const& info,
+        ResultWas::OfType resultType,
+        AssertionReaction& reaction
     ) {
         m_lastAssertionInfo = info;
 
-        AssertionResultData data( resultType, LazyExpression( false ) );
+        AssertionResultData data(resultType, LazyExpression(false));
         AssertionResult assertionResult{ info, data };
-        assertionEnded( assertionResult );
+        assertionEnded(assertionResult);
 
-        if( !assertionResult.isOk() )
-            populateReaction( reaction );
+        if (!assertionResult.isOk())
+            populateReaction(reaction);
     }
 
     IResultCapture& getResultCapture() {
@@ -13101,20 +13207,20 @@ namespace Catch {
 
 namespace Catch {
 
-    Section::Section( SectionInfo const& info )
-    :   m_info( info ),
-        m_sectionIncluded( getResultCapture().sectionStarted( m_info, m_assertions ) )
+    Section::Section(SectionInfo const& info)
+        : m_info(info),
+        m_sectionIncluded(getResultCapture().sectionStarted(m_info, m_assertions))
     {
         m_timer.start();
     }
 
     Section::~Section() {
-        if( m_sectionIncluded ) {
+        if (m_sectionIncluded) {
             SectionEndInfo endInfo{ m_info, m_assertions, m_timer.getElapsedSeconds() };
-            if( uncaught_exceptions() )
-                getResultCapture().sectionEndedEarly( endInfo );
+            if (uncaught_exceptions())
+                getResultCapture().sectionEndedEarly(endInfo);
             else
-                getResultCapture().sectionEnded( endInfo );
+                getResultCapture().sectionEnded(endInfo);
         }
     }
 
@@ -13130,10 +13236,10 @@ namespace Catch {
 namespace Catch {
 
     SectionInfo::SectionInfo
-        (   SourceLineInfo const& _lineInfo,
-            std::string const& _name )
-    :   name( _name ),
-        lineInfo( _lineInfo )
+    (SourceLineInfo const& _lineInfo,
+        std::string const& _name)
+        : name(_name),
+        lineInfo(_lineInfo)
     {}
 
 } // end namespace Catch
@@ -13155,15 +13261,15 @@ namespace Catch {
         void showHelp() const;
         void libIdentify();
 
-        int applyCommandLine( int argc, char const * const * argv );
-    #if defined(CATCH_CONFIG_WCHAR) && defined(_WIN32) && defined(UNICODE)
-        int applyCommandLine( int argc, wchar_t const * const * argv );
-    #endif
+        int applyCommandLine(int argc, char const* const* argv);
+#if defined(CATCH_CONFIG_WCHAR) && defined(_WIN32) && defined(UNICODE)
+        int applyCommandLine(int argc, wchar_t const* const* argv);
+#endif
 
-        void useConfigData( ConfigData const& configData );
+        void useConfigData(ConfigData const& configData);
 
         template<typename CharT>
-        int run(int argc, CharT const * const argv[]) {
+        int run(int argc, CharT const* const argv[]) {
             if (m_startupExceptions)
                 return 1;
             int returnCode = applyCommandLine(argc, argv);
@@ -13175,7 +13281,7 @@ namespace Catch {
         int run();
 
         clara::Parser const& cli() const;
-        void cli( clara::Parser const& newParser );
+        void cli(clara::Parser const& newParser);
         ConfigData& configData();
         Config& config();
     private:
@@ -13198,23 +13304,23 @@ namespace Catch {
 
     // Versioning information
     struct Version {
-        Version( Version const& ) = delete;
-        Version& operator=( Version const& ) = delete;
-        Version(    unsigned int _majorVersion,
-                    unsigned int _minorVersion,
-                    unsigned int _patchNumber,
-                    char const * const _branchName,
-                    unsigned int _buildNumber );
+        Version(Version const&) = delete;
+        Version& operator=(Version const&) = delete;
+        Version(unsigned int _majorVersion,
+            unsigned int _minorVersion,
+            unsigned int _patchNumber,
+            char const* const _branchName,
+            unsigned int _buildNumber);
 
         unsigned int const majorVersion;
         unsigned int const minorVersion;
         unsigned int const patchNumber;
 
         // buildNumber is only used if branchName is not null
-        char const * const branchName;
+        char const* const branchName;
         unsigned int const buildNumber;
 
-        friend std::ostream& operator << ( std::ostream& os, Version const& version );
+        friend std::ostream& operator << (std::ostream& os, Version const& version);
     };
 
     Version const& libraryVersion();
@@ -13261,8 +13367,8 @@ namespace Catch {
         class TestGroup {
         public:
             explicit TestGroup(std::shared_ptr<Config> const& config)
-            : m_config{config}
-            , m_context{config, makeReporter(config)}
+                : m_config{ config }
+                , m_context{ config, makeReporter(config) }
             {
                 auto const& allTestCases = getAllTestCasesSorted(*m_config);
                 m_matches = m_config->testSpec().matchesByFilter(allTestCases, *m_config);
@@ -13272,7 +13378,8 @@ namespace Catch {
                     for (auto const& test : allTestCases)
                         if (!test.isHidden())
                             m_tests.emplace(&test);
-                } else {
+                }
+                else {
                     for (auto const& match : m_matches)
                         m_tests.insert(match.tests.begin(), match.tests.end());
                 }
@@ -13297,8 +13404,8 @@ namespace Catch {
                 }
 
                 if (!invalidArgs.empty()) {
-                    for (auto const& invalidArg: invalidArgs)
-                         m_context.reporter().reportInvalidArguments(invalidArg);
+                    for (auto const& invalidArg : invalidArgs)
+                        m_context.reporter().reportInvalidArguments(invalidArg);
                 }
 
                 m_context.testGroupEnded(m_config->name(), totals, 1, 1);
@@ -13325,6 +13432,10 @@ namespace Catch {
                     filename.erase(0, lastSlash);
                     filename[0] = '#';
                 }
+                else
+                {
+                    filename.insert(0, "#");
+                }
 
                 auto lastDot = filename.find_last_of('.');
                 if (lastDot != std::string::npos) {
@@ -13340,34 +13451,35 @@ namespace Catch {
 
     Session::Session() {
         static bool alreadyInstantiated = false;
-        if( alreadyInstantiated ) {
-            CATCH_TRY { CATCH_INTERNAL_ERROR( "Only one instance of Catch::Session can ever be used" ); }
-            CATCH_CATCH_ALL { getMutableRegistryHub().registerStartupException(); }
+        if (alreadyInstantiated) {
+            CATCH_TRY{ CATCH_INTERNAL_ERROR("Only one instance of Catch::Session can ever be used"); }
+            CATCH_CATCH_ALL{ getMutableRegistryHub().registerStartupException(); }
         }
 
         // There cannot be exceptions at startup in no-exception mode.
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
         const auto& exceptions = getRegistryHub().getStartupExceptionRegistry().getExceptions();
-        if ( !exceptions.empty() ) {
+        if (!exceptions.empty()) {
             config();
             getCurrentMutableContext().setConfig(m_config);
 
             m_startupExceptions = true;
-            Colour colourGuard( Colour::Red );
+            Colour colourGuard(Colour::Red);
             Catch::cerr() << "Errors occurred during startup!" << '\n';
             // iterate over all exceptions and notify user
-            for ( const auto& ex_ptr : exceptions ) {
+            for (const auto& ex_ptr : exceptions) {
                 try {
                     std::rethrow_exception(ex_ptr);
-                } catch ( std::exception const& ex ) {
-                    Catch::cerr() << Column( ex.what() ).indent(2) << '\n';
+                }
+                catch (std::exception const& ex) {
+                    Catch::cerr() << Column(ex.what()).indent(2) << '\n';
                 }
             }
         }
 #endif
 
         alreadyInstantiated = true;
-        m_cli = makeCommandLineParser( m_configData );
+        m_cli = makeCommandLineParser(m_configData);
     }
     Session::~Session() {
         Catch::cleanUp();
@@ -13375,79 +13487,79 @@ namespace Catch {
 
     void Session::showHelp() const {
         Catch::cout()
-                << "\nCatch v" << libraryVersion() << "\n"
-                << m_cli << std::endl
-                << "For more detailed usage please see the project docs\n" << std::endl;
+            << "\nCatch v" << libraryVersion() << "\n"
+            << m_cli << std::endl
+            << "For more detailed usage please see the project docs\n" << std::endl;
     }
     void Session::libIdentify() {
         Catch::cout()
-                << std::left << std::setw(16) << "description: " << "A Catch2 test executable\n"
-                << std::left << std::setw(16) << "category: " << "testframework\n"
-                << std::left << std::setw(16) << "framework: " << "Catch Test\n"
-                << std::left << std::setw(16) << "version: " << libraryVersion() << std::endl;
+            << std::left << std::setw(16) << "description: " << "A Catch2 test executable\n"
+            << std::left << std::setw(16) << "category: " << "testframework\n"
+            << std::left << std::setw(16) << "framework: " << "Catch Test\n"
+            << std::left << std::setw(16) << "version: " << libraryVersion() << std::endl;
     }
 
-    int Session::applyCommandLine( int argc, char const * const * argv ) {
-        if( m_startupExceptions )
+    int Session::applyCommandLine(int argc, char const* const* argv) {
+        if (m_startupExceptions)
             return 1;
 
-        auto result = m_cli.parse( clara::Args( argc, argv ) );
-        if( !result ) {
+        auto result = m_cli.parse(clara::Args(argc, argv));
+        if (!result) {
             config();
             getCurrentMutableContext().setConfig(m_config);
             Catch::cerr()
-                << Colour( Colour::Red )
+                << Colour(Colour::Red)
                 << "\nError(s) in input:\n"
-                << Column( result.errorMessage() ).indent( 2 )
+                << Column(result.errorMessage()).indent(2)
                 << "\n\n";
             Catch::cerr() << "Run with -? for usage\n" << std::endl;
             return MaxExitCode;
         }
 
-        if( m_configData.showHelp )
+        if (m_configData.showHelp)
             showHelp();
-        if( m_configData.libIdentify )
+        if (m_configData.libIdentify)
             libIdentify();
         m_config.reset();
         return 0;
     }
 
 #if defined(CATCH_CONFIG_WCHAR) && defined(_WIN32) && defined(UNICODE)
-    int Session::applyCommandLine( int argc, wchar_t const * const * argv ) {
+    int Session::applyCommandLine(int argc, wchar_t const* const* argv) {
 
-        char **utf8Argv = new char *[ argc ];
+        char** utf8Argv = new char* [argc];
 
-        for ( int i = 0; i < argc; ++i ) {
-            int bufSize = WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, nullptr, 0, nullptr, nullptr );
+        for (int i = 0; i < argc; ++i) {
+            int bufSize = WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, nullptr, 0, nullptr, nullptr);
 
-            utf8Argv[ i ] = new char[ bufSize ];
+            utf8Argv[i] = new char[bufSize];
 
-            WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, utf8Argv[i], bufSize, nullptr, nullptr );
+            WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, utf8Argv[i], bufSize, nullptr, nullptr);
         }
 
-        int returnCode = applyCommandLine( argc, utf8Argv );
+        int returnCode = applyCommandLine(argc, utf8Argv);
 
-        for ( int i = 0; i < argc; ++i )
-            delete [] utf8Argv[ i ];
+        for (int i = 0; i < argc; ++i)
+            delete[] utf8Argv[i];
 
-        delete [] utf8Argv;
+        delete[] utf8Argv;
 
         return returnCode;
     }
 #endif
 
-    void Session::useConfigData( ConfigData const& configData ) {
+    void Session::useConfigData(ConfigData const& configData) {
         m_configData = configData;
         m_config.reset();
     }
 
     int Session::run() {
-        if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeStart ) != 0 ) {
+        if ((m_configData.waitForKeypress & WaitForKeypress::BeforeStart) != 0) {
             Catch::cout() << "...waiting for enter/ return before starting" << std::endl;
             static_cast<void>(std::getchar());
         }
         int exitCode = runInternal();
-        if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeExit ) != 0 ) {
+        if ((m_configData.waitForKeypress & WaitForKeypress::BeforeExit) != 0) {
             Catch::cout() << "...waiting for enter/ return before exiting, with code: " << exitCode << std::endl;
             static_cast<void>(std::getchar());
         }
@@ -13457,51 +13569,51 @@ namespace Catch {
     clara::Parser const& Session::cli() const {
         return m_cli;
     }
-    void Session::cli( clara::Parser const& newParser ) {
+    void Session::cli(clara::Parser const& newParser) {
         m_cli = newParser;
     }
     ConfigData& Session::configData() {
         return m_configData;
     }
     Config& Session::config() {
-        if( !m_config )
-            m_config = std::make_shared<Config>( m_configData );
+        if (!m_config)
+            m_config = std::make_shared<Config>(m_configData);
         return *m_config;
     }
 
     int Session::runInternal() {
-        if( m_startupExceptions )
+        if (m_startupExceptions)
             return 1;
 
         if (m_configData.showHelp || m_configData.libIdentify) {
             return 0;
         }
 
-        CATCH_TRY {
+        CATCH_TRY{
             config(); // Force config to be constructed
 
-            seedRng( *m_config );
+            seedRng(*m_config);
 
-            if( m_configData.filenamesAsTags )
-                applyFilenamesAsTags( *m_config );
+            if (m_configData.filenamesAsTags)
+                applyFilenamesAsTags(*m_config);
 
             // Handle list request
-            if( Option<std::size_t> listed = list( m_config ) )
-                return static_cast<int>( *listed );
+            if (Option<std::size_t> listed = list(m_config))
+                return (std::min)(MaxExitCode, static_cast<int>(*listed));
 
             TestGroup tests { m_config };
             auto const totals = tests.execute();
 
-            if( m_config->warnAboutNoTests() && totals.error == -1 )
+            if (m_config->warnAboutNoTests() && totals.error == -1)
                 return 2;
 
             // Note that on unices only the lower 8 bits are usually used, clamping
             // the return value to 255 prevents false negative when some multiple
             // of 256 tests has failed
-            return (std::min) (MaxExitCode, (std::max) (totals.error, static_cast<int>(totals.assertions.failed)));
+            return (std::min)(MaxExitCode, (std::max)(totals.error, static_cast<int>(totals.assertions.failed)));
         }
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-        catch( std::exception& ex ) {
+            catch (std::exception& ex) {
             Catch::cerr() << ex.what() << std::endl;
             return MaxExitCode;
         }
@@ -13519,7 +13631,7 @@ namespace Catch {
     namespace {
         static auto getSingletons() -> std::vector<ISingleton*>*& {
             static std::vector<ISingleton*>* g_singletons = nullptr;
-            if( !g_singletons )
+            if (!g_singletons)
                 g_singletons = new std::vector<ISingleton*>();
             return g_singletons;
         }
@@ -13527,13 +13639,12 @@ namespace Catch {
 
     ISingleton::~ISingleton() {}
 
-    void addSingleton(ISingleton* singleton ) {
-        getSingletons()->push_back( singleton );
+    void addSingleton(ISingleton* singleton) {
+        getSingletons()->push_back(singleton);
     }
-
     void cleanupSingletons() {
         auto& singletons = getSingletons();
-        for( auto singleton : *singletons )
+        for (auto singleton : *singletons)
             delete singleton;
         delete singletons;
         singletons = nullptr;
@@ -13545,10 +13656,10 @@ namespace Catch {
 
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
 namespace Catch {
-void StartupExceptionRegistry::add( std::exception_ptr const& exception ) noexcept {
-        CATCH_TRY {
+    void StartupExceptionRegistry::add(std::exception_ptr const& exception) noexcept {
+        CATCH_TRY{
             m_exceptions.push_back(exception);
-        } CATCH_CATCH_ALL {
+        } CATCH_CATCH_ALL{
             // If we run out of memory during start-up there's really not a lot more we can do about it
             std::terminate();
         }
@@ -13574,114 +13685,116 @@ namespace Catch {
 
     Catch::IStream::~IStream() = default;
 
-    namespace Detail { namespace {
-        template<typename WriterF, std::size_t bufferSize=256>
-        class StreamBufImpl : public std::streambuf {
-            char data[bufferSize];
-            WriterF m_writer;
+    namespace Detail {
+        namespace {
+            template<typename WriterF, std::size_t bufferSize = 256>
+            class StreamBufImpl : public std::streambuf {
+                char data[bufferSize];
+                WriterF m_writer;
 
-        public:
-            StreamBufImpl() {
-                setp( data, data + sizeof(data) );
-            }
-
-            ~StreamBufImpl() noexcept {
-                StreamBufImpl::sync();
-            }
-
-        private:
-            int overflow( int c ) override {
-                sync();
-
-                if( c != EOF ) {
-                    if( pbase() == epptr() )
-                        m_writer( std::string( 1, static_cast<char>( c ) ) );
-                    else
-                        sputc( static_cast<char>( c ) );
+            public:
+                StreamBufImpl() {
+                    setp(data, data + sizeof(data));
                 }
-                return 0;
-            }
 
-            int sync() override {
-                if( pbase() != pptr() ) {
-                    m_writer( std::string( pbase(), static_cast<std::string::size_type>( pptr() - pbase() ) ) );
-                    setp( pbase(), epptr() );
+                ~StreamBufImpl() noexcept {
+                    StreamBufImpl::sync();
                 }
-                return 0;
-            }
-        };
 
-        ///////////////////////////////////////////////////////////////////////////
+            private:
+                int overflow(int c) override {
+                    sync();
 
-        struct OutputDebugWriter {
+                    if (c != EOF) {
+                        if (pbase() == epptr())
+                            m_writer(std::string(1, static_cast<char>(c)));
+                        else
+                            sputc(static_cast<char>(c));
+                    }
+                    return 0;
+                }
 
-            void operator()( std::string const&str ) {
-                writeToDebugConsole( str );
-            }
-        };
+                int sync() override {
+                    if (pbase() != pptr()) {
+                        m_writer(std::string(pbase(), static_cast<std::string::size_type>(pptr() - pbase())));
+                        setp(pbase(), epptr());
+                    }
+                    return 0;
+                }
+            };
 
-        ///////////////////////////////////////////////////////////////////////////
+            ///////////////////////////////////////////////////////////////////////////
 
-        class FileStream : public IStream {
-            mutable std::ofstream m_ofs;
-        public:
-            FileStream( StringRef filename ) {
-                m_ofs.open( filename.c_str() );
-                CATCH_ENFORCE( !m_ofs.fail(), "Unable to open file: '" << filename << "'" );
-            }
-            ~FileStream() override = default;
-        public: // IStream
-            std::ostream& stream() const override {
-                return m_ofs;
-            }
-        };
+            struct OutputDebugWriter {
 
-        ///////////////////////////////////////////////////////////////////////////
+                void operator()(std::string const& str) {
+                    writeToDebugConsole(str);
+                }
+            };
 
-        class CoutStream : public IStream {
-            mutable std::ostream m_os;
-        public:
-            // Store the streambuf from cout up-front because
-            // cout may get redirected when running tests
-            CoutStream() : m_os( Catch::cout().rdbuf() ) {}
-            ~CoutStream() override = default;
+            ///////////////////////////////////////////////////////////////////////////
 
-        public: // IStream
-            std::ostream& stream() const override { return m_os; }
-        };
+            class FileStream : public IStream {
+                mutable std::ofstream m_ofs;
+            public:
+                FileStream(StringRef filename) {
+                    m_ofs.open(filename.c_str());
+                    CATCH_ENFORCE(!m_ofs.fail(), "Unable to open file: '" << filename << "'");
+                }
+                ~FileStream() override = default;
+            public: // IStream
+                std::ostream& stream() const override {
+                    return m_ofs;
+                }
+            };
 
-        ///////////////////////////////////////////////////////////////////////////
+            ///////////////////////////////////////////////////////////////////////////
 
-        class DebugOutStream : public IStream {
-            std::unique_ptr<StreamBufImpl<OutputDebugWriter>> m_streamBuf;
-            mutable std::ostream m_os;
-        public:
-            DebugOutStream()
-            :   m_streamBuf( new StreamBufImpl<OutputDebugWriter>() ),
-                m_os( m_streamBuf.get() )
-            {}
+            class CoutStream : public IStream {
+                mutable std::ostream m_os;
+            public:
+                // Store the streambuf from cout up-front because
+                // cout may get redirected when running tests
+                CoutStream() : m_os(Catch::cout().rdbuf()) {}
+                ~CoutStream() override = default;
 
-            ~DebugOutStream() override = default;
+            public: // IStream
+                std::ostream& stream() const override { return m_os; }
+            };
 
-        public: // IStream
-            std::ostream& stream() const override { return m_os; }
-        };
+            ///////////////////////////////////////////////////////////////////////////
 
-    }} // namespace anon::detail
+            class DebugOutStream : public IStream {
+                std::unique_ptr<StreamBufImpl<OutputDebugWriter>> m_streamBuf;
+                mutable std::ostream m_os;
+            public:
+                DebugOutStream()
+                    : m_streamBuf(new StreamBufImpl<OutputDebugWriter>()),
+                    m_os(m_streamBuf.get())
+                {}
 
-    ///////////////////////////////////////////////////////////////////////////
+                ~DebugOutStream() override = default;
 
-    auto makeStream( StringRef const &filename ) -> IStream const* {
-        if( filename.empty() )
+            public: // IStream
+                std::ostream& stream() const override { return m_os; }
+            };
+
+        }
+    } // namespace anon::detail
+
+   ///////////////////////////////////////////////////////////////////////////
+
+    auto makeStream(StringRef const& filename) -> IStream const* {
+        if (filename.empty())
             return new Detail::CoutStream();
-        else if( filename[0] == '%' ) {
-            if( filename == "%debug" )
+        else if (filename[0] == '%') {
+            if (filename == "%debug")
                 return new Detail::DebugOutStream();
             else
-                CATCH_ERROR( "Unrecognised stream: '" << filename << "'" );
+                CATCH_ERROR("Unrecognised stream: '" << filename << "'");
         }
         else
-            return new Detail::FileStream( filename );
+            return new Detail::FileStream(filename);
     }
 
     // This class encapsulates the idea of a pool of ostringstreams that can be reused.
@@ -13691,9 +13804,9 @@ namespace Catch {
         std::ostringstream m_referenceStream; // Used for copy state/ flags from
 
         auto add() -> std::size_t {
-            if( m_unused.empty() ) {
-                m_streams.push_back( std::unique_ptr<std::ostringstream>( new std::ostringstream ) );
-                return m_streams.size()-1;
+            if (m_unused.empty()) {
+                m_streams.push_back(std::unique_ptr<std::ostringstream>(new std::ostringstream));
+                return m_streams.size() - 1;
             }
             else {
                 auto index = m_unused.back();
@@ -13702,25 +13815,25 @@ namespace Catch {
             }
         }
 
-        void release( std::size_t index ) {
-            m_streams[index]->copyfmt( m_referenceStream ); // Restore initial flags and other state
+        void release(std::size_t index) {
+            m_streams[index]->copyfmt(m_referenceStream); // Restore initial flags and other state
             m_unused.push_back(index);
         }
     };
 
     ReusableStringStream::ReusableStringStream()
-    :   m_index( Singleton<StringStreams>::getMutable().add() ),
-        m_oss( Singleton<StringStreams>::getMutable().m_streams[m_index].get() )
+        : m_index(Singleton<StringStreams>::getMutable().add()),
+        m_oss(Singleton<StringStreams>::getMutable().m_streams[m_index].get())
     {}
 
     ReusableStringStream::~ReusableStringStream() {
-        static_cast<std::ostringstream*>( m_oss )->str("");
+        static_cast<std::ostringstream*>(m_oss)->str("");
         m_oss->clear();
-        Singleton<StringStreams>::getMutable().release( m_index );
+        Singleton<StringStreams>::getMutable().release(m_index);
     }
 
     auto ReusableStringStream::str() const -> std::string {
-        return static_cast<std::ostringstream*>( m_oss )->str();
+        return static_cast<std::ostringstream*>(m_oss)->str();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -13744,45 +13857,45 @@ namespace Catch {
 
     namespace {
         char toLowerCh(char c) {
-            return static_cast<char>( std::tolower( static_cast<unsigned char>(c) ) );
+            return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         }
     }
 
-    bool startsWith( std::string const& s, std::string const& prefix ) {
+    bool startsWith(std::string const& s, std::string const& prefix) {
         return s.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), s.begin());
     }
-    bool startsWith( std::string const& s, char prefix ) {
+    bool startsWith(std::string const& s, char prefix) {
         return !s.empty() && s[0] == prefix;
     }
-    bool endsWith( std::string const& s, std::string const& suffix ) {
+    bool endsWith(std::string const& s, std::string const& suffix) {
         return s.size() >= suffix.size() && std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
     }
-    bool endsWith( std::string const& s, char suffix ) {
-        return !s.empty() && s[s.size()-1] == suffix;
+    bool endsWith(std::string const& s, char suffix) {
+        return !s.empty() && s[s.size() - 1] == suffix;
     }
-    bool contains( std::string const& s, std::string const& infix ) {
-        return s.find( infix ) != std::string::npos;
+    bool contains(std::string const& s, std::string const& infix) {
+        return s.find(infix) != std::string::npos;
     }
-    void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
+    void toLowerInPlace(std::string& s) {
+        std::transform(s.begin(), s.end(), s.begin(), toLowerCh);
     }
-    std::string toLower( std::string const& s ) {
+    std::string toLower(std::string const& s) {
         std::string lc = s;
-        toLowerInPlace( lc );
+        toLowerInPlace(lc);
         return lc;
     }
-    std::string trim( std::string const& str ) {
+    std::string trim(std::string const& str) {
         static char const* whitespaceChars = "\n\r\t ";
-        std::string::size_type start = str.find_first_not_of( whitespaceChars );
-        std::string::size_type end = str.find_last_not_of( whitespaceChars );
+        std::string::size_type start = str.find_first_not_of(whitespaceChars);
+        std::string::size_type end = str.find_last_not_of(whitespaceChars);
 
-        return start != std::string::npos ? str.substr( start, 1+end-start ) : std::string();
+        return start != std::string::npos ? str.substr(start, 1 + end - start) : std::string();
     }
 
     StringRef trim(StringRef ref) {
         const auto is_ws = [](char c) {
             return c == ' ' || c == '\t' || c == '\n' || c == '\r';
-        };
+            };
         size_t real_begin = 0;
         while (real_begin < ref.size() && is_ws(ref[real_begin])) { ++real_begin; }
         size_t real_end = ref.size();
@@ -13791,43 +13904,43 @@ namespace Catch {
         return ref.substr(real_begin, real_end - real_begin);
     }
 
-    bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis ) {
+    bool replaceInPlace(std::string& str, std::string const& replaceThis, std::string const& withThis) {
         bool replaced = false;
-        std::size_t i = str.find( replaceThis );
-        while( i != std::string::npos ) {
+        std::size_t i = str.find(replaceThis);
+        while (i != std::string::npos) {
             replaced = true;
-            str = str.substr( 0, i ) + withThis + str.substr( i+replaceThis.size() );
-            if( i < str.size()-withThis.size() )
-                i = str.find( replaceThis, i+withThis.size() );
+            str = str.substr(0, i) + withThis + str.substr(i + replaceThis.size());
+            if (i < str.size() - withThis.size())
+                i = str.find(replaceThis, i + withThis.size());
             else
                 i = std::string::npos;
         }
         return replaced;
     }
 
-    std::vector<StringRef> splitStringRef( StringRef str, char delimiter ) {
+    std::vector<StringRef> splitStringRef(StringRef str, char delimiter) {
         std::vector<StringRef> subStrings;
         std::size_t start = 0;
-        for(std::size_t pos = 0; pos < str.size(); ++pos ) {
-            if( str[pos] == delimiter ) {
-                if( pos - start > 1 )
-                    subStrings.push_back( str.substr( start, pos-start ) );
-                start = pos+1;
+        for (std::size_t pos = 0; pos < str.size(); ++pos) {
+            if (str[pos] == delimiter) {
+                if (pos - start > 1)
+                    subStrings.push_back(str.substr(start, pos - start));
+                start = pos + 1;
             }
         }
-        if( start < str.size() )
-            subStrings.push_back( str.substr( start, str.size()-start ) );
+        if (start < str.size())
+            subStrings.push_back(str.substr(start, str.size() - start));
         return subStrings;
     }
 
-    pluralise::pluralise( std::size_t count, std::string const& label )
-    :   m_count( count ),
-        m_label( label )
+    pluralise::pluralise(std::size_t count, std::string const& label)
+        : m_count(count),
+        m_label(label)
     {}
 
-    std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser ) {
+    std::ostream& operator << (std::ostream& os, pluralise const& pluraliser) {
         os << pluraliser.m_count << ' ' << pluraliser.m_label;
-        if( pluraliser.m_count != 1 )
+        if (pluraliser.m_count != 1)
             os << 's';
         return os;
     }
@@ -13842,8 +13955,8 @@ namespace Catch {
 #include <cstdint>
 
 namespace Catch {
-    StringRef::StringRef( char const* rawChars ) noexcept
-    : StringRef( rawChars, static_cast<StringRef::size_type>(std::strlen(rawChars) ) )
+    StringRef::StringRef(char const* rawChars) noexcept
+        : StringRef(rawChars, static_cast<StringRef::size_type>(std::strlen(rawChars)))
     {}
 
     auto StringRef::c_str() const -> char const* {
@@ -13854,23 +13967,24 @@ namespace Catch {
         return m_start;
     }
 
-    auto StringRef::substr( size_type start, size_type size ) const noexcept -> StringRef {
+    auto StringRef::substr(size_type start, size_type size) const noexcept -> StringRef {
         if (start < m_size) {
             return StringRef(m_start + start, (std::min)(m_size - start, size));
-        } else {
+        }
+        else {
             return StringRef();
         }
     }
-    auto StringRef::operator == ( StringRef const& other ) const noexcept -> bool {
+    auto StringRef::operator == (StringRef const& other) const noexcept -> bool {
         return m_size == other.m_size
-            && (std::memcmp( m_start, other.m_start, m_size ) == 0);
+            && (std::memcmp(m_start, other.m_start, m_size) == 0);
     }
 
-    auto operator << ( std::ostream& os, StringRef const& str ) -> std::ostream& {
+    auto operator << (std::ostream& os, StringRef const& str) -> std::ostream& {
         return os.write(str.data(), str.size());
     }
 
-    auto operator+=( std::string& lhs, StringRef const& rhs ) -> std::string& {
+    auto operator+=(std::string& lhs, StringRef const& rhs) -> std::string& {
         lhs.append(rhs.data(), rhs.size());
         return lhs;
     }
@@ -13880,7 +13994,7 @@ namespace Catch {
 // start catch_tag_alias.cpp
 
 namespace Catch {
-    TagAlias::TagAlias(std::string const & _tag, SourceLineInfo _lineInfo): tag(_tag), lineInfo(_lineInfo) {}
+    TagAlias::TagAlias(std::string const& _tag, SourceLineInfo _lineInfo) : tag(_tag), lineInfo(_lineInfo) {}
 }
 // end catch_tag_alias.cpp
 // start catch_tag_alias_autoregistrar.cpp
@@ -13888,9 +14002,9 @@ namespace Catch {
 namespace Catch {
 
     RegistrarForTagAliases::RegistrarForTagAliases(char const* alias, char const* tag, SourceLineInfo const& lineInfo) {
-        CATCH_TRY {
+        CATCH_TRY{
             getMutableRegistryHub().registerTagAlias(alias, tag, lineInfo);
-        } CATCH_CATCH_ALL {
+        } CATCH_CATCH_ALL{
             // Do not throw when constructing global objects, instead register the exception to be processed later
             getMutableRegistryHub().registerStartupException();
         }
@@ -13906,35 +14020,35 @@ namespace Catch {
 
     TagAliasRegistry::~TagAliasRegistry() {}
 
-    TagAlias const* TagAliasRegistry::find( std::string const& alias ) const {
-        auto it = m_registry.find( alias );
-        if( it != m_registry.end() )
+    TagAlias const* TagAliasRegistry::find(std::string const& alias) const {
+        auto it = m_registry.find(alias);
+        if (it != m_registry.end())
             return &(it->second);
         else
             return nullptr;
     }
 
-    std::string TagAliasRegistry::expandAliases( std::string const& unexpandedTestSpec ) const {
+    std::string TagAliasRegistry::expandAliases(std::string const& unexpandedTestSpec) const {
         std::string expandedTestSpec = unexpandedTestSpec;
-        for( auto const& registryKvp : m_registry ) {
-            std::size_t pos = expandedTestSpec.find( registryKvp.first );
-            if( pos != std::string::npos ) {
-                expandedTestSpec =  expandedTestSpec.substr( 0, pos ) +
-                                    registryKvp.second.tag +
-                                    expandedTestSpec.substr( pos + registryKvp.first.size() );
+        for (auto const& registryKvp : m_registry) {
+            std::size_t pos = expandedTestSpec.find(registryKvp.first);
+            if (pos != std::string::npos) {
+                expandedTestSpec = expandedTestSpec.substr(0, pos) +
+                    registryKvp.second.tag +
+                    expandedTestSpec.substr(pos + registryKvp.first.size());
             }
         }
         return expandedTestSpec;
     }
 
-    void TagAliasRegistry::add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) {
-        CATCH_ENFORCE( startsWith(alias, "[@") && endsWith(alias, ']'),
-                      "error: tag alias, '" << alias << "' is not of the form [@alias name].\n" << lineInfo );
+    void TagAliasRegistry::add(std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo) {
+        CATCH_ENFORCE(startsWith(alias, "[@") && endsWith(alias, ']'),
+            "error: tag alias, '" << alias << "' is not of the form [@alias name].\n" << lineInfo);
 
-        CATCH_ENFORCE( m_registry.insert(std::make_pair(alias, TagAlias(tag, lineInfo))).second,
-                      "error: tag alias, '" << alias << "' already registered.\n"
-                      << "\tFirst seen at: " << find(alias)->lineInfo << "\n"
-                      << "\tRedefined at: " << lineInfo );
+        CATCH_ENFORCE(m_registry.insert(std::make_pair(alias, TagAlias(tag, lineInfo))).second,
+            "error: tag alias, '" << alias << "' already registered.\n"
+            << "\tFirst seen at: " << find(alias)->lineInfo << "\n"
+            << "\tRedefined at: " << lineInfo);
     }
 
     ITagAliasRegistry::~ITagAliasRegistry() {}
@@ -13955,38 +14069,38 @@ namespace Catch {
 namespace Catch {
 
     namespace {
-        TestCaseInfo::SpecialProperties parseSpecialTag( std::string const& tag ) {
-            if( startsWith( tag, '.' ) ||
-                tag == "!hide" )
+        TestCaseInfo::SpecialProperties parseSpecialTag(std::string const& tag) {
+            if (startsWith(tag, '.') ||
+                tag == "!hide")
                 return TestCaseInfo::IsHidden;
-            else if( tag == "!throws" )
+            else if (tag == "!throws")
                 return TestCaseInfo::Throws;
-            else if( tag == "!shouldfail" )
+            else if (tag == "!shouldfail")
                 return TestCaseInfo::ShouldFail;
-            else if( tag == "!mayfail" )
+            else if (tag == "!mayfail")
                 return TestCaseInfo::MayFail;
-            else if( tag == "!nonportable" )
+            else if (tag == "!nonportable")
                 return TestCaseInfo::NonPortable;
-            else if( tag == "!benchmark" )
-                return static_cast<TestCaseInfo::SpecialProperties>( TestCaseInfo::Benchmark | TestCaseInfo::IsHidden );
+            else if (tag == "!benchmark")
+                return static_cast<TestCaseInfo::SpecialProperties>(TestCaseInfo::Benchmark | TestCaseInfo::IsHidden);
             else
                 return TestCaseInfo::None;
         }
-        bool isReservedTag( std::string const& tag ) {
-            return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !std::isalnum( static_cast<unsigned char>(tag[0]) );
+        bool isReservedTag(std::string const& tag) {
+            return parseSpecialTag(tag) == TestCaseInfo::None && tag.size() > 0 && !std::isalnum(static_cast<unsigned char>(tag[0]));
         }
-        void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
-            CATCH_ENFORCE( !isReservedTag(tag),
-                          "Tag name: [" << tag << "] is not allowed.\n"
-                          << "Tag names starting with non alphanumeric characters are reserved\n"
-                          << _lineInfo );
+        void enforceNotReservedTag(std::string const& tag, SourceLineInfo const& _lineInfo) {
+            CATCH_ENFORCE(!isReservedTag(tag),
+                "Tag name: [" << tag << "] is not allowed.\n"
+                << "Tag names starting with non alphanumeric characters are reserved\n"
+                << _lineInfo);
         }
     }
 
-    TestCase makeTestCase(  ITestInvoker* _testCase,
-                            std::string const& _className,
-                            NameAndTags const& nameAndTags,
-                            SourceLineInfo const& _lineInfo )
+    TestCase makeTestCase(ITestInvoker* _testCase,
+        std::string const& _className,
+        NameAndTags const& nameAndTags,
+        SourceLineInfo const& _lineInfo)
     {
         bool isHidden = false;
 
@@ -13995,19 +14109,19 @@ namespace Catch {
         std::string desc, tag;
         bool inTag = false;
         for (char c : nameAndTags.tags) {
-            if( !inTag ) {
-                if( c == '[' )
+            if (!inTag) {
+                if (c == '[')
                     inTag = true;
                 else
                     desc += c;
             }
             else {
-                if( c == ']' ) {
-                    TestCaseInfo::SpecialProperties prop = parseSpecialTag( tag );
-                    if( ( prop & TestCaseInfo::IsHidden ) != 0 )
+                if (c == ']') {
+                    TestCaseInfo::SpecialProperties prop = parseSpecialTag(tag);
+                    if ((prop & TestCaseInfo::IsHidden) != 0)
                         isHidden = true;
-                    else if( prop == TestCaseInfo::None )
-                        enforceNotReservedTag( tag, _lineInfo );
+                    else if (prop == TestCaseInfo::None)
+                        enforceNotReservedTag(tag, _lineInfo);
 
                     // Merged hide tags like `[.approvals]` should be added as
                     // `[.][approvals]`. The `[.]` is added at later point, so
@@ -14015,7 +14129,7 @@ namespace Catch {
                     if (startsWith(tag, '.') && tag.size() > 1) {
                         tag.erase(0, 1);
                     }
-                    tags.push_back( tag );
+                    tags.push_back(tag);
                     tag.clear();
                     inTag = false;
                 }
@@ -14023,53 +14137,53 @@ namespace Catch {
                     tag += c;
             }
         }
-        if( isHidden ) {
+        if (isHidden) {
             // Add all "hidden" tags to make them behave identically
-            tags.insert( tags.end(), { ".", "!hide" } );
+            tags.insert(tags.end(), { ".", "!hide" });
         }
 
-        TestCaseInfo info( static_cast<std::string>(nameAndTags.name), _className, desc, tags, _lineInfo );
-        return TestCase( _testCase, std::move(info) );
+        TestCaseInfo info(static_cast<std::string>(nameAndTags.name), _className, desc, tags, _lineInfo);
+        return TestCase(_testCase, std::move(info));
     }
 
-    void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags ) {
+    void setTags(TestCaseInfo& testCaseInfo, std::vector<std::string> tags) {
         std::sort(begin(tags), end(tags));
         tags.erase(std::unique(begin(tags), end(tags)), end(tags));
         testCaseInfo.lcaseTags.clear();
 
-        for( auto const& tag : tags ) {
-            std::string lcaseTag = toLower( tag );
-            testCaseInfo.properties = static_cast<TestCaseInfo::SpecialProperties>( testCaseInfo.properties | parseSpecialTag( lcaseTag ) );
-            testCaseInfo.lcaseTags.push_back( lcaseTag );
+        for (auto const& tag : tags) {
+            std::string lcaseTag = toLower(tag);
+            testCaseInfo.properties = static_cast<TestCaseInfo::SpecialProperties>(testCaseInfo.properties | parseSpecialTag(lcaseTag));
+            testCaseInfo.lcaseTags.push_back(lcaseTag);
         }
         testCaseInfo.tags = std::move(tags);
     }
 
-    TestCaseInfo::TestCaseInfo( std::string const& _name,
-                                std::string const& _className,
-                                std::string const& _description,
-                                std::vector<std::string> const& _tags,
-                                SourceLineInfo const& _lineInfo )
-    :   name( _name ),
-        className( _className ),
-        description( _description ),
-        lineInfo( _lineInfo ),
-        properties( None )
+    TestCaseInfo::TestCaseInfo(std::string const& _name,
+        std::string const& _className,
+        std::string const& _description,
+        std::vector<std::string> const& _tags,
+        SourceLineInfo const& _lineInfo)
+        : name(_name),
+        className(_className),
+        description(_description),
+        lineInfo(_lineInfo),
+        properties(None)
     {
-        setTags( *this, _tags );
+        setTags(*this, _tags);
     }
 
     bool TestCaseInfo::isHidden() const {
-        return ( properties & IsHidden ) != 0;
+        return (properties & IsHidden) != 0;
     }
     bool TestCaseInfo::throws() const {
-        return ( properties & Throws ) != 0;
+        return (properties & Throws) != 0;
     }
     bool TestCaseInfo::okToFail() const {
-        return ( properties & (ShouldFail | MayFail ) ) != 0;
+        return (properties & (ShouldFail | MayFail)) != 0;
     }
     bool TestCaseInfo::expectedToFail() const {
-        return ( properties & (ShouldFail ) ) != 0;
+        return (properties & (ShouldFail)) != 0;
     }
 
     std::string TestCaseInfo::tagsAsString() const {
@@ -14089,10 +14203,10 @@ namespace Catch {
         return ret;
     }
 
-    TestCase::TestCase( ITestInvoker* testCase, TestCaseInfo&& info ) : TestCaseInfo( std::move(info) ), test( testCase ) {}
+    TestCase::TestCase(ITestInvoker* testCase, TestCaseInfo&& info) : TestCaseInfo(std::move(info)), test(testCase) {}
 
-    TestCase TestCase::withName( std::string const& _newName ) const {
-        TestCase other( *this );
+    TestCase TestCase::withName(std::string const& _newName) const {
+        TestCase other(*this);
         other.name = _newName;
         return other;
     }
@@ -14101,13 +14215,13 @@ namespace Catch {
         test->invoke();
     }
 
-    bool TestCase::operator == ( TestCase const& other ) const {
+    bool TestCase::operator == (TestCase const& other) const {
         return  test.get() == other.test.get() &&
-                name == other.name &&
-                className == other.className;
+            name == other.name &&
+            className == other.className;
     }
 
-    bool TestCase::operator < ( TestCase const& other ) const {
+    bool TestCase::operator < (TestCase const& other) const {
         return name < other.name;
     }
 
@@ -14127,94 +14241,98 @@ namespace Catch {
 
     namespace {
         struct TestHasher {
-            explicit TestHasher(Catch::SimplePcg32& rng_instance) {
-                basis = rng_instance();
-                basis <<= 32;
-                basis |= rng_instance();
-            }
+            using hash_t = uint64_t;
 
-            uint64_t basis;
+            explicit TestHasher(hash_t hashSuffix) :
+                m_hashSuffix{ hashSuffix } {}
 
-            uint64_t operator()(TestCase const& t) const {
-                // Modified FNV-1a hash
-                static constexpr uint64_t prime = 1099511628211;
-                uint64_t hash = basis;
+            uint32_t operator()(TestCase const& t) const {
+                // FNV-1a hash with multiplication fold.
+                const hash_t prime = 1099511628211u;
+                hash_t hash = 14695981039346656037u;
                 for (const char c : t.name) {
                     hash ^= c;
                     hash *= prime;
                 }
-                return hash;
+                hash ^= m_hashSuffix;
+                hash *= prime;
+                const uint32_t low{ static_cast<uint32_t>(hash) };
+                const uint32_t high{ static_cast<uint32_t>(hash >> 32) };
+                return low * high;
             }
+
+        private:
+            hash_t m_hashSuffix;
         };
     } // end unnamed namespace
 
-    std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases ) {
-        switch( config.runOrder() ) {
-            case RunTests::InDeclarationOrder:
-                // already in declaration order
-                break;
+    std::vector<TestCase> sortTests(IConfig const& config, std::vector<TestCase> const& unsortedTestCases) {
+        switch (config.runOrder()) {
+        case RunTests::InDeclarationOrder:
+            // already in declaration order
+            break;
 
-            case RunTests::InLexicographicalOrder: {
-                std::vector<TestCase> sorted = unsortedTestCases;
-                std::sort( sorted.begin(), sorted.end() );
-                return sorted;
+        case RunTests::InLexicographicalOrder: {
+            std::vector<TestCase> sorted = unsortedTestCases;
+            std::sort(sorted.begin(), sorted.end());
+            return sorted;
+        }
+
+        case RunTests::InRandomOrder: {
+            seedRng(config);
+            TestHasher h{ config.rngSeed() };
+
+            using hashedTest = std::pair<TestHasher::hash_t, TestCase const*>;
+            std::vector<hashedTest> indexed_tests;
+            indexed_tests.reserve(unsortedTestCases.size());
+
+            for (auto const& testCase : unsortedTestCases) {
+                indexed_tests.emplace_back(h(testCase), &testCase);
             }
 
-            case RunTests::InRandomOrder: {
-                seedRng( config );
-                TestHasher h( rng() );
-
-                using hashedTest = std::pair<uint64_t, TestCase const*>;
-                std::vector<hashedTest> indexed_tests;
-                indexed_tests.reserve( unsortedTestCases.size() );
-
-                for (auto const& testCase : unsortedTestCases) {
-                    indexed_tests.emplace_back(h(testCase), &testCase);
-                }
-
-                std::sort(indexed_tests.begin(), indexed_tests.end(),
-                          [](hashedTest const& lhs, hashedTest const& rhs) {
-                          if (lhs.first == rhs.first) {
-                              return lhs.second->name < rhs.second->name;
-                          }
-                          return lhs.first < rhs.first;
+            std::sort(indexed_tests.begin(), indexed_tests.end(),
+                [](hashedTest const& lhs, hashedTest const& rhs) {
+                    if (lhs.first == rhs.first) {
+                        return lhs.second->name < rhs.second->name;
+                    }
+                    return lhs.first < rhs.first;
                 });
 
-                std::vector<TestCase> sorted;
-                sorted.reserve( indexed_tests.size() );
+            std::vector<TestCase> sorted;
+            sorted.reserve(indexed_tests.size());
 
-                for (auto const& hashed : indexed_tests) {
-                    sorted.emplace_back(*hashed.second);
-                }
-
-                return sorted;
+            for (auto const& hashed : indexed_tests) {
+                sorted.emplace_back(*hashed.second);
             }
+
+            return sorted;
+        }
         }
         return unsortedTestCases;
     }
 
-    bool isThrowSafe( TestCase const& testCase, IConfig const& config ) {
+    bool isThrowSafe(TestCase const& testCase, IConfig const& config) {
         return !testCase.throws() || config.allowThrows();
     }
 
-    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config ) {
-        return testSpec.matches( testCase ) && isThrowSafe( testCase, config );
+    bool matchTest(TestCase const& testCase, TestSpec const& testSpec, IConfig const& config) {
+        return testSpec.matches(testCase) && isThrowSafe(testCase, config);
     }
 
-    void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions ) {
+    void enforceNoDuplicateTestCases(std::vector<TestCase> const& functions) {
         std::set<TestCase> seenFunctions;
-        for( auto const& function : functions ) {
-            auto prev = seenFunctions.insert( function );
-            CATCH_ENFORCE( prev.second,
-                    "error: TEST_CASE( \"" << function.name << "\" ) already defined.\n"
-                    << "\tFirst seen at " << prev.first->getTestCaseInfo().lineInfo << "\n"
-                    << "\tRedefined at " << function.getTestCaseInfo().lineInfo );
+        for (auto const& function : functions) {
+            auto prev = seenFunctions.insert(function);
+            CATCH_ENFORCE(prev.second,
+                "error: TEST_CASE( \"" << function.name << "\" ) already defined.\n"
+                << "\tFirst seen at " << prev.first->getTestCaseInfo().lineInfo << "\n"
+                << "\tRedefined at " << function.getTestCaseInfo().lineInfo);
         }
     }
 
-    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config ) {
+    std::vector<TestCase> filterTests(std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config) {
         std::vector<TestCase> filtered;
-        filtered.reserve( testCases.size() );
+        filtered.reserve(testCases.size());
         for (auto const& testCase : testCases) {
             if ((!testSpec.hasFilters() && !testCase.isHidden()) ||
                 (testSpec.hasFilters() && matchTest(testCase, testSpec, config))) {
@@ -14223,50 +14341,50 @@ namespace Catch {
         }
         return filtered;
     }
-    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config ) {
-        return getRegistryHub().getTestCaseRegistry().getAllTestsSorted( config );
+    std::vector<TestCase> const& getAllTestCasesSorted(IConfig const& config) {
+        return getRegistryHub().getTestCaseRegistry().getAllTestsSorted(config);
     }
 
-    void TestRegistry::registerTest( TestCase const& testCase ) {
+    void TestRegistry::registerTest(TestCase const& testCase) {
         std::string name = testCase.getTestCaseInfo().name;
-        if( name.empty() ) {
+        if (name.empty()) {
             ReusableStringStream rss;
             rss << "Anonymous test case " << ++m_unnamedCount;
-            return registerTest( testCase.withName( rss.str() ) );
+            return registerTest(testCase.withName(rss.str()));
         }
-        m_functions.push_back( testCase );
+        m_functions.push_back(testCase);
     }
 
     std::vector<TestCase> const& TestRegistry::getAllTests() const {
         return m_functions;
     }
-    std::vector<TestCase> const& TestRegistry::getAllTestsSorted( IConfig const& config ) const {
-        if( m_sortedFunctions.empty() )
-            enforceNoDuplicateTestCases( m_functions );
+    std::vector<TestCase> const& TestRegistry::getAllTestsSorted(IConfig const& config) const {
+        if (m_sortedFunctions.empty())
+            enforceNoDuplicateTestCases(m_functions);
 
-        if(  m_currentSortOrder != config.runOrder() || m_sortedFunctions.empty() ) {
-            m_sortedFunctions = sortTests( config, m_functions );
+        if (m_currentSortOrder != config.runOrder() || m_sortedFunctions.empty()) {
+            m_sortedFunctions = sortTests(config, m_functions);
             m_currentSortOrder = config.runOrder();
         }
         return m_sortedFunctions;
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    TestInvokerAsFunction::TestInvokerAsFunction( void(*testAsFunction)() ) noexcept : m_testAsFunction( testAsFunction ) {}
+    TestInvokerAsFunction::TestInvokerAsFunction(void(*testAsFunction)()) noexcept : m_testAsFunction(testAsFunction) {}
 
     void TestInvokerAsFunction::invoke() const {
         m_testAsFunction();
     }
 
-    std::string extractClassName( StringRef const& classOrQualifiedMethodName ) {
+    std::string extractClassName(StringRef const& classOrQualifiedMethodName) {
         std::string className(classOrQualifiedMethodName);
-        if( startsWith( className, '&' ) )
+        if (startsWith(className, '&'))
         {
-            std::size_t lastColons = className.rfind( "::" );
-            std::size_t penultimateColons = className.rfind( "::", lastColons-1 );
-            if( penultimateColons == std::string::npos )
+            std::size_t lastColons = className.rfind("::");
+            std::size_t penultimateColons = className.rfind("::", lastColons - 1);
+            if (penultimateColons == std::string::npos)
                 penultimateColons = 1;
-            className = className.substr( penultimateColons, lastColons-penultimateColons );
+            className = className.substr(penultimateColons, lastColons - penultimateColons);
         }
         return className;
     }
@@ -14287,110 +14405,110 @@ namespace Catch {
 #endif
 
 namespace Catch {
-namespace TestCaseTracking {
+    namespace TestCaseTracking {
 
-    NameAndLocation::NameAndLocation( std::string const& _name, SourceLineInfo const& _location )
-    :   name( _name ),
-        location( _location )
-    {}
+        NameAndLocation::NameAndLocation(std::string const& _name, SourceLineInfo const& _location)
+            : name(_name),
+            location(_location)
+        {}
 
-    ITracker::~ITracker() = default;
+        ITracker::~ITracker() = default;
 
-    ITracker& TrackerContext::startRun() {
-        m_rootTracker = std::make_shared<SectionTracker>( NameAndLocation( "{root}", CATCH_INTERNAL_LINEINFO ), *this, nullptr );
-        m_currentTracker = nullptr;
-        m_runState = Executing;
-        return *m_rootTracker;
-    }
+        ITracker& TrackerContext::startRun() {
+            m_rootTracker = std::make_shared<SectionTracker>(NameAndLocation("{root}", CATCH_INTERNAL_LINEINFO), *this, nullptr);
+            m_currentTracker = nullptr;
+            m_runState = Executing;
+            return *m_rootTracker;
+        }
 
-    void TrackerContext::endRun() {
-        m_rootTracker.reset();
-        m_currentTracker = nullptr;
-        m_runState = NotStarted;
-    }
+        void TrackerContext::endRun() {
+            m_rootTracker.reset();
+            m_currentTracker = nullptr;
+            m_runState = NotStarted;
+        }
 
-    void TrackerContext::startCycle() {
-        m_currentTracker = m_rootTracker.get();
-        m_runState = Executing;
-    }
-    void TrackerContext::completeCycle() {
-        m_runState = CompletedCycle;
-    }
+        void TrackerContext::startCycle() {
+            m_currentTracker = m_rootTracker.get();
+            m_runState = Executing;
+        }
+        void TrackerContext::completeCycle() {
+            m_runState = CompletedCycle;
+        }
 
-    bool TrackerContext::completedCycle() const {
-        return m_runState == CompletedCycle;
-    }
-    ITracker& TrackerContext::currentTracker() {
-        return *m_currentTracker;
-    }
-    void TrackerContext::setCurrentTracker( ITracker* tracker ) {
-        m_currentTracker = tracker;
-    }
+        bool TrackerContext::completedCycle() const {
+            return m_runState == CompletedCycle;
+        }
+        ITracker& TrackerContext::currentTracker() {
+            return *m_currentTracker;
+        }
+        void TrackerContext::setCurrentTracker(ITracker* tracker) {
+            m_currentTracker = tracker;
+        }
 
-    TrackerBase::TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent ):
-        ITracker(nameAndLocation),
-        m_ctx( ctx ),
-        m_parent( parent )
-    {}
+        TrackerBase::TrackerBase(NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent) :
+            ITracker(nameAndLocation),
+            m_ctx(ctx),
+            m_parent(parent)
+        {}
 
-    bool TrackerBase::isComplete() const {
-        return m_runState == CompletedSuccessfully || m_runState == Failed;
-    }
-    bool TrackerBase::isSuccessfullyCompleted() const {
-        return m_runState == CompletedSuccessfully;
-    }
-    bool TrackerBase::isOpen() const {
-        return m_runState != NotStarted && !isComplete();
-    }
-    bool TrackerBase::hasChildren() const {
-        return !m_children.empty();
-    }
+        bool TrackerBase::isComplete() const {
+            return m_runState == CompletedSuccessfully || m_runState == Failed;
+        }
+        bool TrackerBase::isSuccessfullyCompleted() const {
+            return m_runState == CompletedSuccessfully;
+        }
+        bool TrackerBase::isOpen() const {
+            return m_runState != NotStarted && !isComplete();
+        }
+        bool TrackerBase::hasChildren() const {
+            return !m_children.empty();
+        }
 
-    void TrackerBase::addChild( ITrackerPtr const& child ) {
-        m_children.push_back( child );
-    }
+        void TrackerBase::addChild(ITrackerPtr const& child) {
+            m_children.push_back(child);
+        }
 
-    ITrackerPtr TrackerBase::findChild( NameAndLocation const& nameAndLocation ) {
-        auto it = std::find_if( m_children.begin(), m_children.end(),
-            [&nameAndLocation]( ITrackerPtr const& tracker ){
-                return
-                    tracker->nameAndLocation().location == nameAndLocation.location &&
-                    tracker->nameAndLocation().name == nameAndLocation.name;
-            } );
-        return( it != m_children.end() )
-            ? *it
-            : nullptr;
-    }
-    ITracker& TrackerBase::parent() {
-        assert( m_parent ); // Should always be non-null except for root
-        return *m_parent;
-    }
+        ITrackerPtr TrackerBase::findChild(NameAndLocation const& nameAndLocation) {
+            auto it = std::find_if(m_children.begin(), m_children.end(),
+                [&nameAndLocation](ITrackerPtr const& tracker) {
+                    return
+                        tracker->nameAndLocation().location == nameAndLocation.location &&
+                        tracker->nameAndLocation().name == nameAndLocation.name;
+                });
+            return(it != m_children.end())
+                ? *it
+                : nullptr;
+        }
+        ITracker& TrackerBase::parent() {
+            assert(m_parent); // Should always be non-null except for root
+            return *m_parent;
+        }
 
-    void TrackerBase::openChild() {
-        if( m_runState != ExecutingChildren ) {
-            m_runState = ExecutingChildren;
-            if( m_parent )
+        void TrackerBase::openChild() {
+            if (m_runState != ExecutingChildren) {
+                m_runState = ExecutingChildren;
+                if (m_parent)
+                    m_parent->openChild();
+            }
+        }
+
+        bool TrackerBase::isSectionTracker() const { return false; }
+        bool TrackerBase::isGeneratorTracker() const { return false; }
+
+        void TrackerBase::open() {
+            m_runState = Executing;
+            moveToThis();
+            if (m_parent)
                 m_parent->openChild();
         }
-    }
 
-    bool TrackerBase::isSectionTracker() const { return false; }
-    bool TrackerBase::isGeneratorTracker() const { return false; }
+        void TrackerBase::close() {
 
-    void TrackerBase::open() {
-        m_runState = Executing;
-        moveToThis();
-        if( m_parent )
-            m_parent->openChild();
-    }
+            // Close any still open children (e.g. generators)
+            while (&m_ctx.currentTracker() != this)
+                m_ctx.currentTracker().close();
 
-    void TrackerBase::close() {
-
-        // Close any still open children (e.g. generators)
-        while( &m_ctx.currentTracker() != this )
-            m_ctx.currentTracker().close();
-
-        switch( m_runState ) {
+            switch (m_runState) {
             case NeedsAnotherRun:
                 break;
 
@@ -14398,115 +14516,115 @@ namespace TestCaseTracking {
                 m_runState = CompletedSuccessfully;
                 break;
             case ExecutingChildren:
-                if( std::all_of(m_children.begin(), m_children.end(), [](ITrackerPtr const& t){ return t->isComplete(); }) )
+                if (std::all_of(m_children.begin(), m_children.end(), [](ITrackerPtr const& t) { return t->isComplete(); }))
                     m_runState = CompletedSuccessfully;
                 break;
 
             case NotStarted:
             case CompletedSuccessfully:
             case Failed:
-                CATCH_INTERNAL_ERROR( "Illogical state: " << m_runState );
+                CATCH_INTERNAL_ERROR("Illogical state: " << m_runState);
 
             default:
-                CATCH_INTERNAL_ERROR( "Unknown state: " << m_runState );
+                CATCH_INTERNAL_ERROR("Unknown state: " << m_runState);
+            }
+            moveToParent();
+            m_ctx.completeCycle();
         }
-        moveToParent();
-        m_ctx.completeCycle();
-    }
-    void TrackerBase::fail() {
-        m_runState = Failed;
-        if( m_parent )
-            m_parent->markAsNeedingAnotherRun();
-        moveToParent();
-        m_ctx.completeCycle();
-    }
-    void TrackerBase::markAsNeedingAnotherRun() {
-        m_runState = NeedsAnotherRun;
-    }
-
-    void TrackerBase::moveToParent() {
-        assert( m_parent );
-        m_ctx.setCurrentTracker( m_parent );
-    }
-    void TrackerBase::moveToThis() {
-        m_ctx.setCurrentTracker( this );
-    }
-
-    SectionTracker::SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
-    :   TrackerBase( nameAndLocation, ctx, parent ),
-        m_trimmed_name(trim(nameAndLocation.name))
-    {
-        if( parent ) {
-            while( !parent->isSectionTracker() )
-                parent = &parent->parent();
-
-            SectionTracker& parentSection = static_cast<SectionTracker&>( *parent );
-            addNextFilters( parentSection.m_filters );
+        void TrackerBase::fail() {
+            m_runState = Failed;
+            if (m_parent)
+                m_parent->markAsNeedingAnotherRun();
+            moveToParent();
+            m_ctx.completeCycle();
         }
-    }
-
-    bool SectionTracker::isComplete() const {
-        bool complete = true;
-
-        if (m_filters.empty()
-            || m_filters[0] == ""
-            || std::find(m_filters.begin(), m_filters.end(), m_trimmed_name) != m_filters.end()) {
-            complete = TrackerBase::isComplete();
+        void TrackerBase::markAsNeedingAnotherRun() {
+            m_runState = NeedsAnotherRun;
         }
-        return complete;
-    }
 
-    bool SectionTracker::isSectionTracker() const { return true; }
-
-    SectionTracker& SectionTracker::acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation ) {
-        std::shared_ptr<SectionTracker> section;
-
-        ITracker& currentTracker = ctx.currentTracker();
-        if( ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
-            assert( childTracker );
-            assert( childTracker->isSectionTracker() );
-            section = std::static_pointer_cast<SectionTracker>( childTracker );
+        void TrackerBase::moveToParent() {
+            assert(m_parent);
+            m_ctx.setCurrentTracker(m_parent);
         }
-        else {
-            section = std::make_shared<SectionTracker>( nameAndLocation, ctx, &currentTracker );
-            currentTracker.addChild( section );
+        void TrackerBase::moveToThis() {
+            m_ctx.setCurrentTracker(this);
         }
-        if( !ctx.completedCycle() )
-            section->tryOpen();
-        return *section;
-    }
 
-    void SectionTracker::tryOpen() {
-        if( !isComplete() )
-            open();
-    }
+        SectionTracker::SectionTracker(NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent)
+            : TrackerBase(nameAndLocation, ctx, parent),
+            m_trimmed_name(trim(nameAndLocation.name))
+        {
+            if (parent) {
+                while (!parent->isSectionTracker())
+                    parent = &parent->parent();
 
-    void SectionTracker::addInitialFilters( std::vector<std::string> const& filters ) {
-        if( !filters.empty() ) {
-            m_filters.reserve( m_filters.size() + filters.size() + 2 );
-            m_filters.emplace_back(""); // Root - should never be consulted
-            m_filters.emplace_back(""); // Test Case - not a section filter
-            m_filters.insert( m_filters.end(), filters.begin(), filters.end() );
+                SectionTracker& parentSection = static_cast<SectionTracker&>(*parent);
+                addNextFilters(parentSection.m_filters);
+            }
         }
-    }
-    void SectionTracker::addNextFilters( std::vector<std::string> const& filters ) {
-        if( filters.size() > 1 )
-            m_filters.insert( m_filters.end(), filters.begin()+1, filters.end() );
-    }
 
-    std::vector<std::string> const& SectionTracker::getFilters() const {
-        return m_filters;
-    }
+        bool SectionTracker::isComplete() const {
+            bool complete = true;
 
-    std::string const& SectionTracker::trimmedName() const {
-        return m_trimmed_name;
-    }
+            if (m_filters.empty()
+                || m_filters[0] == ""
+                || std::find(m_filters.begin(), m_filters.end(), m_trimmed_name) != m_filters.end()) {
+                complete = TrackerBase::isComplete();
+            }
+            return complete;
+        }
 
-} // namespace TestCaseTracking
+        bool SectionTracker::isSectionTracker() const { return true; }
 
-using TestCaseTracking::ITracker;
-using TestCaseTracking::TrackerContext;
-using TestCaseTracking::SectionTracker;
+        SectionTracker& SectionTracker::acquire(TrackerContext& ctx, NameAndLocation const& nameAndLocation) {
+            std::shared_ptr<SectionTracker> section;
+
+            ITracker& currentTracker = ctx.currentTracker();
+            if (ITrackerPtr childTracker = currentTracker.findChild(nameAndLocation)) {
+                assert(childTracker);
+                assert(childTracker->isSectionTracker());
+                section = std::static_pointer_cast<SectionTracker>(childTracker);
+            }
+            else {
+                section = std::make_shared<SectionTracker>(nameAndLocation, ctx, &currentTracker);
+                currentTracker.addChild(section);
+            }
+            if (!ctx.completedCycle())
+                section->tryOpen();
+            return *section;
+        }
+
+        void SectionTracker::tryOpen() {
+            if (!isComplete())
+                open();
+        }
+
+        void SectionTracker::addInitialFilters(std::vector<std::string> const& filters) {
+            if (!filters.empty()) {
+                m_filters.reserve(m_filters.size() + filters.size() + 2);
+                m_filters.emplace_back(""); // Root - should never be consulted
+                m_filters.emplace_back(""); // Test Case - not a section filter
+                m_filters.insert(m_filters.end(), filters.begin(), filters.end());
+            }
+        }
+        void SectionTracker::addNextFilters(std::vector<std::string> const& filters) {
+            if (filters.size() > 1)
+                m_filters.insert(m_filters.end(), filters.begin() + 1, filters.end());
+        }
+
+        std::vector<std::string> const& SectionTracker::getFilters() const {
+            return m_filters;
+        }
+
+        std::string const& SectionTracker::trimmedName() const {
+            return m_trimmed_name;
+        }
+
+    } // namespace TestCaseTracking
+
+    using TestCaseTracking::ITracker;
+    using TestCaseTracking::TrackerContext;
+    using TestCaseTracking::SectionTracker;
 
 } // namespace Catch
 
@@ -14518,22 +14636,22 @@ using TestCaseTracking::SectionTracker;
 
 namespace Catch {
 
-    auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker* {
-        return new(std::nothrow) TestInvokerAsFunction( testAsFunction );
+    auto makeTestInvoker(void(*testAsFunction)()) noexcept -> ITestInvoker* {
+        return new(std::nothrow) TestInvokerAsFunction(testAsFunction);
     }
 
-    NameAndTags::NameAndTags( StringRef const& name_ , StringRef const& tags_ ) noexcept : name( name_ ), tags( tags_ ) {}
+    NameAndTags::NameAndTags(StringRef const& name_, StringRef const& tags_) noexcept : name(name_), tags(tags_) {}
 
-    AutoReg::AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept {
-        CATCH_TRY {
+    AutoReg::AutoReg(ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags) noexcept {
+        CATCH_TRY{
             getMutableRegistryHub()
                     .registerTest(
                         makeTestCase(
                             invoker,
-                            extractClassName( classOrMethod ),
+                            extractClassName(classOrMethod),
                             nameAndTags,
                             lineInfo));
-        } CATCH_CATCH_ALL {
+        } CATCH_CATCH_ALL{
             // Do not throw when constructing global objects, instead register the exception to be processed later
             getMutableRegistryHub().registerStartupException();
         }
@@ -14551,8 +14669,8 @@ namespace Catch {
 
 namespace Catch {
 
-    TestSpec::Pattern::Pattern( std::string const& name )
-    : m_name( name )
+    TestSpec::Pattern::Pattern(std::string const& name)
+        : m_name(name)
     {}
 
     TestSpec::Pattern::~Pattern() = default;
@@ -14561,42 +14679,42 @@ namespace Catch {
         return m_name;
     }
 
-    TestSpec::NamePattern::NamePattern( std::string const& name, std::string const& filterString )
-    : Pattern( filterString )
-    , m_wildcardPattern( toLower( name ), CaseSensitive::No )
+    TestSpec::NamePattern::NamePattern(std::string const& name, std::string const& filterString)
+        : Pattern(filterString)
+        , m_wildcardPattern(toLower(name), CaseSensitive::No)
     {}
 
-    bool TestSpec::NamePattern::matches( TestCaseInfo const& testCase ) const {
-        return m_wildcardPattern.matches( testCase.name );
+    bool TestSpec::NamePattern::matches(TestCaseInfo const& testCase) const {
+        return m_wildcardPattern.matches(testCase.name);
     }
 
-    TestSpec::TagPattern::TagPattern( std::string const& tag, std::string const& filterString )
-    : Pattern( filterString )
-    , m_tag( toLower( tag ) )
+    TestSpec::TagPattern::TagPattern(std::string const& tag, std::string const& filterString)
+        : Pattern(filterString)
+        , m_tag(toLower(tag))
     {}
 
-    bool TestSpec::TagPattern::matches( TestCaseInfo const& testCase ) const {
+    bool TestSpec::TagPattern::matches(TestCaseInfo const& testCase) const {
         return std::find(begin(testCase.lcaseTags),
-                         end(testCase.lcaseTags),
-                         m_tag) != end(testCase.lcaseTags);
+            end(testCase.lcaseTags),
+            m_tag) != end(testCase.lcaseTags);
     }
 
-    TestSpec::ExcludedPattern::ExcludedPattern( PatternPtr const& underlyingPattern )
-    : Pattern( underlyingPattern->name() )
-    , m_underlyingPattern( underlyingPattern )
+    TestSpec::ExcludedPattern::ExcludedPattern(PatternPtr const& underlyingPattern)
+        : Pattern(underlyingPattern->name())
+        , m_underlyingPattern(underlyingPattern)
     {}
 
-    bool TestSpec::ExcludedPattern::matches( TestCaseInfo const& testCase ) const {
-        return !m_underlyingPattern->matches( testCase );
+    bool TestSpec::ExcludedPattern::matches(TestCaseInfo const& testCase) const {
+        return !m_underlyingPattern->matches(testCase);
     }
 
-    bool TestSpec::Filter::matches( TestCaseInfo const& testCase ) const {
-        return std::all_of( m_patterns.begin(), m_patterns.end(), [&]( PatternPtr const& p ){ return p->matches( testCase ); } );
+    bool TestSpec::Filter::matches(TestCaseInfo const& testCase) const {
+        return std::all_of(m_patterns.begin(), m_patterns.end(), [&](PatternPtr const& p) { return p->matches(testCase); });
     }
 
     std::string TestSpec::Filter::name() const {
         std::string name;
-        for( auto const& p : m_patterns )
+        for (auto const& p : m_patterns)
             name += p->name();
         return name;
     }
@@ -14605,24 +14723,24 @@ namespace Catch {
         return !m_filters.empty();
     }
 
-    bool TestSpec::matches( TestCaseInfo const& testCase ) const {
-        return std::any_of( m_filters.begin(), m_filters.end(), [&]( Filter const& f ){ return f.matches( testCase ); } );
+    bool TestSpec::matches(TestCaseInfo const& testCase) const {
+        return std::any_of(m_filters.begin(), m_filters.end(), [&](Filter const& f) { return f.matches(testCase); });
     }
 
-    TestSpec::Matches TestSpec::matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const
+    TestSpec::Matches TestSpec::matchesByFilter(std::vector<TestCase> const& testCases, IConfig const& config) const
     {
-        Matches matches( m_filters.size() );
-        std::transform( m_filters.begin(), m_filters.end(), matches.begin(), [&]( Filter const& filter ){
+        Matches matches(m_filters.size());
+        std::transform(m_filters.begin(), m_filters.end(), matches.begin(), [&](Filter const& filter) {
             std::vector<TestCase const*> currentMatches;
-            for( auto const& test : testCases )
-                if( isThrowSafe( test, config ) && filter.matches( test ) )
-                    currentMatches.emplace_back( &test );
+            for (auto const& test : testCases)
+                if (isThrowSafe(test, config) && filter.matches(test))
+                    currentMatches.emplace_back(&test);
             return FilterMatch{ filter.name(), currentMatches };
-        } );
+            });
         return matches;
     }
 
-    const TestSpec::vectorStrings& TestSpec::getInvalidArgs() const{
+    const TestSpec::vectorStrings& TestSpec::getInvalidArgs() const {
         return  (m_invalidArgs);
     }
 
@@ -14632,23 +14750,23 @@ namespace Catch {
 
 namespace Catch {
 
-    TestSpecParser::TestSpecParser( ITagAliasRegistry const& tagAliases ) : m_tagAliases( &tagAliases ) {}
+    TestSpecParser::TestSpecParser(ITagAliasRegistry const& tagAliases) : m_tagAliases(&tagAliases) {}
 
-    TestSpecParser& TestSpecParser::parse( std::string const& arg ) {
+    TestSpecParser& TestSpecParser::parse(std::string const& arg) {
         m_mode = None;
         m_exclusion = false;
-        m_arg = m_tagAliases->expandAliases( arg );
+        m_arg = m_tagAliases->expandAliases(arg);
         m_escapeChars.clear();
         m_substring.reserve(m_arg.size());
         m_patternName.reserve(m_arg.size());
         m_realPatternPos = 0;
 
-        for( m_pos = 0; m_pos < m_arg.size(); ++m_pos )
-          //if visitChar fails
-           if( !visitChar( m_arg[m_pos] ) ){
-               m_testSpec.m_invalidArgs.push_back(arg);
-               break;
-           }
+        for (m_pos = 0; m_pos < m_arg.size(); ++m_pos)
+            //if visitChar fails
+            if (!visitChar(m_arg[m_pos])) {
+                m_testSpec.m_invalidArgs.push_back(arg);
+                break;
+            }
         endMode();
         return *this;
     }
@@ -14656,22 +14774,23 @@ namespace Catch {
         addFilter();
         return m_testSpec;
     }
-    bool TestSpecParser::visitChar( char c ) {
-        if( (m_mode != EscapedName) && (c == '\\') ) {
+    bool TestSpecParser::visitChar(char c) {
+        if ((m_mode != EscapedName) && (c == '\\')) {
             escape();
             addCharToPattern(c);
             return true;
-        }else if((m_mode != EscapedName) && (c == ',') )  {
+        }
+        else if ((m_mode != EscapedName) && (c == ',')) {
             return separate();
         }
 
-        switch( m_mode ) {
+        switch (m_mode) {
         case None:
-            if( processNoneChar( c ) )
+            if (processNoneChar(c))
                 return true;
             break;
         case Name:
-            processNameChar( c );
+            processNameChar(c);
             break;
         case EscapedName:
             endMode();
@@ -14680,13 +14799,13 @@ namespace Catch {
         default:
         case Tag:
         case QuotedName:
-            if( processOtherChar( c ) )
+            if (processOtherChar(c))
                 return true;
             break;
         }
 
         m_substring += c;
-        if( !isControlChar( c ) ) {
+        if (!isControlChar(c)) {
             m_patternName += c;
             m_realPatternPos++;
         }
@@ -14694,45 +14813,45 @@ namespace Catch {
     }
     // Two of the processing methods return true to signal the caller to return
     // without adding the given character to the current pattern strings
-    bool TestSpecParser::processNoneChar( char c ) {
-        switch( c ) {
+    bool TestSpecParser::processNoneChar(char c) {
+        switch (c) {
         case ' ':
             return true;
         case '~':
             m_exclusion = true;
             return false;
         case '[':
-            startNewMode( Tag );
+            startNewMode(Tag);
             return false;
         case '"':
-            startNewMode( QuotedName );
+            startNewMode(QuotedName);
             return false;
         default:
-            startNewMode( Name );
+            startNewMode(Name);
             return false;
         }
     }
-    void TestSpecParser::processNameChar( char c ) {
-        if( c == '[' ) {
-            if( m_substring == "exclude:" )
+    void TestSpecParser::processNameChar(char c) {
+        if (c == '[') {
+            if (m_substring == "exclude:")
                 m_exclusion = true;
             else
                 endMode();
-            startNewMode( Tag );
+            startNewMode(Tag);
         }
     }
-    bool TestSpecParser::processOtherChar( char c ) {
-        if( !isControlChar( c ) )
+    bool TestSpecParser::processOtherChar(char c) {
+        if (!isControlChar(c))
             return false;
         m_substring += c;
         endMode();
         return true;
     }
-    void TestSpecParser::startNewMode( Mode mode ) {
+    void TestSpecParser::startNewMode(Mode mode) {
         m_mode = mode;
     }
     void TestSpecParser::endMode() {
-        switch( m_mode ) {
+        switch (m_mode) {
         case Name:
         case QuotedName:
             return addNamePattern();
@@ -14743,7 +14862,7 @@ namespace Catch {
             return;
         case None:
         default:
-            return startNewMode( None );
+            return startNewMode(None);
         }
     }
     void TestSpecParser::escape() {
@@ -14751,51 +14870,51 @@ namespace Catch {
         m_mode = EscapedName;
         m_escapeChars.push_back(m_realPatternPos);
     }
-    bool TestSpecParser::isControlChar( char c ) const {
-        switch( m_mode ) {
-            default:
-                return false;
-            case None:
-                return c == '~';
-            case Name:
-                return c == '[';
-            case EscapedName:
-                return true;
-            case QuotedName:
-                return c == '"';
-            case Tag:
-                return c == '[' || c == ']';
+    bool TestSpecParser::isControlChar(char c) const {
+        switch (m_mode) {
+        default:
+            return false;
+        case None:
+            return c == '~';
+        case Name:
+            return c == '[';
+        case EscapedName:
+            return true;
+        case QuotedName:
+            return c == '"';
+        case Tag:
+            return c == '[' || c == ']';
         }
     }
 
     void TestSpecParser::addFilter() {
-        if( !m_currentFilter.m_patterns.empty() ) {
-            m_testSpec.m_filters.push_back( m_currentFilter );
+        if (!m_currentFilter.m_patterns.empty()) {
+            m_testSpec.m_filters.push_back(m_currentFilter);
             m_currentFilter = TestSpec::Filter();
         }
     }
 
     void TestSpecParser::saveLastMode() {
-      lastMode = m_mode;
+        lastMode = m_mode;
     }
 
     void TestSpecParser::revertBackToLastMode() {
-      m_mode = lastMode;
+        m_mode = lastMode;
     }
 
     bool TestSpecParser::separate() {
-      if( (m_mode==QuotedName) || (m_mode==Tag) ){
-         //invalid argument, signal failure to previous scope.
-         m_mode = None;
-         m_pos = m_arg.size();
-         m_substring.clear();
-         m_patternName.clear();
-         m_realPatternPos = 0;
-         return false;
-      }
-      endMode();
-      addFilter();
-      return true; //success
+        if ((m_mode == QuotedName) || (m_mode == Tag)) {
+            //invalid argument, signal failure to previous scope.
+            m_mode = None;
+            m_pos = m_arg.size();
+            m_substring.clear();
+            m_patternName.clear();
+            m_realPatternPos = 0;
+            return false;
+        }
+        endMode();
+        addFilter();
+        return true; //success
     }
 
     std::string TestSpecParser::preprocessPattern() {
@@ -14855,8 +14974,8 @@ namespace Catch {
         m_mode = None;
     }
 
-    TestSpec parseTestSpec( std::string const& arg ) {
-        return TestSpecParser( ITagAliasRegistry::get() ).parse( arg ).testSpec();
+    TestSpec parseTestSpec(std::string const& arg) {
+        return TestSpecParser(ITagAliasRegistry::get()).parse(arg).testSpec();
     }
 
 } // namespace Catch
@@ -14870,7 +14989,7 @@ static const uint64_t nanosecondsInSecond = 1000000000;
 namespace Catch {
 
     auto getCurrentNanosecondsSinceEpoch() -> uint64_t {
-        return std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::high_resolution_clock::now().time_since_epoch() ).count();
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
     }
 
     namespace {
@@ -14880,13 +14999,13 @@ namespace Catch {
 
             auto startTime = getCurrentNanosecondsSinceEpoch();
 
-            for( std::size_t i = 0; i < iterations; ++i ) {
+            for (std::size_t i = 0; i < iterations; ++i) {
 
                 uint64_t ticks;
                 uint64_t baseTicks = getCurrentNanosecondsSinceEpoch();
                 do {
                     ticks = getCurrentNanosecondsSinceEpoch();
-                } while( ticks == baseTicks );
+                } while (ticks == baseTicks);
 
                 auto delta = ticks - baseTicks;
                 sum += delta;
@@ -14895,13 +15014,13 @@ namespace Catch {
                 // is terrible and we should move on.
                 // TBD: How to signal that the measured resolution is probably wrong?
                 if (ticks > startTime + 3 * nanosecondsInSecond) {
-                    return sum / ( i + 1u );
+                    return sum / (i + 1u);
                 }
             }
 
             // We're just taking the mean, here. To do better we could take the std. dev and exclude outliers
             // - and potentially do more iterations if there's a high variance.
-            return sum/iterations;
+            return sum / iterations;
         }
     }
     auto getEstimatedClockResolution() -> uint64_t {
@@ -14910,19 +15029,19 @@ namespace Catch {
     }
 
     void Timer::start() {
-       m_nanoseconds = getCurrentNanosecondsSinceEpoch();
+        m_nanoseconds = getCurrentNanosecondsSinceEpoch();
     }
     auto Timer::getElapsedNanoseconds() const -> uint64_t {
         return getCurrentNanosecondsSinceEpoch() - m_nanoseconds;
     }
     auto Timer::getElapsedMicroseconds() const -> uint64_t {
-        return getElapsedNanoseconds()/1000;
+        return getElapsedNanoseconds() / 1000;
     }
     auto Timer::getElapsedMilliseconds() const -> unsigned int {
-        return static_cast<unsigned int>(getElapsedMicroseconds()/1000);
+        return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
     }
     auto Timer::getElapsedSeconds() const -> double {
-        return getElapsedMicroseconds()/1000000.0;
+        return getElapsedMicroseconds() / 1000000.0;
     }
 
 } // namespace Catch
@@ -14945,232 +15064,241 @@ namespace Catch {
 
 namespace Catch {
 
-namespace Detail {
+    namespace Detail {
 
-    const std::string unprintableString = "{?}";
+        const std::string unprintableString = "{?}";
 
-    namespace {
-        const int hexThreshold = 255;
+        namespace {
+            const int hexThreshold = 255;
 
-        struct Endianness {
-            enum Arch { Big, Little };
+            struct Endianness {
+                enum Arch { Big, Little };
 
-            static Arch which() {
-                int one = 1;
-                // If the lowest byte we read is non-zero, we can assume
-                // that little endian format is used.
-                auto value = *reinterpret_cast<char*>(&one);
-                return value ? Little : Big;
+                static Arch which() {
+                    int one = 1;
+                    // If the lowest byte we read is non-zero, we can assume
+                    // that little endian format is used.
+                    auto value = *reinterpret_cast<char*>(&one);
+                    return value ? Little : Big;
+                }
+            };
+        }
+
+        std::string rawMemoryToString(const void* object, std::size_t size) {
+            // Reverse order for little endian architectures
+            int i = 0, end = static_cast<int>(size), inc = 1;
+            if (Endianness::which() == Endianness::Little) {
+                i = end - 1;
+                end = inc = -1;
             }
-        };
+
+            unsigned char const* bytes = static_cast<unsigned char const*>(object);
+            ReusableStringStream rss;
+            rss << "0x" << std::setfill('0') << std::hex;
+            for (; i != end; i += inc)
+                rss << std::setw(2) << static_cast<unsigned>(bytes[i]);
+            return rss.str();
+        }
     }
 
-    std::string rawMemoryToString( const void *object, std::size_t size ) {
-        // Reverse order for little endian architectures
-        int i = 0, end = static_cast<int>( size ), inc = 1;
-        if( Endianness::which() == Endianness::Little ) {
-            i = end-1;
-            end = inc = -1;
+    template<typename T>
+    std::string fpToString(T value, int precision) {
+        if (Catch::isnan(value)) {
+            return "nan";
         }
 
-        unsigned char const *bytes = static_cast<unsigned char const *>(object);
         ReusableStringStream rss;
-        rss << "0x" << std::setfill('0') << std::hex;
-        for( ; i != end; i += inc )
-             rss << std::setw(2) << static_cast<unsigned>(bytes[i]);
-       return rss.str();
-    }
-}
-
-template<typename T>
-std::string fpToString( T value, int precision ) {
-    if (Catch::isnan(value)) {
-        return "nan";
-    }
-
-    ReusableStringStream rss;
-    rss << std::setprecision( precision )
-        << std::fixed
-        << value;
-    std::string d = rss.str();
-    std::size_t i = d.find_last_not_of( '0' );
-    if( i != std::string::npos && i != d.size()-1 ) {
-        if( d[i] == '.' )
-            i++;
-        d = d.substr( 0, i+1 );
-    }
-    return d;
-}
-
-//// ======================================================= ////
-//
-//   Out-of-line defs for full specialization of StringMaker
-//
-//// ======================================================= ////
-
-std::string StringMaker<std::string>::convert(const std::string& str) {
-    if (!getCurrentContext().getConfig()->showInvisibles()) {
-        return '"' + str + '"';
-    }
-
-    std::string s("\"");
-    for (char c : str) {
-        switch (c) {
-        case '\n':
-            s.append("\\n");
-            break;
-        case '\t':
-            s.append("\\t");
-            break;
-        default:
-            s.push_back(c);
-            break;
+        rss << std::setprecision(precision)
+            << std::fixed
+            << value;
+        std::string d = rss.str();
+        std::size_t i = d.find_last_not_of('0');
+        if (i != std::string::npos && i != d.size() - 1) {
+            if (d[i] == '.')
+                i++;
+            d = d.substr(0, i + 1);
         }
+        return d;
     }
-    s.append("\"");
-    return s;
-}
+
+    //// ======================================================= ////
+    //
+    //   Out-of-line defs for full specialization of StringMaker
+    //
+    //// ======================================================= ////
+
+    std::string StringMaker<std::string>::convert(const std::string& str) {
+        if (!getCurrentContext().getConfig()->showInvisibles()) {
+            return '"' + str + '"';
+        }
+
+        std::string s("\"");
+        for (char c : str) {
+            switch (c) {
+            case '\n':
+                s.append("\\n");
+                break;
+            case '\t':
+                s.append("\\t");
+                break;
+            default:
+                s.push_back(c);
+                break;
+            }
+        }
+        s.append("\"");
+        return s;
+    }
 
 #ifdef CATCH_CONFIG_CPP17_STRING_VIEW
-std::string StringMaker<std::string_view>::convert(std::string_view str) {
-    return ::Catch::Detail::stringify(std::string{ str });
-}
+    std::string StringMaker<std::string_view>::convert(std::string_view str) {
+        return ::Catch::Detail::stringify(std::string{ str });
+    }
 #endif
 
-std::string StringMaker<char const*>::convert(char const* str) {
-    if (str) {
-        return ::Catch::Detail::stringify(std::string{ str });
-    } else {
-        return{ "{null string}" };
+    std::string StringMaker<char const*>::convert(char const* str) {
+        if (str) {
+            return ::Catch::Detail::stringify(std::string{ str });
+        }
+        else {
+            return{ "{null string}" };
+        }
     }
-}
-std::string StringMaker<char*>::convert(char* str) {
-    if (str) {
-        return ::Catch::Detail::stringify(std::string{ str });
-    } else {
-        return{ "{null string}" };
+    std::string StringMaker<char*>::convert(char* str) {
+        if (str) {
+            return ::Catch::Detail::stringify(std::string{ str });
+        }
+        else {
+            return{ "{null string}" };
+        }
     }
-}
 
 #ifdef CATCH_CONFIG_WCHAR
-std::string StringMaker<std::wstring>::convert(const std::wstring& wstr) {
-    std::string s;
-    s.reserve(wstr.size());
-    for (auto c : wstr) {
-        s += (c <= 0xff) ? static_cast<char>(c) : '?';
+    std::string StringMaker<std::wstring>::convert(const std::wstring& wstr) {
+        std::string s;
+        s.reserve(wstr.size());
+        for (auto c : wstr) {
+            s += (c <= 0xff) ? static_cast<char>(c) : '?';
+        }
+        return ::Catch::Detail::stringify(s);
     }
-    return ::Catch::Detail::stringify(s);
-}
 
 # ifdef CATCH_CONFIG_CPP17_STRING_VIEW
-std::string StringMaker<std::wstring_view>::convert(std::wstring_view str) {
-    return StringMaker<std::wstring>::convert(std::wstring(str));
-}
+    std::string StringMaker<std::wstring_view>::convert(std::wstring_view str) {
+        return StringMaker<std::wstring>::convert(std::wstring(str));
+    }
 # endif
 
-std::string StringMaker<wchar_t const*>::convert(wchar_t const * str) {
-    if (str) {
-        return ::Catch::Detail::stringify(std::wstring{ str });
-    } else {
-        return{ "{null string}" };
+    std::string StringMaker<wchar_t const*>::convert(wchar_t const* str) {
+        if (str) {
+            return ::Catch::Detail::stringify(std::wstring{ str });
+        }
+        else {
+            return{ "{null string}" };
+        }
     }
-}
-std::string StringMaker<wchar_t *>::convert(wchar_t * str) {
-    if (str) {
-        return ::Catch::Detail::stringify(std::wstring{ str });
-    } else {
-        return{ "{null string}" };
+    std::string StringMaker<wchar_t*>::convert(wchar_t* str) {
+        if (str) {
+            return ::Catch::Detail::stringify(std::wstring{ str });
+        }
+        else {
+            return{ "{null string}" };
+        }
     }
-}
 #endif
 
 #if defined(CATCH_CONFIG_CPP17_BYTE)
 #include <cstddef>
-std::string StringMaker<std::byte>::convert(std::byte value) {
-    return ::Catch::Detail::stringify(std::to_integer<unsigned long long>(value));
-}
+    std::string StringMaker<std::byte>::convert(std::byte value) {
+        return ::Catch::Detail::stringify(std::to_integer<unsigned long long>(value));
+    }
 #endif // defined(CATCH_CONFIG_CPP17_BYTE)
 
-std::string StringMaker<int>::convert(int value) {
-    return ::Catch::Detail::stringify(static_cast<long long>(value));
-}
-std::string StringMaker<long>::convert(long value) {
-    return ::Catch::Detail::stringify(static_cast<long long>(value));
-}
-std::string StringMaker<long long>::convert(long long value) {
-    ReusableStringStream rss;
-    rss << value;
-    if (value > Detail::hexThreshold) {
-        rss << " (0x" << std::hex << value << ')';
+    std::string StringMaker<int>::convert(int value) {
+        return ::Catch::Detail::stringify(static_cast<long long>(value));
     }
-    return rss.str();
-}
-
-std::string StringMaker<unsigned int>::convert(unsigned int value) {
-    return ::Catch::Detail::stringify(static_cast<unsigned long long>(value));
-}
-std::string StringMaker<unsigned long>::convert(unsigned long value) {
-    return ::Catch::Detail::stringify(static_cast<unsigned long long>(value));
-}
-std::string StringMaker<unsigned long long>::convert(unsigned long long value) {
-    ReusableStringStream rss;
-    rss << value;
-    if (value > Detail::hexThreshold) {
-        rss << " (0x" << std::hex << value << ')';
+    std::string StringMaker<long>::convert(long value) {
+        return ::Catch::Detail::stringify(static_cast<long long>(value));
     }
-    return rss.str();
-}
-
-std::string StringMaker<bool>::convert(bool b) {
-    return b ? "true" : "false";
-}
-
-std::string StringMaker<signed char>::convert(signed char value) {
-    if (value == '\r') {
-        return "'\\r'";
-    } else if (value == '\f') {
-        return "'\\f'";
-    } else if (value == '\n') {
-        return "'\\n'";
-    } else if (value == '\t') {
-        return "'\\t'";
-    } else if ('\0' <= value && value < ' ') {
-        return ::Catch::Detail::stringify(static_cast<unsigned int>(value));
-    } else {
-        char chstr[] = "' '";
-        chstr[1] = value;
-        return chstr;
+    std::string StringMaker<long long>::convert(long long value) {
+        ReusableStringStream rss;
+        rss << value;
+        if (value > Detail::hexThreshold) {
+            rss << " (0x" << std::hex << value << ')';
+        }
+        return rss.str();
     }
-}
-std::string StringMaker<char>::convert(char c) {
-    return ::Catch::Detail::stringify(static_cast<signed char>(c));
-}
-std::string StringMaker<unsigned char>::convert(unsigned char c) {
-    return ::Catch::Detail::stringify(static_cast<char>(c));
-}
 
-std::string StringMaker<std::nullptr_t>::convert(std::nullptr_t) {
-    return "nullptr";
-}
+    std::string StringMaker<unsigned int>::convert(unsigned int value) {
+        return ::Catch::Detail::stringify(static_cast<unsigned long long>(value));
+    }
+    std::string StringMaker<unsigned long>::convert(unsigned long value) {
+        return ::Catch::Detail::stringify(static_cast<unsigned long long>(value));
+    }
+    std::string StringMaker<unsigned long long>::convert(unsigned long long value) {
+        ReusableStringStream rss;
+        rss << value;
+        if (value > Detail::hexThreshold) {
+            rss << " (0x" << std::hex << value << ')';
+        }
+        return rss.str();
+    }
 
-int StringMaker<float>::precision = 5;
+    std::string StringMaker<bool>::convert(bool b) {
+        return b ? "true" : "false";
+    }
 
-std::string StringMaker<float>::convert(float value) {
-    return fpToString(value, precision) + 'f';
-}
+    std::string StringMaker<signed char>::convert(signed char value) {
+        if (value == '\r') {
+            return "'\\r'";
+        }
+        else if (value == '\f') {
+            return "'\\f'";
+        }
+        else if (value == '\n') {
+            return "'\\n'";
+        }
+        else if (value == '\t') {
+            return "'\\t'";
+        }
+        else if ('\0' <= value && value < ' ') {
+            return ::Catch::Detail::stringify(static_cast<unsigned int>(value));
+        }
+        else {
+            char chstr[] = "' '";
+            chstr[1] = value;
+            return chstr;
+        }
+    }
+    std::string StringMaker<char>::convert(char c) {
+        return ::Catch::Detail::stringify(static_cast<signed char>(c));
+    }
+    std::string StringMaker<unsigned char>::convert(unsigned char c) {
+        return ::Catch::Detail::stringify(static_cast<char>(c));
+    }
 
-int StringMaker<double>::precision = 10;
+    std::string StringMaker<std::nullptr_t>::convert(std::nullptr_t) {
+        return "nullptr";
+    }
 
-std::string StringMaker<double>::convert(double value) {
-    return fpToString(value, precision);
-}
+    int StringMaker<float>::precision = 5;
 
-std::string ratio_string<std::atto>::symbol() { return "a"; }
-std::string ratio_string<std::femto>::symbol() { return "f"; }
-std::string ratio_string<std::pico>::symbol() { return "p"; }
-std::string ratio_string<std::nano>::symbol() { return "n"; }
-std::string ratio_string<std::micro>::symbol() { return "u"; }
-std::string ratio_string<std::milli>::symbol() { return "m"; }
+    std::string StringMaker<float>::convert(float value) {
+        return fpToString(value, precision) + 'f';
+    }
+
+    int StringMaker<double>::precision = 10;
+
+    std::string StringMaker<double>::convert(double value) {
+        return fpToString(value, precision);
+    }
+
+    std::string ratio_string<std::atto>::symbol() { return "a"; }
+    std::string ratio_string<std::femto>::symbol() { return "f"; }
+    std::string ratio_string<std::pico>::symbol() { return "p"; }
+    std::string ratio_string<std::nano>::symbol() { return "n"; }
+    std::string ratio_string<std::micro>::symbol() { return "u"; }
+    std::string ratio_string<std::milli>::symbol() { return "m"; }
 
 } // end namespace Catch
 
@@ -15183,7 +15311,7 @@ std::string ratio_string<std::milli>::symbol() { return "m"; }
 
 namespace Catch {
 
-    Counts Counts::operator - ( Counts const& other ) const {
+    Counts Counts::operator - (Counts const& other) const {
         Counts diff;
         diff.passed = passed - other.passed;
         diff.failed = failed - other.failed;
@@ -15191,7 +15319,7 @@ namespace Catch {
         return diff;
     }
 
-    Counts& Counts::operator += ( Counts const& other ) {
+    Counts& Counts::operator += (Counts const& other) {
         passed += other.passed;
         failed += other.failed;
         failedButOk += other.failedButOk;
@@ -15208,24 +15336,24 @@ namespace Catch {
         return failed == 0;
     }
 
-    Totals Totals::operator - ( Totals const& other ) const {
+    Totals Totals::operator - (Totals const& other) const {
         Totals diff;
         diff.assertions = assertions - other.assertions;
         diff.testCases = testCases - other.testCases;
         return diff;
     }
 
-    Totals& Totals::operator += ( Totals const& other ) {
+    Totals& Totals::operator += (Totals const& other) {
         assertions += other.assertions;
         testCases += other.testCases;
         return *this;
     }
 
-    Totals Totals::delta( Totals const& prevTotals ) const {
+    Totals Totals::delta(Totals const& prevTotals) const {
         Totals diff = *this - prevTotals;
-        if( diff.assertions.failed > 0 )
+        if (diff.assertions.failed > 0)
             ++diff.testCases.failed;
-        else if( diff.assertions.failedButOk > 0 )
+        else if (diff.assertions.failedButOk > 0)
             ++diff.testCases.failedButOk;
         else
             ++diff.testCases.passed;
@@ -15282,7 +15410,7 @@ namespace Catch {
 #else
         return std::uncaught_exception();
 #endif
-  }
+    }
 } // end namespace Catch
 // end catch_uncaught_exceptions.cpp
 // start catch_version.cpp
@@ -15292,32 +15420,32 @@ namespace Catch {
 namespace Catch {
 
     Version::Version
-        (   unsigned int _majorVersion,
-            unsigned int _minorVersion,
-            unsigned int _patchNumber,
-            char const * const _branchName,
-            unsigned int _buildNumber )
-    :   majorVersion( _majorVersion ),
-        minorVersion( _minorVersion ),
-        patchNumber( _patchNumber ),
-        branchName( _branchName ),
-        buildNumber( _buildNumber )
+    (unsigned int _majorVersion,
+        unsigned int _minorVersion,
+        unsigned int _patchNumber,
+        char const* const _branchName,
+        unsigned int _buildNumber)
+        : majorVersion(_majorVersion),
+        minorVersion(_minorVersion),
+        patchNumber(_patchNumber),
+        branchName(_branchName),
+        buildNumber(_buildNumber)
     {}
 
-    std::ostream& operator << ( std::ostream& os, Version const& version ) {
-        os  << version.majorVersion << '.'
+    std::ostream& operator << (std::ostream& os, Version const& version) {
+        os << version.majorVersion << '.'
             << version.minorVersion << '.'
             << version.patchNumber;
         // branchName is never null -> 0th char is \0 if it is empty
         if (version.branchName[0]) {
             os << '-' << version.branchName
-               << '.' << version.buildNumber;
+                << '.' << version.buildNumber;
         }
         return os;
     }
 
     Version const& libraryVersion() {
-        static Version version( 2, 13, 3, "", 0 );
+        static Version version(2, 13, 10, "", 0);
         return version;
     }
 
@@ -15327,38 +15455,38 @@ namespace Catch {
 
 namespace Catch {
 
-    WildcardPattern::WildcardPattern( std::string const& pattern,
-                                      CaseSensitive::Choice caseSensitivity )
-    :   m_caseSensitivity( caseSensitivity ),
-        m_pattern( normaliseString( pattern ) )
+    WildcardPattern::WildcardPattern(std::string const& pattern,
+        CaseSensitive::Choice caseSensitivity)
+        : m_caseSensitivity(caseSensitivity),
+        m_pattern(normaliseString(pattern))
     {
-        if( startsWith( m_pattern, '*' ) ) {
-            m_pattern = m_pattern.substr( 1 );
+        if (startsWith(m_pattern, '*')) {
+            m_pattern = m_pattern.substr(1);
             m_wildcard = WildcardAtStart;
         }
-        if( endsWith( m_pattern, '*' ) ) {
-            m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
-            m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
+        if (endsWith(m_pattern, '*')) {
+            m_pattern = m_pattern.substr(0, m_pattern.size() - 1);
+            m_wildcard = static_cast<WildcardPosition>(m_wildcard | WildcardAtEnd);
         }
     }
 
-    bool WildcardPattern::matches( std::string const& str ) const {
-        switch( m_wildcard ) {
-            case NoWildcard:
-                return m_pattern == normaliseString( str );
-            case WildcardAtStart:
-                return endsWith( normaliseString( str ), m_pattern );
-            case WildcardAtEnd:
-                return startsWith( normaliseString( str ), m_pattern );
-            case WildcardAtBothEnds:
-                return contains( normaliseString( str ), m_pattern );
-            default:
-                CATCH_INTERNAL_ERROR( "Unknown enum" );
+    bool WildcardPattern::matches(std::string const& str) const {
+        switch (m_wildcard) {
+        case NoWildcard:
+            return m_pattern == normaliseString(str);
+        case WildcardAtStart:
+            return endsWith(normaliseString(str), m_pattern);
+        case WildcardAtEnd:
+            return startsWith(normaliseString(str), m_pattern);
+        case WildcardAtBothEnds:
+            return contains(normaliseString(str), m_pattern);
+        default:
+            CATCH_INTERNAL_ERROR("Unknown enum");
         }
     }
 
-    std::string WildcardPattern::normaliseString( std::string const& str ) const {
-        return trim( m_caseSensitivity == CaseSensitive::No ? toLower( str ) : str );
+    std::string WildcardPattern::normaliseString(std::string const& str) const {
+        return trim(m_caseSensitivity == CaseSensitive::No ? toLower(str) : str);
     }
 }
 // end catch_wildcard_pattern.cpp
@@ -15369,76 +15497,76 @@ namespace Catch {
 
 namespace Catch {
 
-namespace {
+    namespace {
 
-    size_t trailingBytes(unsigned char c) {
-        if ((c & 0xE0) == 0xC0) {
-            return 2;
+        size_t trailingBytes(unsigned char c) {
+            if ((c & 0xE0) == 0xC0) {
+                return 2;
+            }
+            if ((c & 0xF0) == 0xE0) {
+                return 3;
+            }
+            if ((c & 0xF8) == 0xF0) {
+                return 4;
+            }
+            CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
         }
-        if ((c & 0xF0) == 0xE0) {
-            return 3;
-        }
-        if ((c & 0xF8) == 0xF0) {
-            return 4;
-        }
-        CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
-    }
 
-    uint32_t headerValue(unsigned char c) {
-        if ((c & 0xE0) == 0xC0) {
-            return c & 0x1F;
+        uint32_t headerValue(unsigned char c) {
+            if ((c & 0xE0) == 0xC0) {
+                return c & 0x1F;
+            }
+            if ((c & 0xF0) == 0xE0) {
+                return c & 0x0F;
+            }
+            if ((c & 0xF8) == 0xF0) {
+                return c & 0x07;
+            }
+            CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
         }
-        if ((c & 0xF0) == 0xE0) {
-            return c & 0x0F;
+
+        void hexEscapeChar(std::ostream& os, unsigned char c) {
+            std::ios_base::fmtflags f(os.flags());
+            os << "\\x"
+                << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+                << static_cast<int>(c);
+            os.flags(f);
         }
-        if ((c & 0xF8) == 0xF0) {
-            return c & 0x07;
+
+        bool shouldNewline(XmlFormatting fmt) {
+            return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Newline));
         }
-        CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
-    }
 
-    void hexEscapeChar(std::ostream& os, unsigned char c) {
-        std::ios_base::fmtflags f(os.flags());
-        os << "\\x"
-            << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
-            << static_cast<int>(c);
-        os.flags(f);
-    }
+        bool shouldIndent(XmlFormatting fmt) {
+            return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Indent));
+        }
 
-    bool shouldNewline(XmlFormatting fmt) {
-        return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Newline));
-    }
-
-    bool shouldIndent(XmlFormatting fmt) {
-        return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Indent));
-    }
-
-} // anonymous namespace
+    } // anonymous namespace
 
     XmlFormatting operator | (XmlFormatting lhs, XmlFormatting rhs) {
         return static_cast<XmlFormatting>(
             static_cast<std::underlying_type<XmlFormatting>::type>(lhs) |
             static_cast<std::underlying_type<XmlFormatting>::type>(rhs)
-        );
+            );
     }
 
     XmlFormatting operator & (XmlFormatting lhs, XmlFormatting rhs) {
         return static_cast<XmlFormatting>(
             static_cast<std::underlying_type<XmlFormatting>::type>(lhs) &
             static_cast<std::underlying_type<XmlFormatting>::type>(rhs)
-        );
+            );
     }
 
-    XmlEncode::XmlEncode( std::string const& str, ForWhat forWhat )
-    :   m_str( str ),
-        m_forWhat( forWhat )
+    XmlEncode::XmlEncode(std::string const& str, ForWhat forWhat)
+        : m_str(str),
+        m_forWhat(forWhat)
     {}
 
-    void XmlEncode::encodeTo( std::ostream& os ) const {
+    void XmlEncode::encodeTo(std::ostream& os) const {
         // Apostrophe escaping not necessary if we always use " to write attributes
         // (see: http://www.w3.org/TR/xml/#syntax)
 
-        for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
+        for (std::size_t idx = 0; idx < m_str.size(); ++idx) {
             unsigned char c = m_str[idx];
             switch (c) {
             case '<':   os << "&lt;"; break;
@@ -15481,7 +15609,7 @@ namespace {
                 // First check that this bytes is a valid lead byte:
                 // This means that it is not encoded as 1111 1XXX
                 // Or as 10XX XXXX
-                if (c <  0xC0 ||
+                if (c < 0xC0 ||
                     c >= 0xF8) {
                     hexEscapeChar(os, c);
                     break;
@@ -15509,7 +15637,7 @@ namespace {
                     (!valid) ||
                     // Overlong encodings
                     (value < 0x80) ||
-                    (0x80 <= value && value < 0x800   && encBytes > 2) ||
+                    (0x80 <= value && value < 0x800 && encBytes > 2) ||
                     (0x800 < value && value < 0x10000 && encBytes > 3) ||
                     // Encoded value out of range
                     (value >= 0x110000)
@@ -15528,25 +15656,25 @@ namespace {
         }
     }
 
-    std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode ) {
-        xmlEncode.encodeTo( os );
+    std::ostream& operator << (std::ostream& os, XmlEncode const& xmlEncode) {
+        xmlEncode.encodeTo(os);
         return os;
     }
 
-    XmlWriter::ScopedElement::ScopedElement( XmlWriter* writer, XmlFormatting fmt )
-    :   m_writer( writer ),
+    XmlWriter::ScopedElement::ScopedElement(XmlWriter* writer, XmlFormatting fmt)
+        : m_writer(writer),
         m_fmt(fmt)
     {}
 
-    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) noexcept
-    :   m_writer( other.m_writer ),
+    XmlWriter::ScopedElement::ScopedElement(ScopedElement&& other) noexcept
+        : m_writer(other.m_writer),
         m_fmt(other.m_fmt)
     {
         other.m_writer = nullptr;
         other.m_fmt = XmlFormatting::None;
     }
-    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) noexcept {
-        if ( m_writer ) {
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=(ScopedElement&& other) noexcept {
+        if (m_writer) {
             m_writer->endElement();
         }
         m_writer = other.m_writer;
@@ -15562,12 +15690,12 @@ namespace {
         }
     }
 
-    XmlWriter::ScopedElement& XmlWriter::ScopedElement::writeText( std::string const& text, XmlFormatting fmt ) {
-        m_writer->writeText( text, fmt );
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::writeText(std::string const& text, XmlFormatting fmt) {
+        m_writer->writeText(text, fmt);
         return *this;
     }
 
-    XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
+    XmlWriter::XmlWriter(std::ostream& os) : m_os(os)
     {
         writeDeclaration();
     }
@@ -15579,7 +15707,7 @@ namespace {
         newlineIfNecessary();
     }
 
-    XmlWriter& XmlWriter::startElement( std::string const& name, XmlFormatting fmt ) {
+    XmlWriter& XmlWriter::startElement(std::string const& name, XmlFormatting fmt) {
         ensureTagClosed();
         newlineIfNecessary();
         if (shouldIndent(fmt)) {
@@ -15587,25 +15715,26 @@ namespace {
             m_indent += "  ";
         }
         m_os << '<' << name;
-        m_tags.push_back( name );
+        m_tags.push_back(name);
         m_tagIsOpen = true;
         applyFormatting(fmt);
         return *this;
     }
 
-    XmlWriter::ScopedElement XmlWriter::scopedElement( std::string const& name, XmlFormatting fmt ) {
-        ScopedElement scoped( this, fmt );
-        startElement( name, fmt );
+    XmlWriter::ScopedElement XmlWriter::scopedElement(std::string const& name, XmlFormatting fmt) {
+        ScopedElement scoped(this, fmt);
+        startElement(name, fmt);
         return scoped;
     }
 
     XmlWriter& XmlWriter::endElement(XmlFormatting fmt) {
         m_indent = m_indent.substr(0, m_indent.size() - 2);
 
-        if( m_tagIsOpen ) {
+        if (m_tagIsOpen) {
             m_os << "/>";
             m_tagIsOpen = false;
-        } else {
+        }
+        else {
             newlineIfNecessary();
             if (shouldIndent(fmt)) {
                 m_os << m_indent;
@@ -15618,31 +15747,31 @@ namespace {
         return *this;
     }
 
-    XmlWriter& XmlWriter::writeAttribute( std::string const& name, std::string const& attribute ) {
-        if( !name.empty() && !attribute.empty() )
-            m_os << ' ' << name << "=\"" << XmlEncode( attribute, XmlEncode::ForAttributes ) << '"';
+    XmlWriter& XmlWriter::writeAttribute(std::string const& name, std::string const& attribute) {
+        if (!name.empty() && !attribute.empty())
+            m_os << ' ' << name << "=\"" << XmlEncode(attribute, XmlEncode::ForAttributes) << '"';
         return *this;
     }
 
-    XmlWriter& XmlWriter::writeAttribute( std::string const& name, bool attribute ) {
-        m_os << ' ' << name << "=\"" << ( attribute ? "true" : "false" ) << '"';
+    XmlWriter& XmlWriter::writeAttribute(std::string const& name, bool attribute) {
+        m_os << ' ' << name << "=\"" << (attribute ? "true" : "false") << '"';
         return *this;
     }
 
-    XmlWriter& XmlWriter::writeText( std::string const& text, XmlFormatting fmt) {
-        if( !text.empty() ){
+    XmlWriter& XmlWriter::writeText(std::string const& text, XmlFormatting fmt) {
+        if (!text.empty()) {
             bool tagWasOpen = m_tagIsOpen;
             ensureTagClosed();
             if (tagWasOpen && shouldIndent(fmt)) {
                 m_os << m_indent;
             }
-            m_os << XmlEncode( text );
+            m_os << XmlEncode(text);
             applyFormatting(fmt);
         }
         return *this;
     }
 
-    XmlWriter& XmlWriter::writeComment( std::string const& text, XmlFormatting fmt) {
+    XmlWriter& XmlWriter::writeComment(std::string const& text, XmlFormatting fmt) {
         ensureTagClosed();
         if (shouldIndent(fmt)) {
             m_os << m_indent;
@@ -15652,7 +15781,7 @@ namespace {
         return *this;
     }
 
-    void XmlWriter::writeStylesheetRef( std::string const& url ) {
+    void XmlWriter::writeStylesheetRef(std::string const& url) {
         m_os << "<?xml-stylesheet type=\"text/xsl\" href=\"" << url << "\"?>\n";
     }
 
@@ -15663,7 +15792,7 @@ namespace {
     }
 
     void XmlWriter::ensureTagClosed() {
-        if( m_tagIsOpen ) {
+        if (m_tagIsOpen) {
             m_os << '>' << std::flush;
             newlineIfNecessary();
             m_tagIsOpen = false;
@@ -15679,7 +15808,7 @@ namespace {
     }
 
     void XmlWriter::newlineIfNecessary() {
-        if( m_needsNewline ) {
+        if (m_needsNewline) {
             m_os << std::endl;
             m_needsNewline = false;
         }
@@ -15701,7 +15830,7 @@ namespace Catch {
 
     // Because formatting using c++ streams is stateful, drop down to C is required
     // Alternatively we could use stringstream, but its performance is... not good.
-    std::string getFormattedDuration( double duration ) {
+    std::string getFormattedDuration(double duration) {
         // Max exponent + 1 is required to represent the whole part
         // + 1 for decimal point
         // + 3 for the 3 decimal places
@@ -15719,18 +15848,18 @@ namespace Catch {
         return std::string(buffer);
     }
 
-    bool shouldShowDuration( IConfig const& config, double duration ) {
-        if ( config.showDurations() == ShowDurations::Always ) {
+    bool shouldShowDuration(IConfig const& config, double duration) {
+        if (config.showDurations() == ShowDurations::Always) {
             return true;
         }
-        if ( config.showDurations() == ShowDurations::Never ) {
+        if (config.showDurations() == ShowDurations::Never) {
             return false;
         }
         const double min = config.minDuration();
         return min >= 0 && duration >= min;
     }
 
-    std::string serializeFilters( std::vector<std::string> const& container ) {
+    std::string serializeFilters(std::vector<std::string> const& container) {
         ReusableStringStream oss;
         bool first = true;
         for (auto&& filter : container)
@@ -15745,16 +15874,16 @@ namespace Catch {
         return oss.str();
     }
 
-    TestEventListenerBase::TestEventListenerBase(ReporterConfig const & _config)
+    TestEventListenerBase::TestEventListenerBase(ReporterConfig const& _config)
         :StreamingReporterBase(_config) {}
 
     std::set<Verbosity> TestEventListenerBase::getSupportedVerbosities() {
         return { Verbosity::Quiet, Verbosity::Normal, Verbosity::High };
     }
 
-    void TestEventListenerBase::assertionStarting(AssertionInfo const &) {}
+    void TestEventListenerBase::assertionStarting(AssertionInfo const&) {}
 
-    bool TestEventListenerBase::assertionEnded(AssertionStats const &) {
+    bool TestEventListenerBase::assertionEnded(AssertionStats const&) {
         return false;
     }
 
@@ -15775,268 +15904,272 @@ namespace {
     // Colour::LightGrey
     Catch::Colour::Code dimColour() { return Catch::Colour::FileName; }
 
-    std::string bothOrAll( std::size_t count ) {
+    std::string bothOrAll(std::size_t count) {
         return count == 1 ? std::string() :
-               count == 2 ? "both " : "all " ;
+            count == 2 ? "both " : "all ";
     }
 
 } // anon namespace
 
 namespace Catch {
-namespace {
-// Colour, message variants:
-// - white: No tests ran.
-// -   red: Failed [both/all] N test cases, failed [both/all] M assertions.
-// - white: Passed [both/all] N test cases (no assertions).
-// -   red: Failed N tests cases, failed M assertions.
-// - green: Passed [both/all] N tests cases with M assertions.
-void printTotals(std::ostream& out, const Totals& totals) {
-    if (totals.testCases.total() == 0) {
-        out << "No tests ran.";
-    } else if (totals.testCases.failed == totals.testCases.total()) {
-        Colour colour(Colour::ResultError);
-        const std::string qualify_assertions_failed =
-            totals.assertions.failed == totals.assertions.total() ?
-            bothOrAll(totals.assertions.failed) : std::string();
-        out <<
-            "Failed " << bothOrAll(totals.testCases.failed)
-            << pluralise(totals.testCases.failed, "test case") << ", "
-            "failed " << qualify_assertions_failed <<
-            pluralise(totals.assertions.failed, "assertion") << '.';
-    } else if (totals.assertions.total() == 0) {
-        out <<
-            "Passed " << bothOrAll(totals.testCases.total())
-            << pluralise(totals.testCases.total(), "test case")
-            << " (no assertions).";
-    } else if (totals.assertions.failed) {
-        Colour colour(Colour::ResultError);
-        out <<
-            "Failed " << pluralise(totals.testCases.failed, "test case") << ", "
-            "failed " << pluralise(totals.assertions.failed, "assertion") << '.';
-    } else {
-        Colour colour(Colour::ResultSuccess);
-        out <<
-            "Passed " << bothOrAll(totals.testCases.passed)
-            << pluralise(totals.testCases.passed, "test case") <<
-            " with " << pluralise(totals.assertions.passed, "assertion") << '.';
-    }
-}
-
-// Implementation of CompactReporter formatting
-class AssertionPrinter {
-public:
-    AssertionPrinter& operator= (AssertionPrinter const&) = delete;
-    AssertionPrinter(AssertionPrinter const&) = delete;
-    AssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
-        : stream(_stream)
-        , result(_stats.assertionResult)
-        , messages(_stats.infoMessages)
-        , itMessage(_stats.infoMessages.begin())
-        , printInfoMessages(_printInfoMessages) {}
-
-    void print() {
-        printSourceInfo();
-
-        itMessage = messages.begin();
-
-        switch (result.getResultType()) {
-        case ResultWas::Ok:
-            printResultType(Colour::ResultSuccess, passedString());
-            printOriginalExpression();
-            printReconstructedExpression();
-            if (!result.hasExpression())
-                printRemainingMessages(Colour::None);
-            else
-                printRemainingMessages();
-            break;
-        case ResultWas::ExpressionFailed:
-            if (result.isOk())
-                printResultType(Colour::ResultSuccess, failedString() + std::string(" - but was ok"));
-            else
-                printResultType(Colour::Error, failedString());
-            printOriginalExpression();
-            printReconstructedExpression();
-            printRemainingMessages();
-            break;
-        case ResultWas::ThrewException:
-            printResultType(Colour::Error, failedString());
-            printIssue("unexpected exception with message:");
-            printMessage();
-            printExpressionWas();
-            printRemainingMessages();
-            break;
-        case ResultWas::FatalErrorCondition:
-            printResultType(Colour::Error, failedString());
-            printIssue("fatal error condition with message:");
-            printMessage();
-            printExpressionWas();
-            printRemainingMessages();
-            break;
-        case ResultWas::DidntThrowException:
-            printResultType(Colour::Error, failedString());
-            printIssue("expected exception, got none");
-            printExpressionWas();
-            printRemainingMessages();
-            break;
-        case ResultWas::Info:
-            printResultType(Colour::None, "info");
-            printMessage();
-            printRemainingMessages();
-            break;
-        case ResultWas::Warning:
-            printResultType(Colour::None, "warning");
-            printMessage();
-            printRemainingMessages();
-            break;
-        case ResultWas::ExplicitFailure:
-            printResultType(Colour::Error, failedString());
-            printIssue("explicitly");
-            printRemainingMessages(Colour::None);
-            break;
-            // These cases are here to prevent compiler warnings
-        case ResultWas::Unknown:
-        case ResultWas::FailureBit:
-        case ResultWas::Exception:
-            printResultType(Colour::Error, "** internal error **");
-            break;
-        }
-    }
-
-private:
-    void printSourceInfo() const {
-        Colour colourGuard(Colour::FileName);
-        stream << result.getSourceInfo() << ':';
-    }
-
-    void printResultType(Colour::Code colour, std::string const& passOrFail) const {
-        if (!passOrFail.empty()) {
-            {
-                Colour colourGuard(colour);
-                stream << ' ' << passOrFail;
+    namespace {
+        // Colour, message variants:
+        // - white: No tests ran.
+        // -   red: Failed [both/all] N test cases, failed [both/all] M assertions.
+        // - white: Passed [both/all] N test cases (no assertions).
+        // -   red: Failed N tests cases, failed M assertions.
+        // - green: Passed [both/all] N tests cases with M assertions.
+        void printTotals(std::ostream& out, const Totals& totals) {
+            if (totals.testCases.total() == 0) {
+                out << "No tests ran.";
             }
-            stream << ':';
-        }
-    }
-
-    void printIssue(std::string const& issue) const {
-        stream << ' ' << issue;
-    }
-
-    void printExpressionWas() {
-        if (result.hasExpression()) {
-            stream << ';';
-            {
-                Colour colour(dimColour());
-                stream << " expression was:";
+            else if (totals.testCases.failed == totals.testCases.total()) {
+                Colour colour(Colour::ResultError);
+                const std::string qualify_assertions_failed =
+                    totals.assertions.failed == totals.assertions.total() ?
+                    bothOrAll(totals.assertions.failed) : std::string();
+                out <<
+                    "Failed " << bothOrAll(totals.testCases.failed)
+                    << pluralise(totals.testCases.failed, "test case") << ", "
+                    "failed " << qualify_assertions_failed <<
+                    pluralise(totals.assertions.failed, "assertion") << '.';
             }
-            printOriginalExpression();
-        }
-    }
-
-    void printOriginalExpression() const {
-        if (result.hasExpression()) {
-            stream << ' ' << result.getExpression();
-        }
-    }
-
-    void printReconstructedExpression() const {
-        if (result.hasExpandedExpression()) {
-            {
-                Colour colour(dimColour());
-                stream << " for: ";
+            else if (totals.assertions.total() == 0) {
+                out <<
+                    "Passed " << bothOrAll(totals.testCases.total())
+                    << pluralise(totals.testCases.total(), "test case")
+                    << " (no assertions).";
             }
-            stream << result.getExpandedExpression();
-        }
-    }
-
-    void printMessage() {
-        if (itMessage != messages.end()) {
-            stream << " '" << itMessage->message << '\'';
-            ++itMessage;
-        }
-    }
-
-    void printRemainingMessages(Colour::Code colour = dimColour()) {
-        if (itMessage == messages.end())
-            return;
-
-        const auto itEnd = messages.cend();
-        const auto N = static_cast<std::size_t>(std::distance(itMessage, itEnd));
-
-        {
-            Colour colourGuard(colour);
-            stream << " with " << pluralise(N, "message") << ':';
+            else if (totals.assertions.failed) {
+                Colour colour(Colour::ResultError);
+                out <<
+                    "Failed " << pluralise(totals.testCases.failed, "test case") << ", "
+                    "failed " << pluralise(totals.assertions.failed, "assertion") << '.';
+            }
+            else {
+                Colour colour(Colour::ResultSuccess);
+                out <<
+                    "Passed " << bothOrAll(totals.testCases.passed)
+                    << pluralise(totals.testCases.passed, "test case") <<
+                    " with " << pluralise(totals.assertions.passed, "assertion") << '.';
+            }
         }
 
-        while (itMessage != itEnd) {
-            // If this assertion is a warning ignore any INFO messages
-            if (printInfoMessages || itMessage->type != ResultWas::Info) {
-                printMessage();
-                if (itMessage != itEnd) {
-                    Colour colourGuard(dimColour());
-                    stream << " and";
+        // Implementation of CompactReporter formatting
+        class AssertionPrinter {
+        public:
+            AssertionPrinter& operator= (AssertionPrinter const&) = delete;
+            AssertionPrinter(AssertionPrinter const&) = delete;
+            AssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
+                : stream(_stream)
+                , result(_stats.assertionResult)
+                , messages(_stats.infoMessages)
+                , itMessage(_stats.infoMessages.begin())
+                , printInfoMessages(_printInfoMessages) {}
+
+            void print() {
+                printSourceInfo();
+
+                itMessage = messages.begin();
+
+                switch (result.getResultType()) {
+                case ResultWas::Ok:
+                    printResultType(Colour::ResultSuccess, passedString());
+                    printOriginalExpression();
+                    printReconstructedExpression();
+                    if (!result.hasExpression())
+                        printRemainingMessages(Colour::None);
+                    else
+                        printRemainingMessages();
+                    break;
+                case ResultWas::ExpressionFailed:
+                    if (result.isOk())
+                        printResultType(Colour::ResultSuccess, failedString() + std::string(" - but was ok"));
+                    else
+                        printResultType(Colour::Error, failedString());
+                    printOriginalExpression();
+                    printReconstructedExpression();
+                    printRemainingMessages();
+                    break;
+                case ResultWas::ThrewException:
+                    printResultType(Colour::Error, failedString());
+                    printIssue("unexpected exception with message:");
+                    printMessage();
+                    printExpressionWas();
+                    printRemainingMessages();
+                    break;
+                case ResultWas::FatalErrorCondition:
+                    printResultType(Colour::Error, failedString());
+                    printIssue("fatal error condition with message:");
+                    printMessage();
+                    printExpressionWas();
+                    printRemainingMessages();
+                    break;
+                case ResultWas::DidntThrowException:
+                    printResultType(Colour::Error, failedString());
+                    printIssue("expected exception, got none");
+                    printExpressionWas();
+                    printRemainingMessages();
+                    break;
+                case ResultWas::Info:
+                    printResultType(Colour::None, "info");
+                    printMessage();
+                    printRemainingMessages();
+                    break;
+                case ResultWas::Warning:
+                    printResultType(Colour::None, "warning");
+                    printMessage();
+                    printRemainingMessages();
+                    break;
+                case ResultWas::ExplicitFailure:
+                    printResultType(Colour::Error, failedString());
+                    printIssue("explicitly");
+                    printRemainingMessages(Colour::None);
+                    break;
+                    // These cases are here to prevent compiler warnings
+                case ResultWas::Unknown:
+                case ResultWas::FailureBit:
+                case ResultWas::Exception:
+                    printResultType(Colour::Error, "** internal error **");
+                    break;
                 }
-                continue;
             }
-            ++itMessage;
+
+        private:
+            void printSourceInfo() const {
+                Colour colourGuard(Colour::FileName);
+                stream << result.getSourceInfo() << ':';
+            }
+
+            void printResultType(Colour::Code colour, std::string const& passOrFail) const {
+                if (!passOrFail.empty()) {
+                    {
+                        Colour colourGuard(colour);
+                        stream << ' ' << passOrFail;
+                    }
+                    stream << ':';
+                }
+            }
+
+            void printIssue(std::string const& issue) const {
+                stream << ' ' << issue;
+            }
+
+            void printExpressionWas() {
+                if (result.hasExpression()) {
+                    stream << ';';
+                    {
+                        Colour colour(dimColour());
+                        stream << " expression was:";
+                    }
+                    printOriginalExpression();
+                }
+            }
+
+            void printOriginalExpression() const {
+                if (result.hasExpression()) {
+                    stream << ' ' << result.getExpression();
+                }
+            }
+
+            void printReconstructedExpression() const {
+                if (result.hasExpandedExpression()) {
+                    {
+                        Colour colour(dimColour());
+                        stream << " for: ";
+                    }
+                    stream << result.getExpandedExpression();
+                }
+            }
+
+            void printMessage() {
+                if (itMessage != messages.end()) {
+                    stream << " '" << itMessage->message << '\'';
+                    ++itMessage;
+                }
+            }
+
+            void printRemainingMessages(Colour::Code colour = dimColour()) {
+                if (itMessage == messages.end())
+                    return;
+
+                const auto itEnd = messages.cend();
+                const auto N = static_cast<std::size_t>(std::distance(itMessage, itEnd));
+
+                {
+                    Colour colourGuard(colour);
+                    stream << " with " << pluralise(N, "message") << ':';
+                }
+
+                while (itMessage != itEnd) {
+                    // If this assertion is a warning ignore any INFO messages
+                    if (printInfoMessages || itMessage->type != ResultWas::Info) {
+                        printMessage();
+                        if (itMessage != itEnd) {
+                            Colour colourGuard(dimColour());
+                            stream << " and";
+                        }
+                        continue;
+                    }
+                    ++itMessage;
+                }
+            }
+
+        private:
+            std::ostream& stream;
+            AssertionResult const& result;
+            std::vector<MessageInfo> messages;
+            std::vector<MessageInfo>::const_iterator itMessage;
+            bool printInfoMessages;
+        };
+
+    } // anon namespace
+
+    std::string CompactReporter::getDescription() {
+        return "Reports test results on a single line, suitable for IDEs";
+    }
+
+    void CompactReporter::noMatchingTestCases(std::string const& spec) {
+        stream << "No test cases matched '" << spec << '\'' << std::endl;
+    }
+
+    void CompactReporter::assertionStarting(AssertionInfo const&) {}
+
+    bool CompactReporter::assertionEnded(AssertionStats const& _assertionStats) {
+        AssertionResult const& result = _assertionStats.assertionResult;
+
+        bool printInfoMessages = true;
+
+        // Drop out if result was successful and we're not printing those
+        if (!m_config->includeSuccessfulResults() && result.isOk()) {
+            if (result.getResultType() != ResultWas::Warning)
+                return false;
+            printInfoMessages = false;
+        }
+
+        AssertionPrinter printer(stream, _assertionStats, printInfoMessages);
+        printer.print();
+
+        stream << std::endl;
+        return true;
+    }
+
+    void CompactReporter::sectionEnded(SectionStats const& _sectionStats) {
+        double dur = _sectionStats.durationInSeconds;
+        if (shouldShowDuration(*m_config, dur)) {
+            stream << getFormattedDuration(dur) << " s: " << _sectionStats.sectionInfo.name << std::endl;
         }
     }
 
-private:
-    std::ostream& stream;
-    AssertionResult const& result;
-    std::vector<MessageInfo> messages;
-    std::vector<MessageInfo>::const_iterator itMessage;
-    bool printInfoMessages;
-};
+    void CompactReporter::testRunEnded(TestRunStats const& _testRunStats) {
+        printTotals(stream, _testRunStats.totals);
+        stream << '\n' << std::endl;
+        StreamingReporterBase::testRunEnded(_testRunStats);
+    }
 
-} // anon namespace
+    CompactReporter::~CompactReporter() {}
 
-        std::string CompactReporter::getDescription() {
-            return "Reports test results on a single line, suitable for IDEs";
-        }
-
-        void CompactReporter::noMatchingTestCases( std::string const& spec ) {
-            stream << "No test cases matched '" << spec << '\'' << std::endl;
-        }
-
-        void CompactReporter::assertionStarting( AssertionInfo const& ) {}
-
-        bool CompactReporter::assertionEnded( AssertionStats const& _assertionStats ) {
-            AssertionResult const& result = _assertionStats.assertionResult;
-
-            bool printInfoMessages = true;
-
-            // Drop out if result was successful and we're not printing those
-            if( !m_config->includeSuccessfulResults() && result.isOk() ) {
-                if( result.getResultType() != ResultWas::Warning )
-                    return false;
-                printInfoMessages = false;
-            }
-
-            AssertionPrinter printer( stream, _assertionStats, printInfoMessages );
-            printer.print();
-
-            stream << std::endl;
-            return true;
-        }
-
-        void CompactReporter::sectionEnded(SectionStats const& _sectionStats) {
-            double dur = _sectionStats.durationInSeconds;
-            if ( shouldShowDuration( *m_config, dur ) ) {
-                stream << getFormattedDuration( dur ) << " s: " << _sectionStats.sectionInfo.name << std::endl;
-            }
-        }
-
-        void CompactReporter::testRunEnded( TestRunStats const& _testRunStats ) {
-            printTotals( stream, _testRunStats.totals );
-            stream << '\n' << std::endl;
-            StreamingReporterBase::testRunEnded( _testRunStats );
-        }
-
-        CompactReporter::~CompactReporter() {}
-
-    CATCH_REGISTER_REPORTER( "compact", CompactReporter )
+    CATCH_REGISTER_REPORTER("compact", CompactReporter)
 
 } // end namespace Catch
 // end catch_reporter_compact.cpp
@@ -16059,660 +16192,666 @@ private:
 
 namespace Catch {
 
-namespace {
+    namespace {
 
-// Formatter impl for ConsoleReporter
-class ConsoleAssertionPrinter {
-public:
-    ConsoleAssertionPrinter& operator= (ConsoleAssertionPrinter const&) = delete;
-    ConsoleAssertionPrinter(ConsoleAssertionPrinter const&) = delete;
-    ConsoleAssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
-        : stream(_stream),
-        stats(_stats),
-        result(_stats.assertionResult),
-        colour(Colour::None),
-        message(result.getMessage()),
-        messages(_stats.infoMessages),
-        printInfoMessages(_printInfoMessages) {
-        switch (result.getResultType()) {
-        case ResultWas::Ok:
-            colour = Colour::Success;
-            passOrFail = "PASSED";
-            //if( result.hasMessage() )
-            if (_stats.infoMessages.size() == 1)
-                messageLabel = "with message";
-            if (_stats.infoMessages.size() > 1)
-                messageLabel = "with messages";
-            break;
-        case ResultWas::ExpressionFailed:
-            if (result.isOk()) {
-                colour = Colour::Success;
-                passOrFail = "FAILED - but was ok";
-            } else {
-                colour = Colour::Error;
-                passOrFail = "FAILED";
+        // Formatter impl for ConsoleReporter
+        class ConsoleAssertionPrinter {
+        public:
+            ConsoleAssertionPrinter& operator= (ConsoleAssertionPrinter const&) = delete;
+            ConsoleAssertionPrinter(ConsoleAssertionPrinter const&) = delete;
+            ConsoleAssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
+                : stream(_stream),
+                stats(_stats),
+                result(_stats.assertionResult),
+                colour(Colour::None),
+                message(result.getMessage()),
+                messages(_stats.infoMessages),
+                printInfoMessages(_printInfoMessages) {
+                switch (result.getResultType()) {
+                case ResultWas::Ok:
+                    colour = Colour::Success;
+                    passOrFail = "PASSED";
+                    //if( result.hasMessage() )
+                    if (_stats.infoMessages.size() == 1)
+                        messageLabel = "with message";
+                    if (_stats.infoMessages.size() > 1)
+                        messageLabel = "with messages";
+                    break;
+                case ResultWas::ExpressionFailed:
+                    if (result.isOk()) {
+                        colour = Colour::Success;
+                        passOrFail = "FAILED - but was ok";
+                    }
+                    else {
+                        colour = Colour::Error;
+                        passOrFail = "FAILED";
+                    }
+                    if (_stats.infoMessages.size() == 1)
+                        messageLabel = "with message";
+                    if (_stats.infoMessages.size() > 1)
+                        messageLabel = "with messages";
+                    break;
+                case ResultWas::ThrewException:
+                    colour = Colour::Error;
+                    passOrFail = "FAILED";
+                    messageLabel = "due to unexpected exception with ";
+                    if (_stats.infoMessages.size() == 1)
+                        messageLabel += "message";
+                    if (_stats.infoMessages.size() > 1)
+                        messageLabel += "messages";
+                    break;
+                case ResultWas::FatalErrorCondition:
+                    colour = Colour::Error;
+                    passOrFail = "FAILED";
+                    messageLabel = "due to a fatal error condition";
+                    break;
+                case ResultWas::DidntThrowException:
+                    colour = Colour::Error;
+                    passOrFail = "FAILED";
+                    messageLabel = "because no exception was thrown where one was expected";
+                    break;
+                case ResultWas::Info:
+                    messageLabel = "info";
+                    break;
+                case ResultWas::Warning:
+                    messageLabel = "warning";
+                    break;
+                case ResultWas::ExplicitFailure:
+                    passOrFail = "FAILED";
+                    colour = Colour::Error;
+                    if (_stats.infoMessages.size() == 1)
+                        messageLabel = "explicitly with message";
+                    if (_stats.infoMessages.size() > 1)
+                        messageLabel = "explicitly with messages";
+                    break;
+                    // These cases are here to prevent compiler warnings
+                case ResultWas::Unknown:
+                case ResultWas::FailureBit:
+                case ResultWas::Exception:
+                    passOrFail = "** internal error **";
+                    colour = Colour::Error;
+                    break;
+                }
             }
-            if (_stats.infoMessages.size() == 1)
-                messageLabel = "with message";
-            if (_stats.infoMessages.size() > 1)
-                messageLabel = "with messages";
-            break;
-        case ResultWas::ThrewException:
-            colour = Colour::Error;
-            passOrFail = "FAILED";
-            messageLabel = "due to unexpected exception with ";
-            if (_stats.infoMessages.size() == 1)
-                messageLabel += "message";
-            if (_stats.infoMessages.size() > 1)
-                messageLabel += "messages";
-            break;
-        case ResultWas::FatalErrorCondition:
-            colour = Colour::Error;
-            passOrFail = "FAILED";
-            messageLabel = "due to a fatal error condition";
-            break;
-        case ResultWas::DidntThrowException:
-            colour = Colour::Error;
-            passOrFail = "FAILED";
-            messageLabel = "because no exception was thrown where one was expected";
-            break;
-        case ResultWas::Info:
-            messageLabel = "info";
-            break;
-        case ResultWas::Warning:
-            messageLabel = "warning";
-            break;
-        case ResultWas::ExplicitFailure:
-            passOrFail = "FAILED";
-            colour = Colour::Error;
-            if (_stats.infoMessages.size() == 1)
-                messageLabel = "explicitly with message";
-            if (_stats.infoMessages.size() > 1)
-                messageLabel = "explicitly with messages";
-            break;
-            // These cases are here to prevent compiler warnings
-        case ResultWas::Unknown:
-        case ResultWas::FailureBit:
-        case ResultWas::Exception:
-            passOrFail = "** internal error **";
-            colour = Colour::Error;
-            break;
+
+            void print() const {
+                printSourceInfo();
+                if (stats.totals.assertions.total() > 0) {
+                    printResultType();
+                    printOriginalExpression();
+                    printReconstructedExpression();
+                }
+                else {
+                    stream << '\n';
+                }
+                printMessage();
+            }
+
+        private:
+            void printResultType() const {
+                if (!passOrFail.empty()) {
+                    Colour colourGuard(colour);
+                    stream << passOrFail << ":\n";
+                }
+            }
+            void printOriginalExpression() const {
+                if (result.hasExpression()) {
+                    Colour colourGuard(Colour::OriginalExpression);
+                    stream << "  ";
+                    stream << result.getExpressionInMacro();
+                    stream << '\n';
+                }
+            }
+            void printReconstructedExpression() const {
+                if (result.hasExpandedExpression()) {
+                    stream << "with expansion:\n";
+                    Colour colourGuard(Colour::ReconstructedExpression);
+                    stream << Column(result.getExpandedExpression()).indent(2) << '\n';
+                }
+            }
+            void printMessage() const {
+                if (!messageLabel.empty())
+                    stream << messageLabel << ':' << '\n';
+                for (auto const& msg : messages) {
+                    // If this assertion is a warning ignore any INFO messages
+                    if (printInfoMessages || msg.type != ResultWas::Info)
+                        stream << Column(msg.message).indent(2) << '\n';
+                }
+            }
+            void printSourceInfo() const {
+                Colour colourGuard(Colour::FileName);
+                stream << result.getSourceInfo() << ": ";
+            }
+
+            std::ostream& stream;
+            AssertionStats const& stats;
+            AssertionResult const& result;
+            Colour::Code colour;
+            std::string passOrFail;
+            std::string messageLabel;
+            std::string message;
+            std::vector<MessageInfo> messages;
+            bool printInfoMessages;
+        };
+
+        std::size_t makeRatio(std::size_t number, std::size_t total) {
+            std::size_t ratio = total > 0 ? CATCH_CONFIG_CONSOLE_WIDTH * number / total : 0;
+            return (ratio == 0 && number > 0) ? 1 : ratio;
         }
-    }
 
-    void print() const {
-        printSourceInfo();
-        if (stats.totals.assertions.total() > 0) {
-            printResultType();
-            printOriginalExpression();
-            printReconstructedExpression();
-        } else {
-            stream << '\n';
-        }
-        printMessage();
-    }
-
-private:
-    void printResultType() const {
-        if (!passOrFail.empty()) {
-            Colour colourGuard(colour);
-            stream << passOrFail << ":\n";
-        }
-    }
-    void printOriginalExpression() const {
-        if (result.hasExpression()) {
-            Colour colourGuard(Colour::OriginalExpression);
-            stream << "  ";
-            stream << result.getExpressionInMacro();
-            stream << '\n';
-        }
-    }
-    void printReconstructedExpression() const {
-        if (result.hasExpandedExpression()) {
-            stream << "with expansion:\n";
-            Colour colourGuard(Colour::ReconstructedExpression);
-            stream << Column(result.getExpandedExpression()).indent(2) << '\n';
-        }
-    }
-    void printMessage() const {
-        if (!messageLabel.empty())
-            stream << messageLabel << ':' << '\n';
-        for (auto const& msg : messages) {
-            // If this assertion is a warning ignore any INFO messages
-            if (printInfoMessages || msg.type != ResultWas::Info)
-                stream << Column(msg.message).indent(2) << '\n';
-        }
-    }
-    void printSourceInfo() const {
-        Colour colourGuard(Colour::FileName);
-        stream << result.getSourceInfo() << ": ";
-    }
-
-    std::ostream& stream;
-    AssertionStats const& stats;
-    AssertionResult const& result;
-    Colour::Code colour;
-    std::string passOrFail;
-    std::string messageLabel;
-    std::string message;
-    std::vector<MessageInfo> messages;
-    bool printInfoMessages;
-};
-
-std::size_t makeRatio(std::size_t number, std::size_t total) {
-    std::size_t ratio = total > 0 ? CATCH_CONFIG_CONSOLE_WIDTH * number / total : 0;
-    return (ratio == 0 && number > 0) ? 1 : ratio;
-}
-
-std::size_t& findMax(std::size_t& i, std::size_t& j, std::size_t& k) {
-    if (i > j && i > k)
-        return i;
-    else if (j > k)
-        return j;
-    else
-        return k;
-}
-
-struct ColumnInfo {
-    enum Justification { Left, Right };
-    std::string name;
-    int width;
-    Justification justification;
-};
-struct ColumnBreak {};
-struct RowBreak {};
-
-class Duration {
-    enum class Unit {
-        Auto,
-        Nanoseconds,
-        Microseconds,
-        Milliseconds,
-        Seconds,
-        Minutes
-    };
-    static const uint64_t s_nanosecondsInAMicrosecond = 1000;
-    static const uint64_t s_nanosecondsInAMillisecond = 1000 * s_nanosecondsInAMicrosecond;
-    static const uint64_t s_nanosecondsInASecond = 1000 * s_nanosecondsInAMillisecond;
-    static const uint64_t s_nanosecondsInAMinute = 60 * s_nanosecondsInASecond;
-
-    double m_inNanoseconds;
-    Unit m_units;
-
-public:
-    explicit Duration(double inNanoseconds, Unit units = Unit::Auto)
-        : m_inNanoseconds(inNanoseconds),
-        m_units(units) {
-        if (m_units == Unit::Auto) {
-            if (m_inNanoseconds < s_nanosecondsInAMicrosecond)
-                m_units = Unit::Nanoseconds;
-            else if (m_inNanoseconds < s_nanosecondsInAMillisecond)
-                m_units = Unit::Microseconds;
-            else if (m_inNanoseconds < s_nanosecondsInASecond)
-                m_units = Unit::Milliseconds;
-            else if (m_inNanoseconds < s_nanosecondsInAMinute)
-                m_units = Unit::Seconds;
+        std::size_t& findMax(std::size_t& i, std::size_t& j, std::size_t& k) {
+            if (i > j && i > k)
+                return i;
+            else if (j > k)
+                return j;
             else
-                m_units = Unit::Minutes;
+                return k;
         }
 
-    }
+        struct ColumnInfo {
+            enum Justification { Left, Right };
+            std::string name;
+            int width;
+            Justification justification;
+        };
+        struct ColumnBreak {};
+        struct RowBreak {};
 
-    auto value() const -> double {
-        switch (m_units) {
-        case Unit::Microseconds:
-            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMicrosecond);
-        case Unit::Milliseconds:
-            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMillisecond);
-        case Unit::Seconds:
-            return m_inNanoseconds / static_cast<double>(s_nanosecondsInASecond);
-        case Unit::Minutes:
-            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMinute);
-        default:
-            return m_inNanoseconds;
-        }
-    }
-    auto unitsAsString() const -> std::string {
-        switch (m_units) {
-        case Unit::Nanoseconds:
-            return "ns";
-        case Unit::Microseconds:
-            return "us";
-        case Unit::Milliseconds:
-            return "ms";
-        case Unit::Seconds:
-            return "s";
-        case Unit::Minutes:
-            return "m";
-        default:
-            return "** internal error **";
-        }
-
-    }
-    friend auto operator << (std::ostream& os, Duration const& duration) -> std::ostream& {
-        return os << duration.value() << ' ' << duration.unitsAsString();
-    }
-};
-} // end anon namespace
-
-class TablePrinter {
-    std::ostream& m_os;
-    std::vector<ColumnInfo> m_columnInfos;
-    std::ostringstream m_oss;
-    int m_currentColumn = -1;
-    bool m_isOpen = false;
-
-public:
-    TablePrinter( std::ostream& os, std::vector<ColumnInfo> columnInfos )
-    :   m_os( os ),
-        m_columnInfos( std::move( columnInfos ) ) {}
-
-    auto columnInfos() const -> std::vector<ColumnInfo> const& {
-        return m_columnInfos;
-    }
-
-    void open() {
-        if (!m_isOpen) {
-            m_isOpen = true;
-            *this << RowBreak();
-
-			Columns headerCols;
-			Spacer spacer(2);
-			for (auto const& info : m_columnInfos) {
-				headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
-				headerCols += spacer;
-			}
-			m_os << headerCols << '\n';
-
-            m_os << Catch::getLineOfChars<'-'>() << '\n';
-        }
-    }
-    void close() {
-        if (m_isOpen) {
-            *this << RowBreak();
-            m_os << std::endl;
-            m_isOpen = false;
-        }
-    }
-
-    template<typename T>
-    friend TablePrinter& operator << (TablePrinter& tp, T const& value) {
-        tp.m_oss << value;
-        return tp;
-    }
-
-    friend TablePrinter& operator << (TablePrinter& tp, ColumnBreak) {
-        auto colStr = tp.m_oss.str();
-        const auto strSize = colStr.size();
-        tp.m_oss.str("");
-        tp.open();
-        if (tp.m_currentColumn == static_cast<int>(tp.m_columnInfos.size() - 1)) {
-            tp.m_currentColumn = -1;
-            tp.m_os << '\n';
-        }
-        tp.m_currentColumn++;
-
-        auto colInfo = tp.m_columnInfos[tp.m_currentColumn];
-        auto padding = (strSize + 1 < static_cast<std::size_t>(colInfo.width))
-            ? std::string(colInfo.width - (strSize + 1), ' ')
-            : std::string();
-        if (colInfo.justification == ColumnInfo::Left)
-            tp.m_os << colStr << padding << ' ';
-        else
-            tp.m_os << padding << colStr << ' ';
-        return tp;
-    }
-
-    friend TablePrinter& operator << (TablePrinter& tp, RowBreak) {
-        if (tp.m_currentColumn > 0) {
-            tp.m_os << '\n';
-            tp.m_currentColumn = -1;
-        }
-        return tp;
-    }
-};
-
-ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
-    : StreamingReporterBase(config),
-    m_tablePrinter(new TablePrinter(config.stream(),
-        [&config]() -> std::vector<ColumnInfo> {
-        if (config.fullConfig()->benchmarkNoAnalysis())
-        {
-            return{
-                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
-                { "     samples", 14, ColumnInfo::Right },
-                { "  iterations", 14, ColumnInfo::Right },
-                { "        mean", 14, ColumnInfo::Right }
+        class Duration {
+            enum class Unit {
+                Auto,
+                Nanoseconds,
+                Microseconds,
+                Milliseconds,
+                Seconds,
+                Minutes
             };
+            static const uint64_t s_nanosecondsInAMicrosecond = 1000;
+            static const uint64_t s_nanosecondsInAMillisecond = 1000 * s_nanosecondsInAMicrosecond;
+            static const uint64_t s_nanosecondsInASecond = 1000 * s_nanosecondsInAMillisecond;
+            static const uint64_t s_nanosecondsInAMinute = 60 * s_nanosecondsInASecond;
+
+            double m_inNanoseconds;
+            Unit m_units;
+
+        public:
+            explicit Duration(double inNanoseconds, Unit units = Unit::Auto)
+                : m_inNanoseconds(inNanoseconds),
+                m_units(units) {
+                if (m_units == Unit::Auto) {
+                    if (m_inNanoseconds < s_nanosecondsInAMicrosecond)
+                        m_units = Unit::Nanoseconds;
+                    else if (m_inNanoseconds < s_nanosecondsInAMillisecond)
+                        m_units = Unit::Microseconds;
+                    else if (m_inNanoseconds < s_nanosecondsInASecond)
+                        m_units = Unit::Milliseconds;
+                    else if (m_inNanoseconds < s_nanosecondsInAMinute)
+                        m_units = Unit::Seconds;
+                    else
+                        m_units = Unit::Minutes;
+                }
+
+            }
+
+            auto value() const -> double {
+                switch (m_units) {
+                case Unit::Microseconds:
+                    return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMicrosecond);
+                case Unit::Milliseconds:
+                    return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMillisecond);
+                case Unit::Seconds:
+                    return m_inNanoseconds / static_cast<double>(s_nanosecondsInASecond);
+                case Unit::Minutes:
+                    return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMinute);
+                default:
+                    return m_inNanoseconds;
+                }
+            }
+            auto unitsAsString() const -> std::string {
+                switch (m_units) {
+                case Unit::Nanoseconds:
+                    return "ns";
+                case Unit::Microseconds:
+                    return "us";
+                case Unit::Milliseconds:
+                    return "ms";
+                case Unit::Seconds:
+                    return "s";
+                case Unit::Minutes:
+                    return "m";
+                default:
+                    return "** internal error **";
+                }
+
+            }
+            friend auto operator << (std::ostream& os, Duration const& duration) -> std::ostream& {
+                return os << duration.value() << ' ' << duration.unitsAsString();
+            }
+        };
+    } // end anon namespace
+
+    class TablePrinter {
+        std::ostream& m_os;
+        std::vector<ColumnInfo> m_columnInfos;
+        std::ostringstream m_oss;
+        int m_currentColumn = -1;
+        bool m_isOpen = false;
+
+    public:
+        TablePrinter(std::ostream& os, std::vector<ColumnInfo> columnInfos)
+            : m_os(os),
+            m_columnInfos(std::move(columnInfos)) {}
+
+        auto columnInfos() const -> std::vector<ColumnInfo> const& {
+            return m_columnInfos;
         }
-        else
-        {
-            return{
-                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
-                { "samples      mean       std dev", 14, ColumnInfo::Right },
-                { "iterations   low mean   low std dev", 14, ColumnInfo::Right },
-                { "estimated    high mean  high std dev", 14, ColumnInfo::Right }
-            };
+
+        void open() {
+            if (!m_isOpen) {
+                m_isOpen = true;
+                *this << RowBreak();
+
+                Columns headerCols;
+                Spacer spacer(2);
+                for (auto const& info : m_columnInfos) {
+                    headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
+                    headerCols += spacer;
+                }
+                m_os << headerCols << '\n';
+
+                m_os << Catch::getLineOfChars<'-'>() << '\n';
+            }
         }
-    }())) {}
-ConsoleReporter::~ConsoleReporter() = default;
+        void close() {
+            if (m_isOpen) {
+                *this << RowBreak();
+                m_os << std::endl;
+                m_isOpen = false;
+            }
+        }
 
-std::string ConsoleReporter::getDescription() {
-    return "Reports test results as plain lines of text";
-}
+        template<typename T>
+        friend TablePrinter& operator << (TablePrinter& tp, T const& value) {
+            tp.m_oss << value;
+            return tp;
+        }
 
-void ConsoleReporter::noMatchingTestCases(std::string const& spec) {
-    stream << "No test cases matched '" << spec << '\'' << std::endl;
-}
+        friend TablePrinter& operator << (TablePrinter& tp, ColumnBreak) {
+            auto colStr = tp.m_oss.str();
+            const auto strSize = colStr.size();
+            tp.m_oss.str("");
+            tp.open();
+            if (tp.m_currentColumn == static_cast<int>(tp.m_columnInfos.size() - 1)) {
+                tp.m_currentColumn = -1;
+                tp.m_os << '\n';
+            }
+            tp.m_currentColumn++;
 
-void ConsoleReporter::reportInvalidArguments(std::string const&arg){
-    stream << "Invalid Filter: " << arg << std::endl;
-}
+            auto colInfo = tp.m_columnInfos[tp.m_currentColumn];
+            auto padding = (strSize + 1 < static_cast<std::size_t>(colInfo.width))
+                ? std::string(colInfo.width - (strSize + 1), ' ')
+                : std::string();
+            if (colInfo.justification == ColumnInfo::Left)
+                tp.m_os << colStr << padding << ' ';
+            else
+                tp.m_os << padding << colStr << ' ';
+            return tp;
+        }
 
-void ConsoleReporter::assertionStarting(AssertionInfo const&) {}
+        friend TablePrinter& operator << (TablePrinter& tp, RowBreak) {
+            if (tp.m_currentColumn > 0) {
+                tp.m_os << '\n';
+                tp.m_currentColumn = -1;
+            }
+            return tp;
+        }
+    };
 
-bool ConsoleReporter::assertionEnded(AssertionStats const& _assertionStats) {
-    AssertionResult const& result = _assertionStats.assertionResult;
+    ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
+        : StreamingReporterBase(config),
+        m_tablePrinter(new TablePrinter(config.stream(),
+            [&config]() -> std::vector<ColumnInfo> {
+                if (config.fullConfig()->benchmarkNoAnalysis())
+                {
+                    return{
+                        { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
+                        { "     samples", 14, ColumnInfo::Right },
+                        { "  iterations", 14, ColumnInfo::Right },
+                        { "        mean", 14, ColumnInfo::Right }
+                    };
+                }
+                else
+                {
+                    return{
+                        { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
+                        { "samples      mean       std dev", 14, ColumnInfo::Right },
+                        { "iterations   low mean   low std dev", 14, ColumnInfo::Right },
+                        { "estimated    high mean  high std dev", 14, ColumnInfo::Right }
+                    };
+                }
+            }())) {}
+    ConsoleReporter::~ConsoleReporter() = default;
 
-    bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
+    std::string ConsoleReporter::getDescription() {
+        return "Reports test results as plain lines of text";
+    }
 
-    // Drop out if result was successful but we're not printing them.
-    if (!includeResults && result.getResultType() != ResultWas::Warning)
-        return false;
+    void ConsoleReporter::noMatchingTestCases(std::string const& spec) {
+        stream << "No test cases matched '" << spec << '\'' << std::endl;
+    }
 
-    lazyPrint();
+    void ConsoleReporter::reportInvalidArguments(std::string const& arg) {
+        stream << "Invalid Filter: " << arg << std::endl;
+    }
 
-    ConsoleAssertionPrinter printer(stream, _assertionStats, includeResults);
-    printer.print();
-    stream << std::endl;
-    return true;
-}
+    void ConsoleReporter::assertionStarting(AssertionInfo const&) {}
 
-void ConsoleReporter::sectionStarting(SectionInfo const& _sectionInfo) {
-    m_tablePrinter->close();
-    m_headerPrinted = false;
-    StreamingReporterBase::sectionStarting(_sectionInfo);
-}
-void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
-    m_tablePrinter->close();
-    if (_sectionStats.missingAssertions) {
+    bool ConsoleReporter::assertionEnded(AssertionStats const& _assertionStats) {
+        AssertionResult const& result = _assertionStats.assertionResult;
+
+        bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
+
+        // Drop out if result was successful but we're not printing them.
+        if (!includeResults && result.getResultType() != ResultWas::Warning)
+            return false;
+
         lazyPrint();
-        Colour colour(Colour::ResultError);
-        if (m_sectionStack.size() > 1)
-            stream << "\nNo assertions in section";
-        else
-            stream << "\nNo assertions in test case";
-        stream << " '" << _sectionStats.sectionInfo.name << "'\n" << std::endl;
+
+        ConsoleAssertionPrinter printer(stream, _assertionStats, includeResults);
+        printer.print();
+        stream << std::endl;
+        return true;
     }
-    double dur = _sectionStats.durationInSeconds;
-    if (shouldShowDuration(*m_config, dur)) {
-        stream << getFormattedDuration(dur) << " s: " << _sectionStats.sectionInfo.name << std::endl;
-    }
-    if (m_headerPrinted) {
+
+    void ConsoleReporter::sectionStarting(SectionInfo const& _sectionInfo) {
+        m_tablePrinter->close();
         m_headerPrinted = false;
+        StreamingReporterBase::sectionStarting(_sectionInfo);
     }
-    StreamingReporterBase::sectionEnded(_sectionStats);
-}
+    void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
+        m_tablePrinter->close();
+        if (_sectionStats.missingAssertions) {
+            lazyPrint();
+            Colour colour(Colour::ResultError);
+            if (m_sectionStack.size() > 1)
+                stream << "\nNo assertions in section";
+            else
+                stream << "\nNo assertions in test case";
+            stream << " '" << _sectionStats.sectionInfo.name << "'\n" << std::endl;
+        }
+        double dur = _sectionStats.durationInSeconds;
+        if (shouldShowDuration(*m_config, dur)) {
+            stream << getFormattedDuration(dur) << " s: " << _sectionStats.sectionInfo.name << std::endl;
+        }
+        if (m_headerPrinted) {
+            m_headerPrinted = false;
+        }
+        StreamingReporterBase::sectionEnded(_sectionStats);
+    }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-void ConsoleReporter::benchmarkPreparing(std::string const& name) {
-	lazyPrintWithoutClosingBenchmarkTable();
+    void ConsoleReporter::benchmarkPreparing(std::string const& name) {
+        lazyPrintWithoutClosingBenchmarkTable();
 
-	auto nameCol = Column(name).width(static_cast<std::size_t>(m_tablePrinter->columnInfos()[0].width - 2));
+        auto nameCol = Column(name).width(static_cast<std::size_t>(m_tablePrinter->columnInfos()[0].width - 2));
 
-	bool firstLine = true;
-	for (auto line : nameCol) {
-		if (!firstLine)
-			(*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
-		else
-			firstLine = false;
+        bool firstLine = true;
+        for (auto line : nameCol) {
+            if (!firstLine)
+                (*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
+            else
+                firstLine = false;
 
-		(*m_tablePrinter) << line << ColumnBreak();
-	}
-}
-
-void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
-    (*m_tablePrinter) << info.samples << ColumnBreak()
-        << info.iterations << ColumnBreak();
-    if (!m_config->benchmarkNoAnalysis())
-        (*m_tablePrinter) << Duration(info.estimatedDuration) << ColumnBreak();
-}
-void ConsoleReporter::benchmarkEnded(BenchmarkStats<> const& stats) {
-    if (m_config->benchmarkNoAnalysis())
-    {
-        (*m_tablePrinter) << Duration(stats.mean.point.count()) << ColumnBreak();
+            (*m_tablePrinter) << line << ColumnBreak();
+        }
     }
-    else
-    {
-        (*m_tablePrinter) << ColumnBreak()
-            << Duration(stats.mean.point.count()) << ColumnBreak()
-            << Duration(stats.mean.lower_bound.count()) << ColumnBreak()
-            << Duration(stats.mean.upper_bound.count()) << ColumnBreak() << ColumnBreak()
-            << Duration(stats.standardDeviation.point.count()) << ColumnBreak()
-            << Duration(stats.standardDeviation.lower_bound.count()) << ColumnBreak()
-            << Duration(stats.standardDeviation.upper_bound.count()) << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak();
-    }
-}
 
-void ConsoleReporter::benchmarkFailed(std::string const& error) {
-	Colour colour(Colour::Red);
-    (*m_tablePrinter)
-        << "Benchmark failed (" << error << ')'
-        << ColumnBreak() << RowBreak();
-}
+    void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
+        (*m_tablePrinter) << info.samples << ColumnBreak()
+            << info.iterations << ColumnBreak();
+        if (!m_config->benchmarkNoAnalysis())
+            (*m_tablePrinter) << Duration(info.estimatedDuration) << ColumnBreak();
+    }
+    void ConsoleReporter::benchmarkEnded(BenchmarkStats<> const& stats) {
+        if (m_config->benchmarkNoAnalysis())
+        {
+            (*m_tablePrinter) << Duration(stats.mean.point.count()) << ColumnBreak();
+        }
+        else
+        {
+            (*m_tablePrinter) << ColumnBreak()
+                << Duration(stats.mean.point.count()) << ColumnBreak()
+                << Duration(stats.mean.lower_bound.count()) << ColumnBreak()
+                << Duration(stats.mean.upper_bound.count()) << ColumnBreak() << ColumnBreak()
+                << Duration(stats.standardDeviation.point.count()) << ColumnBreak()
+                << Duration(stats.standardDeviation.lower_bound.count()) << ColumnBreak()
+                << Duration(stats.standardDeviation.upper_bound.count()) << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak();
+        }
+    }
+
+    void ConsoleReporter::benchmarkFailed(std::string const& error) {
+        Colour colour(Colour::Red);
+        (*m_tablePrinter)
+            << "Benchmark failed (" << error << ')'
+            << ColumnBreak() << RowBreak();
+    }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-void ConsoleReporter::testCaseEnded(TestCaseStats const& _testCaseStats) {
-    m_tablePrinter->close();
-    StreamingReporterBase::testCaseEnded(_testCaseStats);
-    m_headerPrinted = false;
-}
-void ConsoleReporter::testGroupEnded(TestGroupStats const& _testGroupStats) {
-    if (currentGroupInfo.used) {
-        printSummaryDivider();
-        stream << "Summary for group '" << _testGroupStats.groupInfo.name << "':\n";
-        printTotals(_testGroupStats.totals);
-        stream << '\n' << std::endl;
+    void ConsoleReporter::testCaseEnded(TestCaseStats const& _testCaseStats) {
+        m_tablePrinter->close();
+        StreamingReporterBase::testCaseEnded(_testCaseStats);
+        m_headerPrinted = false;
     }
-    StreamingReporterBase::testGroupEnded(_testGroupStats);
-}
-void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
-    printTotalsDivider(_testRunStats.totals);
-    printTotals(_testRunStats.totals);
-    stream << std::endl;
-    StreamingReporterBase::testRunEnded(_testRunStats);
-}
-void ConsoleReporter::testRunStarting(TestRunInfo const& _testInfo) {
-    StreamingReporterBase::testRunStarting(_testInfo);
-    printTestFilters();
-}
-
-void ConsoleReporter::lazyPrint() {
-
-    m_tablePrinter->close();
-    lazyPrintWithoutClosingBenchmarkTable();
-}
-
-void ConsoleReporter::lazyPrintWithoutClosingBenchmarkTable() {
-
-    if (!currentTestRunInfo.used)
-        lazyPrintRunInfo();
-    if (!currentGroupInfo.used)
-        lazyPrintGroupInfo();
-
-    if (!m_headerPrinted) {
-        printTestCaseAndSectionHeader();
-        m_headerPrinted = true;
-    }
-}
-void ConsoleReporter::lazyPrintRunInfo() {
-    stream << '\n' << getLineOfChars<'~'>() << '\n';
-    Colour colour(Colour::SecondaryText);
-    stream << currentTestRunInfo->name
-        << " is a Catch v" << libraryVersion() << " host application.\n"
-        << "Run with -? for options\n\n";
-
-    if (m_config->rngSeed() != 0)
-        stream << "Randomness seeded to: " << m_config->rngSeed() << "\n\n";
-
-    currentTestRunInfo.used = true;
-}
-void ConsoleReporter::lazyPrintGroupInfo() {
-    if (!currentGroupInfo->name.empty() && currentGroupInfo->groupsCounts > 1) {
-        printClosedHeader("Group: " + currentGroupInfo->name);
-        currentGroupInfo.used = true;
-    }
-}
-void ConsoleReporter::printTestCaseAndSectionHeader() {
-    assert(!m_sectionStack.empty());
-    printOpenHeader(currentTestCaseInfo->name);
-
-    if (m_sectionStack.size() > 1) {
-        Colour colourGuard(Colour::Headers);
-
-        auto
-            it = m_sectionStack.begin() + 1, // Skip first section (test case)
-            itEnd = m_sectionStack.end();
-        for (; it != itEnd; ++it)
-            printHeaderString(it->name, 2);
-    }
-
-    SourceLineInfo lineInfo = m_sectionStack.back().lineInfo;
-
-    stream << getLineOfChars<'-'>() << '\n';
-    Colour colourGuard(Colour::FileName);
-    stream << lineInfo << '\n';
-    stream << getLineOfChars<'.'>() << '\n' << std::endl;
-}
-
-void ConsoleReporter::printClosedHeader(std::string const& _name) {
-    printOpenHeader(_name);
-    stream << getLineOfChars<'.'>() << '\n';
-}
-void ConsoleReporter::printOpenHeader(std::string const& _name) {
-    stream << getLineOfChars<'-'>() << '\n';
-    {
-        Colour colourGuard(Colour::Headers);
-        printHeaderString(_name);
-    }
-}
-
-// if string has a : in first line will set indent to follow it on
-// subsequent lines
-void ConsoleReporter::printHeaderString(std::string const& _string, std::size_t indent) {
-    std::size_t i = _string.find(": ");
-    if (i != std::string::npos)
-        i += 2;
-    else
-        i = 0;
-    stream << Column(_string).indent(indent + i).initialIndent(indent) << '\n';
-}
-
-struct SummaryColumn {
-
-    SummaryColumn( std::string _label, Colour::Code _colour )
-    :   label( std::move( _label ) ),
-        colour( _colour ) {}
-    SummaryColumn addRow( std::size_t count ) {
-        ReusableStringStream rss;
-        rss << count;
-        std::string row = rss.str();
-        for (auto& oldRow : rows) {
-            while (oldRow.size() < row.size())
-                oldRow = ' ' + oldRow;
-            while (oldRow.size() > row.size())
-                row = ' ' + row;
+    void ConsoleReporter::testGroupEnded(TestGroupStats const& _testGroupStats) {
+        if (currentGroupInfo.used) {
+            printSummaryDivider();
+            stream << "Summary for group '" << _testGroupStats.groupInfo.name << "':\n";
+            printTotals(_testGroupStats.totals);
+            stream << '\n' << std::endl;
         }
-        rows.push_back(row);
-        return *this;
+        StreamingReporterBase::testGroupEnded(_testGroupStats);
+    }
+    void ConsoleReporter::testRunEnded(TestRunStats const& _testRunStats) {
+        printTotalsDivider(_testRunStats.totals);
+        printTotals(_testRunStats.totals);
+        stream << std::endl;
+        StreamingReporterBase::testRunEnded(_testRunStats);
+    }
+    void ConsoleReporter::testRunStarting(TestRunInfo const& _testInfo) {
+        StreamingReporterBase::testRunStarting(_testInfo);
+        printTestFilters();
     }
 
-    std::string label;
-    Colour::Code colour;
-    std::vector<std::string> rows;
+    void ConsoleReporter::lazyPrint() {
 
-};
-
-void ConsoleReporter::printTotals( Totals const& totals ) {
-    if (totals.testCases.total() == 0) {
-        stream << Colour(Colour::Warning) << "No tests ran\n";
-    } else if (totals.assertions.total() > 0 && totals.testCases.allPassed()) {
-        stream << Colour(Colour::ResultSuccess) << "All tests passed";
-        stream << " ("
-            << pluralise(totals.assertions.passed, "assertion") << " in "
-            << pluralise(totals.testCases.passed, "test case") << ')'
-            << '\n';
-    } else {
-
-        std::vector<SummaryColumn> columns;
-        columns.push_back(SummaryColumn("", Colour::None)
-                          .addRow(totals.testCases.total())
-                          .addRow(totals.assertions.total()));
-        columns.push_back(SummaryColumn("passed", Colour::Success)
-                          .addRow(totals.testCases.passed)
-                          .addRow(totals.assertions.passed));
-        columns.push_back(SummaryColumn("failed", Colour::ResultError)
-                          .addRow(totals.testCases.failed)
-                          .addRow(totals.assertions.failed));
-        columns.push_back(SummaryColumn("failed as expected", Colour::ResultExpectedFailure)
-                          .addRow(totals.testCases.failedButOk)
-                          .addRow(totals.assertions.failedButOk));
-
-        printSummaryRow("test cases", columns, 0);
-        printSummaryRow("assertions", columns, 1);
+        m_tablePrinter->close();
+        lazyPrintWithoutClosingBenchmarkTable();
     }
-}
-void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row) {
-    for (auto col : cols) {
-        std::string value = col.rows[row];
-        if (col.label.empty()) {
-            stream << label << ": ";
-            if (value != "0")
-                stream << value;
-            else
-                stream << Colour(Colour::Warning) << "- none -";
-        } else if (value != "0") {
-            stream << Colour(Colour::LightGrey) << " | ";
-            stream << Colour(col.colour)
-                << value << ' ' << col.label;
+
+    void ConsoleReporter::lazyPrintWithoutClosingBenchmarkTable() {
+
+        if (!currentTestRunInfo.used)
+            lazyPrintRunInfo();
+        if (!currentGroupInfo.used)
+            lazyPrintGroupInfo();
+
+        if (!m_headerPrinted) {
+            printTestCaseAndSectionHeader();
+            m_headerPrinted = true;
         }
     }
-    stream << '\n';
-}
+    void ConsoleReporter::lazyPrintRunInfo() {
+        stream << '\n' << getLineOfChars<'~'>() << '\n';
+        Colour colour(Colour::SecondaryText);
+        stream << currentTestRunInfo->name
+            << " is a Catch v" << libraryVersion() << " host application.\n"
+            << "Run with -? for options\n\n";
 
-void ConsoleReporter::printTotalsDivider(Totals const& totals) {
-    if (totals.testCases.total() > 0) {
-        std::size_t failedRatio = makeRatio(totals.testCases.failed, totals.testCases.total());
-        std::size_t failedButOkRatio = makeRatio(totals.testCases.failedButOk, totals.testCases.total());
-        std::size_t passedRatio = makeRatio(totals.testCases.passed, totals.testCases.total());
-        while (failedRatio + failedButOkRatio + passedRatio < CATCH_CONFIG_CONSOLE_WIDTH - 1)
-            findMax(failedRatio, failedButOkRatio, passedRatio)++;
-        while (failedRatio + failedButOkRatio + passedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
-            findMax(failedRatio, failedButOkRatio, passedRatio)--;
+        if (m_config->rngSeed() != 0)
+            stream << "Randomness seeded to: " << m_config->rngSeed() << "\n\n";
 
-        stream << Colour(Colour::Error) << std::string(failedRatio, '=');
-        stream << Colour(Colour::ResultExpectedFailure) << std::string(failedButOkRatio, '=');
-        if (totals.testCases.allPassed())
-            stream << Colour(Colour::ResultSuccess) << std::string(passedRatio, '=');
+        currentTestRunInfo.used = true;
+    }
+    void ConsoleReporter::lazyPrintGroupInfo() {
+        if (!currentGroupInfo->name.empty() && currentGroupInfo->groupsCounts > 1) {
+            printClosedHeader("Group: " + currentGroupInfo->name);
+            currentGroupInfo.used = true;
+        }
+    }
+    void ConsoleReporter::printTestCaseAndSectionHeader() {
+        assert(!m_sectionStack.empty());
+        printOpenHeader(currentTestCaseInfo->name);
+
+        if (m_sectionStack.size() > 1) {
+            Colour colourGuard(Colour::Headers);
+
+            auto
+                it = m_sectionStack.begin() + 1, // Skip first section (test case)
+                itEnd = m_sectionStack.end();
+            for (; it != itEnd; ++it)
+                printHeaderString(it->name, 2);
+        }
+
+        SourceLineInfo lineInfo = m_sectionStack.back().lineInfo;
+
+        stream << getLineOfChars<'-'>() << '\n';
+        Colour colourGuard(Colour::FileName);
+        stream << lineInfo << '\n';
+        stream << getLineOfChars<'.'>() << '\n' << std::endl;
+    }
+
+    void ConsoleReporter::printClosedHeader(std::string const& _name) {
+        printOpenHeader(_name);
+        stream << getLineOfChars<'.'>() << '\n';
+    }
+    void ConsoleReporter::printOpenHeader(std::string const& _name) {
+        stream << getLineOfChars<'-'>() << '\n';
+        {
+            Colour colourGuard(Colour::Headers);
+            printHeaderString(_name);
+        }
+    }
+
+    // if string has a : in first line will set indent to follow it on
+    // subsequent lines
+    void ConsoleReporter::printHeaderString(std::string const& _string, std::size_t indent) {
+        std::size_t i = _string.find(": ");
+        if (i != std::string::npos)
+            i += 2;
         else
-            stream << Colour(Colour::Success) << std::string(passedRatio, '=');
-    } else {
-        stream << Colour(Colour::Warning) << std::string(CATCH_CONFIG_CONSOLE_WIDTH - 1, '=');
+            i = 0;
+        stream << Column(_string).indent(indent + i).initialIndent(indent) << '\n';
     }
-    stream << '\n';
-}
-void ConsoleReporter::printSummaryDivider() {
-    stream << getLineOfChars<'-'>() << '\n';
-}
 
-void ConsoleReporter::printTestFilters() {
-    if (m_config->testSpec().hasFilters()) {
-        Colour guard(Colour::BrightYellow);
-        stream << "Filters: " << serializeFilters(m_config->getTestsOrTags()) << '\n';
+    struct SummaryColumn {
+
+        SummaryColumn(std::string _label, Colour::Code _colour)
+            : label(std::move(_label)),
+            colour(_colour) {}
+        SummaryColumn addRow(std::size_t count) {
+            ReusableStringStream rss;
+            rss << count;
+            std::string row = rss.str();
+            for (auto& oldRow : rows) {
+                while (oldRow.size() < row.size())
+                    oldRow = ' ' + oldRow;
+                while (oldRow.size() > row.size())
+                    row = ' ' + row;
+            }
+            rows.push_back(row);
+            return *this;
+        }
+
+        std::string label;
+        Colour::Code colour;
+        std::vector<std::string> rows;
+
+    };
+
+    void ConsoleReporter::printTotals(Totals const& totals) {
+        if (totals.testCases.total() == 0) {
+            stream << Colour(Colour::Warning) << "No tests ran\n";
+        }
+        else if (totals.assertions.total() > 0 && totals.testCases.allPassed()) {
+            stream << Colour(Colour::ResultSuccess) << "All tests passed";
+            stream << " ("
+                << pluralise(totals.assertions.passed, "assertion") << " in "
+                << pluralise(totals.testCases.passed, "test case") << ')'
+                << '\n';
+        }
+        else {
+
+            std::vector<SummaryColumn> columns;
+            columns.push_back(SummaryColumn("", Colour::None)
+                .addRow(totals.testCases.total())
+                .addRow(totals.assertions.total()));
+            columns.push_back(SummaryColumn("passed", Colour::Success)
+                .addRow(totals.testCases.passed)
+                .addRow(totals.assertions.passed));
+            columns.push_back(SummaryColumn("failed", Colour::ResultError)
+                .addRow(totals.testCases.failed)
+                .addRow(totals.assertions.failed));
+            columns.push_back(SummaryColumn("failed as expected", Colour::ResultExpectedFailure)
+                .addRow(totals.testCases.failedButOk)
+                .addRow(totals.assertions.failedButOk));
+
+            printSummaryRow("test cases", columns, 0);
+            printSummaryRow("assertions", columns, 1);
+        }
     }
-}
+    void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row) {
+        for (auto col : cols) {
+            std::string value = col.rows[row];
+            if (col.label.empty()) {
+                stream << label << ": ";
+                if (value != "0")
+                    stream << value;
+                else
+                    stream << Colour(Colour::Warning) << "- none -";
+            }
+            else if (value != "0") {
+                stream << Colour(Colour::LightGrey) << " | ";
+                stream << Colour(col.colour)
+                    << value << ' ' << col.label;
+            }
+        }
+        stream << '\n';
+    }
 
-CATCH_REGISTER_REPORTER("console", ConsoleReporter)
+    void ConsoleReporter::printTotalsDivider(Totals const& totals) {
+        if (totals.testCases.total() > 0) {
+            std::size_t failedRatio = makeRatio(totals.testCases.failed, totals.testCases.total());
+            std::size_t failedButOkRatio = makeRatio(totals.testCases.failedButOk, totals.testCases.total());
+            std::size_t passedRatio = makeRatio(totals.testCases.passed, totals.testCases.total());
+            while (failedRatio + failedButOkRatio + passedRatio < CATCH_CONFIG_CONSOLE_WIDTH - 1)
+                findMax(failedRatio, failedButOkRatio, passedRatio)++;
+            while (failedRatio + failedButOkRatio + passedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
+                findMax(failedRatio, failedButOkRatio, passedRatio)--;
+
+            stream << Colour(Colour::Error) << std::string(failedRatio, '=');
+            stream << Colour(Colour::ResultExpectedFailure) << std::string(failedButOkRatio, '=');
+            if (totals.testCases.allPassed())
+                stream << Colour(Colour::ResultSuccess) << std::string(passedRatio, '=');
+            else
+                stream << Colour(Colour::Success) << std::string(passedRatio, '=');
+        }
+        else {
+            stream << Colour(Colour::Warning) << std::string(CATCH_CONFIG_CONSOLE_WIDTH - 1, '=');
+        }
+        stream << '\n';
+    }
+    void ConsoleReporter::printSummaryDivider() {
+        stream << getLineOfChars<'-'>() << '\n';
+    }
+
+    void ConsoleReporter::printTestFilters() {
+        if (m_config->testSpec().hasFilters()) {
+            Colour guard(Colour::BrightYellow);
+            stream << "Filters: " << serializeFilters(m_config->getTestsOrTags()) << '\n';
+        }
+    }
+
+    CATCH_REGISTER_REPORTER("console", ConsoleReporter)
 
 } // end namespace Catch
 
@@ -16730,6 +16869,7 @@ CATCH_REGISTER_REPORTER("console", ConsoleReporter)
 #include <sstream>
 #include <ctime>
 #include <algorithm>
+#include <iomanip>
 
 namespace Catch {
 
@@ -16750,33 +16890,44 @@ namespace Catch {
 #endif
 
             char timeStamp[timeStampSize];
-            const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
+            const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
 #ifdef _MSC_VER
             std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
 #else
             std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
 #endif
-            return std::string(timeStamp);
+            return std::string(timeStamp, timeStampSize - 1);
         }
 
-        std::string fileNameTag(const std::vector<std::string> &tags) {
+        std::string fileNameTag(const std::vector<std::string>& tags) {
             auto it = std::find_if(begin(tags),
-                                   end(tags),
-                                   [] (std::string const& tag) {return tag.front() == '#'; });
+                end(tags),
+                [](std::string const& tag) {return tag.front() == '#'; });
             if (it != tags.end())
                 return it->substr(1);
             return std::string();
         }
+
+        // Formats the duration in seconds to 3 decimal places.
+        // This is done because some genius defined Maven Surefire schema
+        // in a way that only accepts 3 decimal places, and tools like
+        // Jenkins use that schema for validation JUnit reporter output.
+        std::string formatDuration(double seconds) {
+            ReusableStringStream rss;
+            rss << std::fixed << std::setprecision(3) << seconds;
+            return rss.str();
+        }
+
     } // anonymous namespace
 
-    JunitReporter::JunitReporter( ReporterConfig const& _config )
-        :   CumulativeReporterBase( _config ),
-            xml( _config.stream() )
-        {
-            m_reporterPrefs.shouldRedirectStdOut = true;
-            m_reporterPrefs.shouldReportAllAssertions = true;
-        }
+    JunitReporter::JunitReporter(ReporterConfig const& _config)
+        : CumulativeReporterBase(_config),
+        xml(_config.stream())
+    {
+        m_reporterPrefs.shouldRedirectStdOut = true;
+        m_reporterPrefs.shouldReportAllAssertions = true;
+    }
 
     JunitReporter::~JunitReporter() {}
 
@@ -16784,61 +16935,61 @@ namespace Catch {
         return "Reports test results in an XML format that looks like Ant's junitreport target";
     }
 
-    void JunitReporter::noMatchingTestCases( std::string const& /*spec*/ ) {}
+    void JunitReporter::noMatchingTestCases(std::string const& /*spec*/) {}
 
-    void JunitReporter::testRunStarting( TestRunInfo const& runInfo )  {
-        CumulativeReporterBase::testRunStarting( runInfo );
-        xml.startElement( "testsuites" );
+    void JunitReporter::testRunStarting(TestRunInfo const& runInfo) {
+        CumulativeReporterBase::testRunStarting(runInfo);
+        xml.startElement("testsuites");
     }
 
-    void JunitReporter::testGroupStarting( GroupInfo const& groupInfo ) {
+    void JunitReporter::testGroupStarting(GroupInfo const& groupInfo) {
         suiteTimer.start();
         stdOutForSuite.clear();
         stdErrForSuite.clear();
         unexpectedExceptions = 0;
-        CumulativeReporterBase::testGroupStarting( groupInfo );
+        CumulativeReporterBase::testGroupStarting(groupInfo);
     }
 
-    void JunitReporter::testCaseStarting( TestCaseInfo const& testCaseInfo ) {
+    void JunitReporter::testCaseStarting(TestCaseInfo const& testCaseInfo) {
         m_okToFail = testCaseInfo.okToFail();
     }
 
-    bool JunitReporter::assertionEnded( AssertionStats const& assertionStats ) {
-        if( assertionStats.assertionResult.getResultType() == ResultWas::ThrewException && !m_okToFail )
+    bool JunitReporter::assertionEnded(AssertionStats const& assertionStats) {
+        if (assertionStats.assertionResult.getResultType() == ResultWas::ThrewException && !m_okToFail)
             unexpectedExceptions++;
-        return CumulativeReporterBase::assertionEnded( assertionStats );
+        return CumulativeReporterBase::assertionEnded(assertionStats);
     }
 
-    void JunitReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
+    void JunitReporter::testCaseEnded(TestCaseStats const& testCaseStats) {
         stdOutForSuite += testCaseStats.stdOut;
         stdErrForSuite += testCaseStats.stdErr;
-        CumulativeReporterBase::testCaseEnded( testCaseStats );
+        CumulativeReporterBase::testCaseEnded(testCaseStats);
     }
 
-    void JunitReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
+    void JunitReporter::testGroupEnded(TestGroupStats const& testGroupStats) {
         double suiteTime = suiteTimer.getElapsedSeconds();
-        CumulativeReporterBase::testGroupEnded( testGroupStats );
-        writeGroup( *m_testGroups.back(), suiteTime );
+        CumulativeReporterBase::testGroupEnded(testGroupStats);
+        writeGroup(*m_testGroups.back(), suiteTime);
     }
 
     void JunitReporter::testRunEndedCumulative() {
         xml.endElement();
     }
 
-    void JunitReporter::writeGroup( TestGroupNode const& groupNode, double suiteTime ) {
-        XmlWriter::ScopedElement e = xml.scopedElement( "testsuite" );
+    void JunitReporter::writeGroup(TestGroupNode const& groupNode, double suiteTime) {
+        XmlWriter::ScopedElement e = xml.scopedElement("testsuite");
 
         TestGroupStats const& stats = groupNode.value;
-        xml.writeAttribute( "name", stats.groupInfo.name );
-        xml.writeAttribute( "errors", unexpectedExceptions );
-        xml.writeAttribute( "failures", stats.totals.assertions.failed-unexpectedExceptions );
-        xml.writeAttribute( "tests", stats.totals.assertions.total() );
-        xml.writeAttribute( "hostname", "tbd" ); // !TBD
-        if( m_config->showDurations() == ShowDurations::Never )
-            xml.writeAttribute( "time", "" );
+        xml.writeAttribute("name", stats.groupInfo.name);
+        xml.writeAttribute("errors", unexpectedExceptions);
+        xml.writeAttribute("failures", stats.totals.assertions.failed - unexpectedExceptions);
+        xml.writeAttribute("tests", stats.totals.assertions.total());
+        xml.writeAttribute("hostname", "tbd"); // !TBD
+        if (m_config->showDurations() == ShowDurations::Never)
+            xml.writeAttribute("time", "");
         else
-            xml.writeAttribute( "time", suiteTime );
-        xml.writeAttribute( "timestamp", getCurrentTimestamp() );
+            xml.writeAttribute("time", formatDuration(suiteTime));
+        xml.writeAttribute("timestamp", getCurrentTimestamp());
 
         // Write properties if there are any
         if (m_config->hasTestFilters() || m_config->rngSeed() != 0) {
@@ -16856,110 +17007,116 @@ namespace Catch {
         }
 
         // Write test cases
-        for( auto const& child : groupNode.children )
-            writeTestCase( *child );
+        for (auto const& child : groupNode.children)
+            writeTestCase(*child);
 
-        xml.scopedElement( "system-out" ).writeText( trim( stdOutForSuite ), XmlFormatting::Newline );
-        xml.scopedElement( "system-err" ).writeText( trim( stdErrForSuite ), XmlFormatting::Newline );
+        xml.scopedElement("system-out").writeText(trim(stdOutForSuite), XmlFormatting::Newline);
+        xml.scopedElement("system-err").writeText(trim(stdErrForSuite), XmlFormatting::Newline);
     }
 
-    void JunitReporter::writeTestCase( TestCaseNode const& testCaseNode ) {
+    void JunitReporter::writeTestCase(TestCaseNode const& testCaseNode) {
         TestCaseStats const& stats = testCaseNode.value;
 
         // All test cases have exactly one section - which represents the
         // test case itself. That section may have 0-n nested sections
-        assert( testCaseNode.children.size() == 1 );
+        assert(testCaseNode.children.size() == 1);
         SectionNode const& rootSection = *testCaseNode.children.front();
 
         std::string className = stats.testInfo.className;
 
-        if( className.empty() ) {
+        if (className.empty()) {
             className = fileNameTag(stats.testInfo.tags);
-            if ( className.empty() )
+            if (className.empty())
                 className = "global";
         }
 
-        if ( !m_config->name().empty() )
+        if (!m_config->name().empty())
             className = m_config->name() + "." + className;
 
-        writeSection( className, "", rootSection );
+        writeSection(className, "", rootSection, stats.testInfo.okToFail());
     }
 
-    void JunitReporter::writeSection(  std::string const& className,
-                        std::string const& rootName,
-                        SectionNode const& sectionNode ) {
-        std::string name = trim( sectionNode.stats.sectionInfo.name );
-        if( !rootName.empty() )
+    void JunitReporter::writeSection(std::string const& className,
+        std::string const& rootName,
+        SectionNode const& sectionNode,
+        bool testOkToFail) {
+        std::string name = trim(sectionNode.stats.sectionInfo.name);
+        if (!rootName.empty())
             name = rootName + '/' + name;
 
-        if( !sectionNode.assertions.empty() ||
+        if (!sectionNode.assertions.empty() ||
             !sectionNode.stdOut.empty() ||
-            !sectionNode.stdErr.empty() ) {
-            XmlWriter::ScopedElement e = xml.scopedElement( "testcase" );
-            if( className.empty() ) {
-                xml.writeAttribute( "classname", name );
-                xml.writeAttribute( "name", "root" );
+            !sectionNode.stdErr.empty()) {
+            XmlWriter::ScopedElement e = xml.scopedElement("testcase");
+            if (className.empty()) {
+                xml.writeAttribute("classname", name);
+                xml.writeAttribute("name", "root");
             }
             else {
-                xml.writeAttribute( "classname", className );
-                xml.writeAttribute( "name", name );
+                xml.writeAttribute("classname", className);
+                xml.writeAttribute("name", name);
             }
-            xml.writeAttribute( "time", ::Catch::Detail::stringify( sectionNode.stats.durationInSeconds ) );
+            xml.writeAttribute("time", formatDuration(sectionNode.stats.durationInSeconds));
             // This is not ideal, but it should be enough to mimic gtest's
             // junit output.
             // Ideally the JUnit reporter would also handle `skipTest`
             // events and write those out appropriately.
-            xml.writeAttribute( "status", "run" );
+            xml.writeAttribute("status", "run");
 
-            writeAssertions( sectionNode );
-
-            if( !sectionNode.stdOut.empty() )
-                xml.scopedElement( "system-out" ).writeText( trim( sectionNode.stdOut ), XmlFormatting::Newline );
-            if( !sectionNode.stdErr.empty() )
-                xml.scopedElement( "system-err" ).writeText( trim( sectionNode.stdErr ), XmlFormatting::Newline );
-        }
-        for( auto const& childNode : sectionNode.childSections )
-            if( className.empty() )
-                writeSection( name, "", *childNode );
-            else
-                writeSection( className, name, *childNode );
-    }
-
-    void JunitReporter::writeAssertions( SectionNode const& sectionNode ) {
-        for( auto const& assertion : sectionNode.assertions )
-            writeAssertion( assertion );
-    }
-
-    void JunitReporter::writeAssertion( AssertionStats const& stats ) {
-        AssertionResult const& result = stats.assertionResult;
-        if( !result.isOk() ) {
-            std::string elementName;
-            switch( result.getResultType() ) {
-                case ResultWas::ThrewException:
-                case ResultWas::FatalErrorCondition:
-                    elementName = "error";
-                    break;
-                case ResultWas::ExplicitFailure:
-                case ResultWas::ExpressionFailed:
-                case ResultWas::DidntThrowException:
-                    elementName = "failure";
-                    break;
-
-                // We should never see these here:
-                case ResultWas::Info:
-                case ResultWas::Warning:
-                case ResultWas::Ok:
-                case ResultWas::Unknown:
-                case ResultWas::FailureBit:
-                case ResultWas::Exception:
-                    elementName = "internalError";
-                    break;
+            if (sectionNode.stats.assertions.failedButOk) {
+                xml.scopedElement("skipped")
+                    .writeAttribute("message", "TEST_CASE tagged with !mayfail");
             }
 
-            XmlWriter::ScopedElement e = xml.scopedElement( elementName );
+            writeAssertions(sectionNode);
 
-            xml.writeAttribute( "message", result.getExpression() );
-            xml.writeAttribute( "type", result.getTestMacroName() );
+            if (!sectionNode.stdOut.empty())
+                xml.scopedElement("system-out").writeText(trim(sectionNode.stdOut), XmlFormatting::Newline);
+            if (!sectionNode.stdErr.empty())
+                xml.scopedElement("system-err").writeText(trim(sectionNode.stdErr), XmlFormatting::Newline);
+        }
+        for (auto const& childNode : sectionNode.childSections)
+            if (className.empty())
+                writeSection(name, "", *childNode, testOkToFail);
+            else
+                writeSection(className, name, *childNode, testOkToFail);
+    }
+
+    void JunitReporter::writeAssertions(SectionNode const& sectionNode) {
+        for (auto const& assertion : sectionNode.assertions)
+            writeAssertion(assertion);
+    }
+
+    void JunitReporter::writeAssertion(AssertionStats const& stats) {
+        AssertionResult const& result = stats.assertionResult;
+        if (!result.isOk()) {
+            std::string elementName;
+            switch (result.getResultType()) {
+            case ResultWas::ThrewException:
+            case ResultWas::FatalErrorCondition:
+                elementName = "error";
+                break;
+            case ResultWas::ExplicitFailure:
+            case ResultWas::ExpressionFailed:
+            case ResultWas::DidntThrowException:
+                elementName = "failure";
+                break;
+
+                // We should never see these here:
+            case ResultWas::Info:
+            case ResultWas::Warning:
+            case ResultWas::Ok:
+            case ResultWas::Unknown:
+            case ResultWas::FailureBit:
+            case ResultWas::Exception:
+                elementName = "internalError";
+                break;
+            }
+
+            XmlWriter::ScopedElement e = xml.scopedElement(elementName);
+
+            xml.writeAttribute("message", result.getExpression());
+            xml.writeAttribute("type", result.getTestMacroName());
 
             ReusableStringStream rss;
             if (stats.totals.assertions.total() > 0) {
@@ -16973,22 +17130,23 @@ namespace Catch {
                     rss << "with expansion:\n";
                     rss << Column(result.getExpandedExpression()).indent(2) << '\n';
                 }
-            } else {
+            }
+            else {
                 rss << '\n';
             }
 
-            if( !result.getMessage().empty() )
+            if (!result.getMessage().empty())
                 rss << result.getMessage() << '\n';
-            for( auto const& msg : stats.infoMessages )
-                if( msg.type == ResultWas::Info )
+            for (auto const& msg : stats.infoMessages)
+                if (msg.type == ResultWas::Info)
                     rss << msg.message << '\n';
 
             rss << "at " << result.getSourceInfo();
-            xml.writeText( rss.str(), XmlFormatting::Newline );
+            xml.writeText(rss.str(), XmlFormatting::Newline);
         }
     }
 
-    CATCH_REGISTER_REPORTER( "junit", JunitReporter )
+    CATCH_REGISTER_REPORTER("junit", JunitReporter)
 
 } // end namespace Catch
 // end catch_reporter_junit.cpp
@@ -17003,13 +17161,13 @@ namespace Catch {
         m_preferences.shouldReportAllAssertions = true;
     }
 
-    void ListeningReporter::addListener( IStreamingReporterPtr&& listener ) {
-        m_listeners.push_back( std::move( listener ) );
+    void ListeningReporter::addListener(IStreamingReporterPtr&& listener) {
+        m_listeners.push_back(std::move(listener));
     }
 
     void ListeningReporter::addReporter(IStreamingReporterPtr&& reporter) {
         assert(!m_reporter && "Listening reporter can wrap only 1 real reporter");
-        m_reporter = std::move( reporter );
+        m_reporter = std::move(reporter);
         m_preferences.shouldRedirectStdOut = m_reporter->getPreferences().shouldRedirectStdOut;
     }
 
@@ -17021,124 +17179,124 @@ namespace Catch {
         return std::set<Verbosity>{ };
     }
 
-    void ListeningReporter::noMatchingTestCases( std::string const& spec ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->noMatchingTestCases( spec );
+    void ListeningReporter::noMatchingTestCases(std::string const& spec) {
+        for (auto const& listener : m_listeners) {
+            listener->noMatchingTestCases(spec);
         }
-        m_reporter->noMatchingTestCases( spec );
+        m_reporter->noMatchingTestCases(spec);
     }
 
-    void ListeningReporter::reportInvalidArguments(std::string const&arg){
-        for ( auto const& listener : m_listeners ) {
-            listener->reportInvalidArguments( arg );
+    void ListeningReporter::reportInvalidArguments(std::string const& arg) {
+        for (auto const& listener : m_listeners) {
+            listener->reportInvalidArguments(arg);
         }
-        m_reporter->reportInvalidArguments( arg );
+        m_reporter->reportInvalidArguments(arg);
     }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    void ListeningReporter::benchmarkPreparing( std::string const& name ) {
-		for (auto const& listener : m_listeners) {
-			listener->benchmarkPreparing(name);
-		}
-		m_reporter->benchmarkPreparing(name);
-	}
-    void ListeningReporter::benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->benchmarkStarting( benchmarkInfo );
+    void ListeningReporter::benchmarkPreparing(std::string const& name) {
+        for (auto const& listener : m_listeners) {
+            listener->benchmarkPreparing(name);
         }
-        m_reporter->benchmarkStarting( benchmarkInfo );
+        m_reporter->benchmarkPreparing(name);
     }
-    void ListeningReporter::benchmarkEnded( BenchmarkStats<> const& benchmarkStats ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->benchmarkEnded( benchmarkStats );
+    void ListeningReporter::benchmarkStarting(BenchmarkInfo const& benchmarkInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->benchmarkStarting(benchmarkInfo);
         }
-        m_reporter->benchmarkEnded( benchmarkStats );
+        m_reporter->benchmarkStarting(benchmarkInfo);
+    }
+    void ListeningReporter::benchmarkEnded(BenchmarkStats<> const& benchmarkStats) {
+        for (auto const& listener : m_listeners) {
+            listener->benchmarkEnded(benchmarkStats);
+        }
+        m_reporter->benchmarkEnded(benchmarkStats);
     }
 
-	void ListeningReporter::benchmarkFailed( std::string const& error ) {
-		for (auto const& listener : m_listeners) {
-			listener->benchmarkFailed(error);
-		}
-		m_reporter->benchmarkFailed(error);
-	}
+    void ListeningReporter::benchmarkFailed(std::string const& error) {
+        for (auto const& listener : m_listeners) {
+            listener->benchmarkFailed(error);
+        }
+        m_reporter->benchmarkFailed(error);
+    }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    void ListeningReporter::testRunStarting( TestRunInfo const& testRunInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->testRunStarting( testRunInfo );
+    void ListeningReporter::testRunStarting(TestRunInfo const& testRunInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->testRunStarting(testRunInfo);
         }
-        m_reporter->testRunStarting( testRunInfo );
+        m_reporter->testRunStarting(testRunInfo);
     }
 
-    void ListeningReporter::testGroupStarting( GroupInfo const& groupInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->testGroupStarting( groupInfo );
+    void ListeningReporter::testGroupStarting(GroupInfo const& groupInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->testGroupStarting(groupInfo);
         }
-        m_reporter->testGroupStarting( groupInfo );
+        m_reporter->testGroupStarting(groupInfo);
     }
 
-    void ListeningReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->testCaseStarting( testInfo );
+    void ListeningReporter::testCaseStarting(TestCaseInfo const& testInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->testCaseStarting(testInfo);
         }
-        m_reporter->testCaseStarting( testInfo );
+        m_reporter->testCaseStarting(testInfo);
     }
 
-    void ListeningReporter::sectionStarting( SectionInfo const& sectionInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->sectionStarting( sectionInfo );
+    void ListeningReporter::sectionStarting(SectionInfo const& sectionInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->sectionStarting(sectionInfo);
         }
-        m_reporter->sectionStarting( sectionInfo );
+        m_reporter->sectionStarting(sectionInfo);
     }
 
-    void ListeningReporter::assertionStarting( AssertionInfo const& assertionInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->assertionStarting( assertionInfo );
+    void ListeningReporter::assertionStarting(AssertionInfo const& assertionInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->assertionStarting(assertionInfo);
         }
-        m_reporter->assertionStarting( assertionInfo );
+        m_reporter->assertionStarting(assertionInfo);
     }
 
     // The return value indicates if the messages buffer should be cleared:
-    bool ListeningReporter::assertionEnded( AssertionStats const& assertionStats ) {
-        for( auto const& listener : m_listeners ) {
-            static_cast<void>( listener->assertionEnded( assertionStats ) );
+    bool ListeningReporter::assertionEnded(AssertionStats const& assertionStats) {
+        for (auto const& listener : m_listeners) {
+            static_cast<void>(listener->assertionEnded(assertionStats));
         }
-        return m_reporter->assertionEnded( assertionStats );
+        return m_reporter->assertionEnded(assertionStats);
     }
 
-    void ListeningReporter::sectionEnded( SectionStats const& sectionStats ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->sectionEnded( sectionStats );
+    void ListeningReporter::sectionEnded(SectionStats const& sectionStats) {
+        for (auto const& listener : m_listeners) {
+            listener->sectionEnded(sectionStats);
         }
-        m_reporter->sectionEnded( sectionStats );
+        m_reporter->sectionEnded(sectionStats);
     }
 
-    void ListeningReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->testCaseEnded( testCaseStats );
+    void ListeningReporter::testCaseEnded(TestCaseStats const& testCaseStats) {
+        for (auto const& listener : m_listeners) {
+            listener->testCaseEnded(testCaseStats);
         }
-        m_reporter->testCaseEnded( testCaseStats );
+        m_reporter->testCaseEnded(testCaseStats);
     }
 
-    void ListeningReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->testGroupEnded( testGroupStats );
+    void ListeningReporter::testGroupEnded(TestGroupStats const& testGroupStats) {
+        for (auto const& listener : m_listeners) {
+            listener->testGroupEnded(testGroupStats);
         }
-        m_reporter->testGroupEnded( testGroupStats );
+        m_reporter->testGroupEnded(testGroupStats);
     }
 
-    void ListeningReporter::testRunEnded( TestRunStats const& testRunStats ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->testRunEnded( testRunStats );
+    void ListeningReporter::testRunEnded(TestRunStats const& testRunStats) {
+        for (auto const& listener : m_listeners) {
+            listener->testRunEnded(testRunStats);
         }
-        m_reporter->testRunEnded( testRunStats );
+        m_reporter->testRunEnded(testRunStats);
     }
 
-    void ListeningReporter::skipTest( TestCaseInfo const& testInfo ) {
-        for ( auto const& listener : m_listeners ) {
-            listener->skipTest( testInfo );
+    void ListeningReporter::skipTest(TestCaseInfo const& testInfo) {
+        for (auto const& listener : m_listeners) {
+            listener->skipTest(testInfo);
         }
-        m_reporter->skipTest( testInfo );
+        m_reporter->skipTest(testInfo);
     }
 
     bool ListeningReporter::isMulti() const {
@@ -17157,8 +17315,8 @@ namespace Catch {
 #endif
 
 namespace Catch {
-    XmlReporter::XmlReporter( ReporterConfig const& _config )
-    :   StreamingReporterBase( _config ),
+    XmlReporter::XmlReporter(ReporterConfig const& _config)
+        : StreamingReporterBase(_config),
         m_xml(_config.stream())
     {
         m_reporterPrefs.shouldRedirectStdOut = true;
@@ -17175,192 +17333,193 @@ namespace Catch {
         return std::string();
     }
 
-    void XmlReporter::writeSourceInfo( SourceLineInfo const& sourceInfo ) {
+    void XmlReporter::writeSourceInfo(SourceLineInfo const& sourceInfo) {
         m_xml
-            .writeAttribute( "filename", sourceInfo.file )
-            .writeAttribute( "line", sourceInfo.line );
+            .writeAttribute("filename", sourceInfo.file)
+            .writeAttribute("line", sourceInfo.line);
     }
 
-    void XmlReporter::noMatchingTestCases( std::string const& s ) {
-        StreamingReporterBase::noMatchingTestCases( s );
+    void XmlReporter::noMatchingTestCases(std::string const& s) {
+        StreamingReporterBase::noMatchingTestCases(s);
     }
 
-    void XmlReporter::testRunStarting( TestRunInfo const& testInfo ) {
-        StreamingReporterBase::testRunStarting( testInfo );
+    void XmlReporter::testRunStarting(TestRunInfo const& testInfo) {
+        StreamingReporterBase::testRunStarting(testInfo);
         std::string stylesheetRef = getStylesheetRef();
-        if( !stylesheetRef.empty() )
-            m_xml.writeStylesheetRef( stylesheetRef );
-        m_xml.startElement( "Catch" );
-        if( !m_config->name().empty() )
-            m_xml.writeAttribute( "name", m_config->name() );
+        if (!stylesheetRef.empty())
+            m_xml.writeStylesheetRef(stylesheetRef);
+        m_xml.startElement("Catch");
+        if (!m_config->name().empty())
+            m_xml.writeAttribute("name", m_config->name());
         if (m_config->testSpec().hasFilters())
-            m_xml.writeAttribute( "filters", serializeFilters( m_config->getTestsOrTags() ) );
-        if( m_config->rngSeed() != 0 )
-            m_xml.scopedElement( "Randomness" )
-                .writeAttribute( "seed", m_config->rngSeed() );
+            m_xml.writeAttribute("filters", serializeFilters(m_config->getTestsOrTags()));
+        if (m_config->rngSeed() != 0)
+            m_xml.scopedElement("Randomness")
+            .writeAttribute("seed", m_config->rngSeed());
     }
 
-    void XmlReporter::testGroupStarting( GroupInfo const& groupInfo ) {
-        StreamingReporterBase::testGroupStarting( groupInfo );
-        m_xml.startElement( "Group" )
-            .writeAttribute( "name", groupInfo.name );
+    void XmlReporter::testGroupStarting(GroupInfo const& groupInfo) {
+        StreamingReporterBase::testGroupStarting(groupInfo);
+        m_xml.startElement("Group")
+            .writeAttribute("name", groupInfo.name);
     }
 
-    void XmlReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
+    void XmlReporter::testCaseStarting(TestCaseInfo const& testInfo) {
         StreamingReporterBase::testCaseStarting(testInfo);
-        m_xml.startElement( "TestCase" )
-            .writeAttribute( "name", trim( testInfo.name ) )
-            .writeAttribute( "description", testInfo.description )
-            .writeAttribute( "tags", testInfo.tagsAsString() );
+        m_xml.startElement("TestCase")
+            .writeAttribute("name", trim(testInfo.name))
+            .writeAttribute("description", testInfo.description)
+            .writeAttribute("tags", testInfo.tagsAsString());
 
-        writeSourceInfo( testInfo.lineInfo );
+        writeSourceInfo(testInfo.lineInfo);
 
-        if ( m_config->showDurations() == ShowDurations::Always )
+        if (m_config->showDurations() == ShowDurations::Always)
             m_testCaseTimer.start();
         m_xml.ensureTagClosed();
     }
 
-    void XmlReporter::sectionStarting( SectionInfo const& sectionInfo ) {
-        StreamingReporterBase::sectionStarting( sectionInfo );
-        if( m_sectionDepth++ > 0 ) {
-            m_xml.startElement( "Section" )
-                .writeAttribute( "name", trim( sectionInfo.name ) );
-            writeSourceInfo( sectionInfo.lineInfo );
+    void XmlReporter::sectionStarting(SectionInfo const& sectionInfo) {
+        StreamingReporterBase::sectionStarting(sectionInfo);
+        if (m_sectionDepth++ > 0) {
+            m_xml.startElement("Section")
+                .writeAttribute("name", trim(sectionInfo.name));
+            writeSourceInfo(sectionInfo.lineInfo);
             m_xml.ensureTagClosed();
         }
     }
 
-    void XmlReporter::assertionStarting( AssertionInfo const& ) { }
+    void XmlReporter::assertionStarting(AssertionInfo const&) { }
 
-    bool XmlReporter::assertionEnded( AssertionStats const& assertionStats ) {
+    bool XmlReporter::assertionEnded(AssertionStats const& assertionStats) {
 
         AssertionResult const& result = assertionStats.assertionResult;
 
         bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
 
-        if( includeResults || result.getResultType() == ResultWas::Warning ) {
+        if (includeResults || result.getResultType() == ResultWas::Warning) {
             // Print any info messages in <Info> tags.
-            for( auto const& msg : assertionStats.infoMessages ) {
-                if( msg.type == ResultWas::Info && includeResults ) {
-                    m_xml.scopedElement( "Info" )
-                            .writeText( msg.message );
-                } else if ( msg.type == ResultWas::Warning ) {
-                    m_xml.scopedElement( "Warning" )
-                            .writeText( msg.message );
+            for (auto const& msg : assertionStats.infoMessages) {
+                if (msg.type == ResultWas::Info && includeResults) {
+                    m_xml.scopedElement("Info")
+                        .writeText(msg.message);
+                }
+                else if (msg.type == ResultWas::Warning) {
+                    m_xml.scopedElement("Warning")
+                        .writeText(msg.message);
                 }
             }
         }
 
         // Drop out if result was successful but we're not printing them.
-        if( !includeResults && result.getResultType() != ResultWas::Warning )
+        if (!includeResults && result.getResultType() != ResultWas::Warning)
             return true;
 
         // Print the expression if there is one.
-        if( result.hasExpression() ) {
-            m_xml.startElement( "Expression" )
-                .writeAttribute( "success", result.succeeded() )
-                .writeAttribute( "type", result.getTestMacroName() );
+        if (result.hasExpression()) {
+            m_xml.startElement("Expression")
+                .writeAttribute("success", result.succeeded())
+                .writeAttribute("type", result.getTestMacroName());
 
-            writeSourceInfo( result.getSourceInfo() );
+            writeSourceInfo(result.getSourceInfo());
 
-            m_xml.scopedElement( "Original" )
-                .writeText( result.getExpression() );
-            m_xml.scopedElement( "Expanded" )
-                .writeText( result.getExpandedExpression() );
+            m_xml.scopedElement("Original")
+                .writeText(result.getExpression());
+            m_xml.scopedElement("Expanded")
+                .writeText(result.getExpandedExpression());
         }
 
         // And... Print a result applicable to each result type.
-        switch( result.getResultType() ) {
-            case ResultWas::ThrewException:
-                m_xml.startElement( "Exception" );
-                writeSourceInfo( result.getSourceInfo() );
-                m_xml.writeText( result.getMessage() );
-                m_xml.endElement();
-                break;
-            case ResultWas::FatalErrorCondition:
-                m_xml.startElement( "FatalErrorCondition" );
-                writeSourceInfo( result.getSourceInfo() );
-                m_xml.writeText( result.getMessage() );
-                m_xml.endElement();
-                break;
-            case ResultWas::Info:
-                m_xml.scopedElement( "Info" )
-                    .writeText( result.getMessage() );
-                break;
-            case ResultWas::Warning:
-                // Warning will already have been written
-                break;
-            case ResultWas::ExplicitFailure:
-                m_xml.startElement( "Failure" );
-                writeSourceInfo( result.getSourceInfo() );
-                m_xml.writeText( result.getMessage() );
-                m_xml.endElement();
-                break;
-            default:
-                break;
+        switch (result.getResultType()) {
+        case ResultWas::ThrewException:
+            m_xml.startElement("Exception");
+            writeSourceInfo(result.getSourceInfo());
+            m_xml.writeText(result.getMessage());
+            m_xml.endElement();
+            break;
+        case ResultWas::FatalErrorCondition:
+            m_xml.startElement("FatalErrorCondition");
+            writeSourceInfo(result.getSourceInfo());
+            m_xml.writeText(result.getMessage());
+            m_xml.endElement();
+            break;
+        case ResultWas::Info:
+            m_xml.scopedElement("Info")
+                .writeText(result.getMessage());
+            break;
+        case ResultWas::Warning:
+            // Warning will already have been written
+            break;
+        case ResultWas::ExplicitFailure:
+            m_xml.startElement("Failure");
+            writeSourceInfo(result.getSourceInfo());
+            m_xml.writeText(result.getMessage());
+            m_xml.endElement();
+            break;
+        default:
+            break;
         }
 
-        if( result.hasExpression() )
+        if (result.hasExpression())
             m_xml.endElement();
 
         return true;
     }
 
-    void XmlReporter::sectionEnded( SectionStats const& sectionStats ) {
-        StreamingReporterBase::sectionEnded( sectionStats );
-        if( --m_sectionDepth > 0 ) {
-            XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResults" );
-            e.writeAttribute( "successes", sectionStats.assertions.passed );
-            e.writeAttribute( "failures", sectionStats.assertions.failed );
-            e.writeAttribute( "expectedFailures", sectionStats.assertions.failedButOk );
+    void XmlReporter::sectionEnded(SectionStats const& sectionStats) {
+        StreamingReporterBase::sectionEnded(sectionStats);
+        if (--m_sectionDepth > 0) {
+            XmlWriter::ScopedElement e = m_xml.scopedElement("OverallResults");
+            e.writeAttribute("successes", sectionStats.assertions.passed);
+            e.writeAttribute("failures", sectionStats.assertions.failed);
+            e.writeAttribute("expectedFailures", sectionStats.assertions.failedButOk);
 
-            if ( m_config->showDurations() == ShowDurations::Always )
-                e.writeAttribute( "durationInSeconds", sectionStats.durationInSeconds );
+            if (m_config->showDurations() == ShowDurations::Always)
+                e.writeAttribute("durationInSeconds", sectionStats.durationInSeconds);
 
             m_xml.endElement();
         }
     }
 
-    void XmlReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
-        StreamingReporterBase::testCaseEnded( testCaseStats );
-        XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResult" );
-        e.writeAttribute( "success", testCaseStats.totals.assertions.allOk() );
+    void XmlReporter::testCaseEnded(TestCaseStats const& testCaseStats) {
+        StreamingReporterBase::testCaseEnded(testCaseStats);
+        XmlWriter::ScopedElement e = m_xml.scopedElement("OverallResult");
+        e.writeAttribute("success", testCaseStats.totals.assertions.allOk());
 
-        if ( m_config->showDurations() == ShowDurations::Always )
-            e.writeAttribute( "durationInSeconds", m_testCaseTimer.getElapsedSeconds() );
+        if (m_config->showDurations() == ShowDurations::Always)
+            e.writeAttribute("durationInSeconds", m_testCaseTimer.getElapsedSeconds());
 
-        if( !testCaseStats.stdOut.empty() )
-            m_xml.scopedElement( "StdOut" ).writeText( trim( testCaseStats.stdOut ), XmlFormatting::Newline );
-        if( !testCaseStats.stdErr.empty() )
-            m_xml.scopedElement( "StdErr" ).writeText( trim( testCaseStats.stdErr ), XmlFormatting::Newline );
+        if (!testCaseStats.stdOut.empty())
+            m_xml.scopedElement("StdOut").writeText(trim(testCaseStats.stdOut), XmlFormatting::Newline);
+        if (!testCaseStats.stdErr.empty())
+            m_xml.scopedElement("StdErr").writeText(trim(testCaseStats.stdErr), XmlFormatting::Newline);
 
         m_xml.endElement();
     }
 
-    void XmlReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
-        StreamingReporterBase::testGroupEnded( testGroupStats );
+    void XmlReporter::testGroupEnded(TestGroupStats const& testGroupStats) {
+        StreamingReporterBase::testGroupEnded(testGroupStats);
         // TODO: Check testGroupStats.aborting and act accordingly.
-        m_xml.scopedElement( "OverallResults" )
-            .writeAttribute( "successes", testGroupStats.totals.assertions.passed )
-            .writeAttribute( "failures", testGroupStats.totals.assertions.failed )
-            .writeAttribute( "expectedFailures", testGroupStats.totals.assertions.failedButOk );
-        m_xml.scopedElement( "OverallResultsCases")
-            .writeAttribute( "successes", testGroupStats.totals.testCases.passed )
-            .writeAttribute( "failures", testGroupStats.totals.testCases.failed )
-            .writeAttribute( "expectedFailures", testGroupStats.totals.testCases.failedButOk );
+        m_xml.scopedElement("OverallResults")
+            .writeAttribute("successes", testGroupStats.totals.assertions.passed)
+            .writeAttribute("failures", testGroupStats.totals.assertions.failed)
+            .writeAttribute("expectedFailures", testGroupStats.totals.assertions.failedButOk);
+        m_xml.scopedElement("OverallResultsCases")
+            .writeAttribute("successes", testGroupStats.totals.testCases.passed)
+            .writeAttribute("failures", testGroupStats.totals.testCases.failed)
+            .writeAttribute("expectedFailures", testGroupStats.totals.testCases.failedButOk);
         m_xml.endElement();
     }
 
-    void XmlReporter::testRunEnded( TestRunStats const& testRunStats ) {
-        StreamingReporterBase::testRunEnded( testRunStats );
-        m_xml.scopedElement( "OverallResults" )
-            .writeAttribute( "successes", testRunStats.totals.assertions.passed )
-            .writeAttribute( "failures", testRunStats.totals.assertions.failed )
-            .writeAttribute( "expectedFailures", testRunStats.totals.assertions.failedButOk );
-        m_xml.scopedElement( "OverallResultsCases")
-            .writeAttribute( "successes", testRunStats.totals.testCases.passed )
-            .writeAttribute( "failures", testRunStats.totals.testCases.failed )
-            .writeAttribute( "expectedFailures", testRunStats.totals.testCases.failedButOk );
+    void XmlReporter::testRunEnded(TestRunStats const& testRunStats) {
+        StreamingReporterBase::testRunEnded(testRunStats);
+        m_xml.scopedElement("OverallResults")
+            .writeAttribute("successes", testRunStats.totals.assertions.passed)
+            .writeAttribute("failures", testRunStats.totals.assertions.failed)
+            .writeAttribute("expectedFailures", testRunStats.totals.assertions.failedButOk);
+        m_xml.scopedElement("OverallResultsCases")
+            .writeAttribute("successes", testRunStats.totals.testCases.passed)
+            .writeAttribute("failures", testRunStats.totals.testCases.failed)
+            .writeAttribute("expectedFailures", testRunStats.totals.testCases.failedButOk);
         m_xml.endElement();
     }
 
@@ -17370,7 +17529,7 @@ namespace Catch {
             .writeAttribute("name", name);
     }
 
-    void XmlReporter::benchmarkStarting(BenchmarkInfo const &info) {
+    void XmlReporter::benchmarkStarting(BenchmarkInfo const& info) {
         m_xml.writeAttribute("samples", info.samples)
             .writeAttribute("resamples", info.resamples)
             .writeAttribute("iterations", info.iterations)
@@ -17402,14 +17561,14 @@ namespace Catch {
         m_xml.endElement();
     }
 
-    void XmlReporter::benchmarkFailed(std::string const &error) {
+    void XmlReporter::benchmarkFailed(std::string const& error) {
         m_xml.scopedElement("failed").
             writeAttribute("message", error);
         m_xml.endElement();
     }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    CATCH_REGISTER_REPORTER( "xml", XmlReporter )
+    CATCH_REGISTER_REPORTER("xml", XmlReporter)
 
 } // end namespace Catch
 
@@ -17434,27 +17593,35 @@ namespace Catch {
 
 #ifndef __OBJC__
 
-#if defined(CATCH_CONFIG_WCHAR) && defined(CATCH_PLATFORM_WINDOWS) && defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
-// Standard C/C++ Win32 Unicode wmain entry point
-extern "C" int wmain (int argc, wchar_t * argv[], wchar_t * []) {
+#ifndef CATCH_INTERNAL_CDECL
+#ifdef _MSC_VER
+#define CATCH_INTERNAL_CDECL __cdecl
 #else
-// Standard C/C++ main entry point
-int main (int argc, char * argv[]) {
+#define CATCH_INTERNAL_CDECL
+#endif
 #endif
 
-    return Catch::Session().run( argc, argv );
+#if defined(CATCH_CONFIG_WCHAR) && defined(CATCH_PLATFORM_WINDOWS) && defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
+// Standard C/C++ Win32 Unicode wmain entry point
+extern "C" int CATCH_INTERNAL_CDECL wmain(int argc, wchar_t* argv[], wchar_t* []) {
+#else
+// Standard C/C++ main entry point
+int CATCH_INTERNAL_CDECL main(int argc, char* argv[]) {
+#endif
+
+    return Catch::Session().run(argc, argv);
 }
 
 #else // __OBJC__
 
 // Objective-C entry point
-int main (int argc, char * const argv[]) {
+int main(int argc, char* const argv[]) {
 #if !CATCH_ARC_ENABLED
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc]init];
 #endif
 
     Catch::registerTestMethods();
-    int result = Catch::Session().run( argc, (char**)argv );
+    int result = Catch::Session().run(argc, (char**)argv);
 
 #if !CATCH_ARC_ENABLED
     [pool drain];
@@ -17567,9 +17734,9 @@ int main (int argc, char * const argv[]) {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 #define CATCH_BENCHMARK(...) \
-    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
+    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
 #define CATCH_BENCHMARK_ADVANCED(name) \
-    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), name)
+    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), name)
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 // If CATCH_CONFIG_PREFIX_ALL is not defined then the CATCH_ prefix is not required
@@ -17671,9 +17838,9 @@ int main (int argc, char * const argv[]) {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 #define BENCHMARK(...) \
-    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
+    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
 #define BENCHMARK_ADVANCED(name) \
-    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), name)
+    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), name)
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 using Catch::Detail::Approx;
@@ -17720,8 +17887,8 @@ using Catch::Detail::Approx;
 #define CATCH_WARN( msg )          (void)(0)
 #define CATCH_CAPTURE( msg )       (void)(0)
 
-#define CATCH_TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
-#define CATCH_TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
+#define CATCH_TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 #define CATCH_METHOD_AS_TEST_CASE( method, ... )
 #define CATCH_REGISTER_TEST_CASE( Function, ... ) (void)(0)
 #define CATCH_SECTION( ... )
@@ -17730,7 +17897,7 @@ using Catch::Detail::Approx;
 #define CATCH_FAIL_CHECK( ... ) (void)(0)
 #define CATCH_SUCCEED( ... ) (void)(0)
 
-#define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define CATCH_TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(__VA_ARGS__)
@@ -17753,8 +17920,8 @@ using Catch::Detail::Approx;
 #endif
 
 // "BDD-style" convenience wrappers
-#define CATCH_SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
-#define CATCH_SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), className )
+#define CATCH_SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
+#define CATCH_SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), className )
 #define CATCH_GIVEN( desc )
 #define CATCH_AND_GIVEN( desc )
 #define CATCH_WHEN( desc )
@@ -17802,10 +17969,10 @@ using Catch::Detail::Approx;
 #define INFO( msg ) (void)(0)
 #define UNSCOPED_INFO( msg ) (void)(0)
 #define WARN( msg ) (void)(0)
-#define CAPTURE( msg ) (void)(0)
+#define CAPTURE( ... ) (void)(0)
 
-#define TEST_CASE( ... )  INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
-#define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define TEST_CASE( ... )  INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
+#define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 #define METHOD_AS_TEST_CASE( method, ... )
 #define REGISTER_TEST_CASE( Function, ... ) (void)(0)
 #define SECTION( ... )
@@ -17813,7 +17980,7 @@ using Catch::Detail::Approx;
 #define FAIL( ... ) (void)(0)
 #define FAIL_CHECK( ... ) (void)(0)
 #define SUCCEED( ... ) (void)(0)
-#define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(__VA_ARGS__)
@@ -17843,8 +18010,8 @@ using Catch::Detail::Approx;
 #define CATCH_TRANSLATE_EXCEPTION( signature ) INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( INTERNAL_CATCH_UNIQUE_NAME( catch_internal_ExceptionTranslator ), signature )
 
 // "BDD-style" convenience wrappers
-#define SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ) )
-#define SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), className )
+#define SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ) )
+#define SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), className )
 
 #define GIVEN( desc )
 #define AND_GIVEN( desc )

--- a/UnitTests/linux/TestDetourx86hotpatch.cpp
+++ b/UnitTests/linux/TestDetourx86hotpatch.cpp
@@ -1,0 +1,1 @@
+// not tested on linux

--- a/UnitTests/windows/TestDetourx86hotpatch.cpp
+++ b/UnitTests/windows/TestDetourx86hotpatch.cpp
@@ -1,0 +1,68 @@
+#include <Catch.hpp>
+#include "polyhook2/Detour/x86HotpatchDetour.hpp"
+
+#include "polyhook2/Tests/TestEffectTracker.hpp"
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+/**These tests can spontaneously fail if the compiler desides to optimize away
+the handler or inline the function. NOINLINE attempts to fix the latter, the former
+is out of our control but typically returning volatile things, volatile locals, and a
+printf inside the body can mitigate this significantly. Do serious checking in debug
+or releasewithdebinfo mode (relwithdebinfo optimizes sliiiightly less)**/
+
+EffectTracker effectsHotpatch;
+
+
+#include <cstdlib>
+
+uint64_t hotpatchHookMallocTramp = NULL;
+HOOK_CALLBACK(&malloc, h_hotpatchHookMalloc, { // NOLINT(cert-err58-cpp)
+    effectsHotpatch.PeakEffect().trigger();
+    return PLH::FnCast(hotpatchHookMallocTramp, &malloc)(_args...);
+    });
+
+#include <WinSock2.h>
+
+#pragma comment(lib, "Ws2_32.lib")
+
+uint64_t hotpatchHookRecvTramp = NULL;
+HOOK_CALLBACK(&recv, h_hotpatchHookRecv, { // NOLINT(cert-err58-cpp)
+    return PLH::FnCast(hotpatchHookRecvTramp, &recv)(_args...);
+    });
+
+typedef void(*PKNORMAL_ROUTINE)(void* NormalContext, void* SystemArgument1, void* SystemArgument2);
+typedef unsigned long(__stdcall* tNtQueueApcThread)(void* ThreadHandle, PKNORMAL_ROUTINE ApcRoutine, void* NormalContext, void* SystemArgument1, void* SystemArgument2);
+
+uint64_t hotpatchHkNtQueueapcThread = NULL;
+tNtQueueApcThread pHotpatchNtQueueApcthread = (tNtQueueApcThread)GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQueueApcThread");
+HOOK_CALLBACK(pHotpatchNtQueueApcthread, h_hotpatchNtQueueapcThread, { // NOLINT(cert-err58-cpp)
+    std::cout << "hkNtQueueApcThread!" << std::endl;
+
+    return PLH::FnCast(hotpatchHkNtQueueapcThread, pHotpatchNtQueueApcthread)(_args...);
+    });
+
+TEST_CASE("Testing x86 hotpatch detours", "[x86HotpatchDetour][ADetour]") {
+    SECTION("hook malloc") {
+        PLH::x86HotpatchDetour detour((uint64_t)&malloc, (uint64_t)h_hotpatchHookMalloc, &hotpatchHookMallocTramp);
+        effectsHotpatch.PushEffect(); // catch does some allocations, push effect first so peak works
+        REQUIRE(detour.hook() == true);
+
+        void* pMem = malloc(16);
+        free(pMem);
+        bool unHookRet = detour.unHook(); // unhook so we can popeffect safely w/o catch allocation happening again
+        REQUIRE(unHookRet == true);
+        REQUIRE(effectsHotpatch.PopEffect().didExecute());
+    }
+
+    SECTION("hook recv") {
+        PLH::x86HotpatchDetour detour((uint64_t)&recv, (uint64_t)h_hotpatchHookRecv, &hotpatchHookRecvTramp);
+        REQUIRE(detour.hook() == true);
+    }
+
+    SECTION("queue apc thread should fail due to too narrow space") {
+        PLH::x86HotpatchDetour detour((uint64_t)pHotpatchNtQueueApcthread, (uint64_t)h_hotpatchNtQueueapcThread, &hotpatchHkNtQueueapcThread);
+        effectsHotpatch.PushEffect(); // catch does some allocations, push effect first so peak works
+        REQUIRE(detour.hook() == false);  
+    }
+}

--- a/polyhook2/Detour/ADetour.hpp
+++ b/polyhook2/Detour/ADetour.hpp
@@ -88,6 +88,8 @@ protected:
     If end of function is encountered before this condition an empty optional is returned. Returns instructions in the range start to adjusted end**/
     static std::optional<insts_t> calcNearestSz(const insts_t& functionInsts, uint64_t minSz, uint64_t& roundedSz);
 
+    static std::optional<insts_t> calcNearestSzForHotpatch(const insts_t& functionInsts, uint64_t minSz, uint64_t& roundedSz);
+
     /**If function starts with a jump follow it until the first non-jump instruction, recursively. This handles already hooked functions
     and also compilers that emit jump tables on function call. Returns true if resolution was successful (nothing to resolve, or resolution worked),
     false if resolution failed.**/

--- a/polyhook2/Detour/x86Detour.hpp
+++ b/polyhook2/Detour/x86Detour.hpp
@@ -25,6 +25,8 @@ public:
 
     Mode getArchType() const override;
 
+    static uint8_t getJmpSize();
+
 protected:
     bool makeTrampoline(insts_t& prologue, insts_t& trampolineOut);
 };

--- a/polyhook2/Detour/x86HotpatchDetour.hpp
+++ b/polyhook2/Detour/x86HotpatchDetour.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "polyhook2/PolyHookOs.hpp"
+#include "polyhook2/Detour/ADetour.hpp"
+#include "polyhook2/Enums.hpp"
+#include "polyhook2/Instruction.hpp"
+#include "polyhook2/ZydisDisassembler.hpp"
+#include "polyhook2/ErrorLog.hpp"
+#include "polyhook2/MemProtector.hpp"
+
+using namespace std::placeholders;
+
+namespace PLH {
+
+class x86HotpatchDetour : public Detour {
+public:
+    x86HotpatchDetour(uint64_t fnAddress, uint64_t fnCallback, uint64_t* userTrampVar);
+
+    virtual ~x86HotpatchDetour() = default;
+
+    virtual bool hook() override;
+
+    virtual bool unHook() override;
+
+    virtual bool reHook() override;
+
+    Mode getArchType() const override;
+
+    uint8_t getJmpSize() const;
+
+    uint8_t getShortJmpSize() const;
+
+protected:
+
+    uint64_t m_addressInAlignArea;   // 5 byte jmp location
+
+    insts_t m_originalInstsOnFnAddress; // will be overwritten by 2 byte short jump
+    insts_t m_hookInstsOnFnAddress;
+    uint32_t m_hookSizeOnFnAddress;
+    uint16_t m_nopProlOffsetOnFnAddress;
+    uint16_t m_nopSizeOnFnAddress;
+
+    bool makeTrampoline(insts_t& prologue, insts_t& trampolineOut);
+};
+
+}

--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -172,6 +172,28 @@ public:
 		return m_mnemonic;
 	}
 
+	/** Set mnemonic from zydis **/
+	void setMnemonicZydis(ZydisMnemonic mnemonic)
+	{
+		m_mnemonic_zydis = mnemonic;
+	}
+
+	/** Get previous recorded zydis mnemonic **/
+	ZydisMnemonic getMnemonicZydis() const
+	{
+		return m_mnemonic_zydis;
+	}
+
+	void setIsNoOp(bool value)
+	{
+		m_isNoOp = value;
+	}
+
+	bool getIsNoOp() const
+	{
+		return m_isNoOp;
+	}
+
 	/**Get symbol name and parameters**/
 	std::string getFullName() const {
 		return m_mnemonic + " " + m_opStr;
@@ -338,6 +360,8 @@ private:
 	std::vector<uint8_t> m_bytes;    // All the raw bytes of this instruction
 	std::vector<OperandType> m_operands; // Types of all instruction operands
 	std::string          m_mnemonic;
+	ZydisMnemonic        m_mnemonic_zydis;
+	bool                 m_isNoOp;  // Does this instruction doing non-operation
 	std::string          m_opStr;
 
 	Mode m_mode;
@@ -472,6 +496,17 @@ inline PLH::insts_t makex86Jmp(const uint64_t address, const uint64_t destinatio
 	std::vector<uint8_t> bytes(5);
 	bytes[0] = 0xE9;
 	memcpy(&bytes[1], &disp.Relative, 4);
+
+	return { Instruction(address, disp, 1, true, false, bytes, "jmp", PLH::int_to_hex(destination), Mode::x86) };
+}
+
+inline PLH::insts_t makex86ShortJmp(const uint64_t address, const uint64_t destination) {
+	Instruction::Displacement disp{ 0 };
+	disp.Relative = Instruction::calculateRelativeDisplacement<int32_t>(address, destination, 2);
+
+	std::vector<uint8_t> bytes(2);
+	bytes[0] = 0xEB;
+	bytes[1] = static_cast<uint8_t>(disp.Relative);
 
 	return { Instruction(address, disp, 1, true, false, bytes, "jmp", PLH::int_to_hex(destination), Mode::x86) };
 }

--- a/polyhook2/ZydisDisassembler.hpp
+++ b/polyhook2/ZydisDisassembler.hpp
@@ -18,6 +18,8 @@ public:
 	virtual ~ZydisDisassembler();
 
 	std::vector<PLH::Instruction> disassemble(uint64_t firstInstruction, uint64_t start, uint64_t end, const MemAccessor& accessor);
+	std::optional<PLH::Instruction> disassemble_one_inst(uint64_t firstInstruction, const MemAccessor& accessor);
+	std::vector<PLH::Instruction> disassemble_backward_until_prev_func_end(uint64_t firstInstruction, const MemAccessor& accessor);
 
     // TODO: Move to accessor
 	static void writeEncoding(const PLH::insts_t& instructions, const MemAccessor& accessor) {
@@ -118,6 +120,8 @@ protected:
 	bool getOpStr(ZydisDecodedInstruction* pInstruction, const ZydisDecodedOperand* decoded_operands, uint64_t addr, std::string* pOpStrOut);
 
 	void setDisplacementFields(PLH::Instruction& inst, const ZydisDecodedInstruction* zydisInst, const ZydisDecodedOperand* operands) const;
+
+	void setNoOpField(PLH::Instruction& inst, const ZydisDecodedInstruction* zydisInst, const ZydisDecodedOperand* operands) const;
 
 	typename branch_map_t::mapped_type& updateBranchMap(uint64_t key, const Instruction& new_val) {
 		auto it = m_branchMap.find(key);

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -51,6 +51,31 @@ std::optional<insts_t> Detour::calcNearestSz(
     return std::nullopt;
 }
 
+std::optional<insts_t> Detour::calcNearestSzForHotpatch(
+    const insts_t& functionInsts,
+    const uint64_t prolOvrwStartOffset,
+    uint64_t& prolOvrwEndOffset
+) {
+    uint64_t prolLen = 0;
+    insts_t instructionsInRange;
+
+    // count instructions until at least length needed
+    for (const auto& inst : functionInsts) {
+        prolLen += inst.size();
+        instructionsInRange.push_back(inst);
+
+        if (prolLen >= prolOvrwStartOffset)
+            break;
+    }
+
+    prolOvrwEndOffset = prolLen;
+    if (prolLen >= prolOvrwStartOffset) {
+        return instructionsInRange;
+    }
+
+    return std::nullopt;
+}
+
 bool Detour::followJmp(insts_t& functionInsts, const uint8_t curDepth) { // NOLINT(misc-no-recursion)
     if (functionInsts.empty()) {
         Log::log("Couldn't decompile instructions at followed jmp", ErrorLevel::WARN);

--- a/sources/ILCallback.cpp
+++ b/sources/ILCallback.cpp
@@ -165,7 +165,7 @@ uint64_t PLH::ILCallback::getJitFunc(const asmjit::FuncSignature& sig, const asm
 	asmjit::InvokeNode* invokeNode;
 	cc.invoke(&invokeNode,
 		(uint64_t)callback,
-		asmjit::FuncSignatureT<void, Parameters*, uint8_t, ReturnValue*>()
+		asmjit::FuncSignature::build<void, Parameters*, uint8_t, ReturnValue*>()
 	);
 
 	// call to user provided function (use ABI of host compiler)

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -12,7 +12,7 @@ Mode x86Detour::getArchType() const {
     return Mode::x86;
 }
 
-uint8_t getJmpSize() {
+uint8_t x86Detour::getJmpSize() {
     return 5;
 }
 

--- a/sources/x86HotpatchDetour.cpp
+++ b/sources/x86HotpatchDetour.cpp
@@ -1,0 +1,292 @@
+#include "polyhook2/Detour/x86HotpatchDetour.hpp"
+
+#include <cassert>
+
+namespace PLH {
+
+	x86HotpatchDetour::x86HotpatchDetour(const uint64_t fnAddress, const uint64_t fnCallback, uint64_t* userTrampVar)
+    : Detour(fnAddress, fnCallback, userTrampVar, getArchType()) {}
+
+Mode x86HotpatchDetour::getArchType() const {
+    return Mode::x86;
+}
+
+uint8_t x86HotpatchDetour::getJmpSize() const {
+    return 5;
+}
+
+uint8_t x86HotpatchDetour::getShortJmpSize() const {
+    return 2;
+}
+
+bool x86HotpatchDetour::hook() {
+    Log::log("x86 hotpatch detour is assuming the very beginning of a function is passed in", ErrorLevel::WARN);
+    Log::log("m_fnAddress: " + int_to_hex(m_fnAddress) + "\n", ErrorLevel::INFO);
+	
+    insts_t orig_insts = m_disasm.disassemble(m_fnAddress, m_fnAddress, m_fnAddress+100, *this);
+
+    Log::log("passed in original function:\n" + instsToStr(orig_insts) + "\n", ErrorLevel::INFO);
+    if (orig_insts.empty()) {
+        Log::log("Disassembler unable to decode any valid instructions at m_fnAddress", ErrorLevel::SEV);
+        return false;
+    }
+
+    if (!followJmp(orig_insts)) {
+        Log::log("Prologue jmp resolution at m_fnAddress failed", ErrorLevel::SEV);
+        return false;
+    }
+
+    // new m_fnAddress
+    m_fnAddress = orig_insts.front().getAddress();
+    Log::log("original function after jump resolution:\n" + instsToStr(orig_insts) + "\n", ErrorLevel::INFO);
+
+    int orig_insts_bytes_len = calcInstsSz(orig_insts);
+
+    Log::log("try to disassemble backwards until we find the previous function end point:\n", ErrorLevel::INFO);
+    insts_t backward_insts = m_disasm.disassemble_backward_until_prev_func_end(m_fnAddress, *this);
+    Log::log("backward until prev function end:\n" + instsToStr(backward_insts) + "\n", ErrorLevel::INFO);
+    if (backward_insts.empty()) {
+        Log::log("Disassembler unable to decode any valid instructions before fnAddress", ErrorLevel::SEV);
+        return false;
+    }
+    int backward_inst_bytes_len = 0;
+    // asserting this area is full of no-op instructions
+    for(const auto& ins : backward_insts)
+    {
+	    if (!ins.getIsNoOp())
+	    {
+            {
+                std::stringstream ss;
+                ss << ins;
+                Log::log("Please determine if '" + ss.str() + "' is a no-op, report to us please", ErrorLevel::SEV);
+                return false;
+            }
+	    }
+        backward_inst_bytes_len += ins.getBytes().size();
+    }
+
+    // check whether we can put short jump in this function
+    if (orig_insts_bytes_len < getShortJmpSize())
+    {
+        Log::log("Original function is too narrow to put short jump", ErrorLevel::SEV);
+        return false;
+    }
+    if (backward_inst_bytes_len < getJmpSize())
+    {
+        Log::log("backward until prev function end is too narrow to put x86 5-byte jump", ErrorLevel::SEV);
+        return false;
+    }
+
+    if (!followJmp(backward_insts)) {
+        Log::log("Prologue jmp resolution at backward_insts failed", ErrorLevel::SEV);
+        return false;
+    }
+	//                        hook point             saved_original_instructions  hook_instructions
+    // 2 bytes short jump -> m_fnAddress             m_originalInstsOnFnAddress  m_hookInstsOnFnAddress  this part is specific to hotpatch
+    // 5 bytes long jump  -> m_addressInAlignArea    m_originalInsts             m_hookInsts             this part using x86Detour logic
+    // m_fnAddress, m_originalInsts and m_hookInsts are not representing the same memory block, we should override all hooking methods
+
+    // set align area address
+    m_addressInAlignArea = backward_insts.front().getAddress();
+    Log::log("m_addressInAlignArea: " + int_to_hex(m_addressInAlignArea) + "\n", ErrorLevel::INFO);
+    
+
+    // --------------- END RECURSIVE JMP RESOLUTION ---------------------
+    
+    uint64_t minProlSzInAlignArea = getJmpSize(); // min size of patches that may split instructions
+    uint64_t roundProlSzInAlignArea = minProlSzInAlignArea; // nearest size to min that doesn't split any instructions
+
+    uint64_t minProlSzOnFnAddress = getShortJmpSize(); // min size of patches that may split instructions
+    uint64_t roundProlSzOnFnAddress = minProlSzOnFnAddress; // nearest size to min that doesn't split any instructions
+    
+    // find the prologue section we will overwrite with jmp + zero or more nops
+    auto prologueOptInAlignArea = calcNearestSzForHotpatch(backward_insts, minProlSzInAlignArea, roundProlSzInAlignArea);
+    if (!prologueOptInAlignArea) {
+        Log::log("instructions in align area is too small to hook safely!", ErrorLevel::SEV);
+        return false;
+    }
+    assert(roundProlSzInAlignArea >= minProlSzInAlignArea);
+    auto prologueInAlignArea = *prologueOptInAlignArea;
+
+    auto prologueOptOnFnAddress = calcNearestSz(orig_insts, minProlSzOnFnAddress, roundProlSzOnFnAddress);
+    if (!prologueOptOnFnAddress) {
+        Log::log("instructions on m_fnAddress is too small to hook safely!", ErrorLevel::SEV);
+        return false;
+    }
+
+    assert(roundProlSzOnFnAddress >= minProlSzOnFnAddress);
+    auto prologueOnFnAddress = *prologueOptOnFnAddress;
+    
+    if (!expandProlSelfJmps(prologueOnFnAddress, orig_insts, minProlSzOnFnAddress, roundProlSzOnFnAddress)) {
+        Log::log("instructions on fn_Address need a prologue jmp table but it's too small to insert one", ErrorLevel::SEV);
+        return false;
+    }
+
+    m_originalInstsOnFnAddress = prologueOnFnAddress;
+    Log::log("Prologue on fnAddress to overwrite with 2 bytes jump:\n" + instsToStr(prologueOnFnAddress) + "\n", ErrorLevel::INFO);
+
+    m_originalInsts = prologueInAlignArea;
+    Log::log("Prologue in align area to overwrite with 5 bytes jump:\n" + instsToStr(prologueInAlignArea) + "\n", ErrorLevel::INFO);
+    
+    // copy all the prologue stuff to trampoline, no need to consider prologue in align area
+    // asserting these instructions are no-op
+    insts_t jmpTblOpt;
+    if (!makeTrampoline(prologueOnFnAddress, jmpTblOpt)) {
+        return false;
+    }
+    Log::log("m_trampoline: " + int_to_hex(m_trampoline) + "\n", ErrorLevel::INFO);
+    Log::log("m_trampolineSz: " + int_to_hex(m_trampolineSz) + "\n", ErrorLevel::INFO);
+    
+    auto tramp_instructions = m_disasm.disassemble(m_trampoline, m_trampoline, m_trampoline + m_trampolineSz, *this);
+    Log::log("Trampoline:\n" + instsToStr(tramp_instructions) + "\n\n", ErrorLevel::INFO);
+    if (!jmpTblOpt.empty()) {
+        Log::log("Trampoline Jmp Tbl:\n" + instsToStr(jmpTblOpt) + "\n\n", ErrorLevel::INFO);
+    }
+    
+    *m_userTrampVar = m_trampoline;
+    m_hookSize = (uint32_t) roundProlSzInAlignArea;
+    m_nopProlOffset = (uint16_t) minProlSzInAlignArea;
+    
+    MemoryProtector prot(m_addressInAlignArea, m_hookSize, ProtFlag::RWX, *this);
+    m_hookInsts = makex86Jmp(m_addressInAlignArea, m_fnCallback);
+    Log::log("Hook instructions in align area:\n" + instsToStr(m_hookInsts) + "\n", ErrorLevel::INFO);
+    ZydisDisassembler::writeEncoding(m_hookInsts, *this);
+    
+    // Nop the space between jmp and end of prologue
+    assert(m_hookSize >= m_nopProlOffset);
+    m_nopSize = (uint16_t) (m_hookSize - m_nopProlOffset);
+    const auto nops = make_nops(m_addressInAlignArea + m_nopProlOffset, m_nopSize);
+    ZydisDisassembler::writeEncoding(nops, *this);
+
+    Log::log("Hook size in align area: " + std::to_string(m_hookSize) + "\n", ErrorLevel::INFO);
+    Log::log("Prologue offset in align area: " + std::to_string(m_nopProlOffset) + "\n", ErrorLevel::INFO);
+
+	// handle the short jump part
+    m_hookSizeOnFnAddress = (uint32_t) roundProlSzOnFnAddress;
+    m_nopProlOffsetOnFnAddress = (uint16_t) minProlSzOnFnAddress;
+
+    MemoryProtector prot_shortjmp(m_fnAddress, m_hookSizeOnFnAddress, ProtFlag::RWX, *this);
+    m_hookInstsOnFnAddress = makex86ShortJmp(m_fnAddress, m_addressInAlignArea);
+    Log::log("Hook instructions on fn_Address:\n" + instsToStr(m_hookInstsOnFnAddress) + "\n", ErrorLevel::INFO);
+    ZydisDisassembler::writeEncoding(m_hookInstsOnFnAddress, *this);
+
+    assert(m_hookSizeOnFnAddress >= m_nopProlOffsetOnFnAddress);
+    m_nopSizeOnFnAddress = (uint16_t)(m_hookSizeOnFnAddress - m_nopProlOffsetOnFnAddress);
+    const auto nopsOnFnAddress = make_nops(m_fnAddress + m_nopProlOffsetOnFnAddress, m_nopSizeOnFnAddress);
+    ZydisDisassembler::writeEncoding(nopsOnFnAddress, *this);
+
+    Log::log("Hook size on fnAddress: " + std::to_string(m_hookSizeOnFnAddress) + "\n", ErrorLevel::INFO);
+    Log::log("Prologue offset on fnAddress: " + std::to_string(m_nopProlOffsetOnFnAddress) + "\n", ErrorLevel::INFO);
+
+    m_hooked = true;
+    return true;
+}
+
+bool x86HotpatchDetour::unHook() {
+    if (!m_hooked) {
+        Log::log("x86HotpatchDetour unhook failed: no hook present", ErrorLevel::SEV);
+        return false;
+    }
+    // restore 2 bytes short jump
+    MemoryProtector prot_short(m_fnAddress, calcInstsSz(m_originalInstsOnFnAddress), ProtFlag::R | ProtFlag::W | ProtFlag::X, *this);
+    ZydisDisassembler::writeEncoding(m_originalInstsOnFnAddress, *this);
+
+    // restore 5 bytes jump
+    MemoryProtector prot(m_addressInAlignArea, calcInstsSz(m_originalInsts), ProtFlag::R | ProtFlag::W | ProtFlag::X, *this);
+    ZydisDisassembler::writeEncoding(m_originalInsts, *this);
+
+    if (m_trampoline != NULL) {
+        delete[](uint8_t*) m_trampoline;
+        m_trampoline = NULL;
+    }
+
+    if (m_userTrampVar != nullptr) {
+        *m_userTrampVar = NULL;
+    }
+
+    m_hooked = false;
+    return true;
+}
+
+bool x86HotpatchDetour::reHook() {
+    MemoryProtector prot(m_addressInAlignArea, m_hookSize, ProtFlag::RWX, *this);
+    ZydisDisassembler::writeEncoding(m_hookInsts, *this);
+
+    // Nop the space between jmp and end of prologue
+    assert(m_hookSize >= m_nopProlOffset);
+    const auto nops = make_nops(m_addressInAlignArea + m_nopProlOffset, m_nopSize);
+    ZydisDisassembler::writeEncoding(nops, *this);
+
+    // handle the short jump part
+
+    MemoryProtector prot_shortjmp(m_fnAddress, m_hookSizeOnFnAddress, ProtFlag::RWX, *this);
+    ZydisDisassembler::writeEncoding(m_hookInstsOnFnAddress, *this);
+
+    assert(m_hookSizeOnFnAddress >= m_nopProlOffsetOnFnAddress);
+    const auto nopsOnFnAddress = make_nops(m_fnAddress + m_nopProlOffsetOnFnAddress, m_nopSizeOnFnAddress);
+    ZydisDisassembler::writeEncoding(nopsOnFnAddress, *this);
+
+    return true;
+}
+
+bool x86HotpatchDetour::makeTrampoline(insts_t& prologue, insts_t& trampolineOut) {
+    assert(!prologue.empty());
+    const uint64_t prolStart = prologue.front().getAddress();
+    const uint16_t prolSz = calcInstsSz(prologue);
+
+    /** Make a guess for the number entries we need so we can try to allocate a trampoline. The allocation
+    address will change each attempt, which changes delta, which changes the number of needed entries. So
+    we just try until we hit that lucky number that works.
+
+    The relocation could also because of data operations too. But that's specific to the function and can't
+    work again on a retry (same function, duh). Return immediately in that case.
+    **/
+    uint8_t neededEntryCount = 5;
+    insts_t instsNeedingEntry;
+    insts_t instsNeedingReloc;
+    insts_t instsNeedingTranslation;
+
+    uint8_t retries = 0;
+    do {
+        if (retries++ > 4) {
+            Log::log("Failed to calculate trampoline information", ErrorLevel::SEV);
+            return false;
+        }
+
+        if (m_trampoline != NULL) {
+            delete[](unsigned char*) m_trampoline;
+            neededEntryCount = (uint8_t)instsNeedingEntry.size();
+        }
+
+        // prol + jmp back to prol + N * jmpEntries
+        m_trampolineSz = (uint16_t)(prolSz + getJmpSize() + getJmpSize() * neededEntryCount);
+        m_trampoline = (uint64_t) new unsigned char[m_trampolineSz];
+
+        const int64_t delta = m_trampoline - prolStart;
+
+        buildRelocationList(prologue, prolSz, delta, instsNeedingEntry, instsNeedingReloc, instsNeedingTranslation);
+    } while (instsNeedingEntry.size() > neededEntryCount);
+
+    const int64_t delta = m_trampoline - prolStart;
+    MemoryProtector prot(m_trampoline, m_trampolineSz, ProtFlag::R | ProtFlag::W | ProtFlag::X, *this, false);
+
+    // Insert jmp from trampoline -> prologue after overwritten section
+    const uint64_t jmpToProlAddr = m_trampoline + prolSz;
+    const auto jmpToProl = makex86Jmp(jmpToProlAddr, prolStart + prolSz);
+    ZydisDisassembler::writeEncoding(jmpToProl, *this);
+
+    const auto makeJmpFn = [=](uint64_t a, Instruction& inst) mutable {
+        // move inst to trampoline and point instruction to entry
+        auto oldDest = inst.getDestination();
+        inst.setAddress(inst.getAddress() + delta);
+        inst.setDestination(a);
+
+        return makex86Jmp(a, oldDest);
+        };
+
+    const uint64_t jmpTblStart = jmpToProlAddr + getJmpSize();
+    trampolineOut = relocateTrampoline(prologue, jmpTblStart, delta, makeJmpFn, instsNeedingReloc, instsNeedingEntry);
+    return true;
+}
+
+}


### PR DESCRIPTION
This implements #202 

This is two level of trampoline, the first level is short jump to the align area between functions, then the next level
put 5-byte jump to user provided callback.

This method requires we recognize consecutive no-op instructions and the end point of the previous function correctly.

It is especially useful to hook empty functions with just 'rep ret'.
You cannot hook them using x86Detour and EATHook doesn't work well on direct call from the lib itself.