### PR TITLE
Pass module name to FindIatThunk

### DIFF
--- a/polyhook2/PE/IatHook.hpp
+++ b/polyhook2/PE/IatHook.hpp
@@ -27,7 +27,7 @@ public:
 		return HookType::IAT;
 	}
 protected:
-	IMAGE_THUNK_DATA* FindIatThunk(const std::string& dllName, const std::string& apiName, const std::wstring moduleName = L"");
+	IMAGE_THUNK_DATA* FindIatThunk(const std::string& dllName, const std::string& apiName, const std::wstring& moduleName = L"");
 	IMAGE_THUNK_DATA* FindIatThunkInModule(void* moduleBase, const std::string& dllName, const std::string& apiName);
 
 	std::string m_dllName;

--- a/sources/IatHook.cpp
+++ b/sources/IatHook.cpp
@@ -15,7 +15,7 @@ PLH::IatHook::IatHook(const std::string& dllName, const std::string& apiName, co
 
 bool PLH::IatHook::hook() {
 	assert(m_userOrigVar != nullptr);
-	IMAGE_THUNK_DATA* pThunk = FindIatThunk(m_dllName, m_apiName);
+	IMAGE_THUNK_DATA* pThunk = FindIatThunk(m_dllName, m_apiName, m_moduleName);
 	if (pThunk == nullptr)
 		return false;
 
@@ -34,7 +34,7 @@ bool PLH::IatHook::unHook() {
 	if (!m_hooked)
 		return false;
 
-	IMAGE_THUNK_DATA* pThunk = FindIatThunk(m_dllName, m_apiName);
+	IMAGE_THUNK_DATA* pThunk = FindIatThunk(m_dllName, m_apiName, m_moduleName);
 	if (pThunk == nullptr)
 		return false;
 
@@ -45,7 +45,7 @@ bool PLH::IatHook::unHook() {
 	return true;
 }
 
-IMAGE_THUNK_DATA* PLH::IatHook::FindIatThunk(const std::string& dllName, const std::string& apiName, const std::wstring moduleName /* = L"" */) {
+IMAGE_THUNK_DATA* PLH::IatHook::FindIatThunk(const std::string& dllName, const std::string& apiName, const std::wstring& moduleName /* = L"" */) {
 #if defined(_WIN64)
 	PEB* peb = (PPEB)__readgsqword(0x60);
 #else


### PR DESCRIPTION
Also made moduleName a reference for good measure, and so clion wouldn't tell me that it's copied.

Apparently this has been unnoticed since 2018 https://github.com/stevemk14ebr/PolyHook_2_0/commit/810068a6b4a8664f590d353b796437255483dc68#diff-00cb1ee7bf12270d7c614126cfdc95d9071053c57453e39d1371a9dca10d4f66