### PR TITLE
Fix/#215

### DIFF
--- a/UnitTests/linux/TestDetourx86.cpp
+++ b/UnitTests/linux/TestDetourx86.cpp
@@ -216,8 +216,6 @@ TEST_CASE("Testing x86 detours", "[x86Detour][ADetour]") {
 		REQUIRE(detour.hook() == true);
 	}
 
-	// TODO: Fix this. when making jmpToProl, relative displacement can only encode offset up to 0x7FFFFFFF
-	//       But during tests, distance between prologue and trampoline was larger than that, leading to incorrect jump.
 	SECTION("hook printf") {
 		PLH::x86Detour detour((uint64_t)&printf, (uint64_t)h_hookPrintf, &hookPrintfTramp);
 		REQUIRE(detour.hook() == true);

--- a/UnitTests/linux/TestDisassembler.cpp
+++ b/UnitTests/linux/TestDisassembler.cpp
@@ -263,7 +263,7 @@ TEMPLATE_TEST_CASE("Test Disassemblers x86 FF25", "[ZydisDisassembler]", PLH::Zy
 	auto Instructions = disasm.disassemble(
 		(uint64_t)x86ASM_FF25.data(),
 		(uint64_t)x86ASM_FF25.data(),
-		(uint64_t)(x86ASM_FF25.data() + address_length),
+		(uint64_t)(jmp_address_ptr + address_length),
 		PLH::MemAccessor()
 	);
 

--- a/UnitTests/windows/TestDetourx64.cpp
+++ b/UnitTests/windows/TestDetourx64.cpp
@@ -9,7 +9,7 @@
 
 #include "polyhook2/PolyHookOsIncludes.hpp"
 
-#include <asmjit/asmjit.h>
+#include <asmjit/x86.h>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/polyhook2/Detour/ADetour.hpp
+++ b/polyhook2/Detour/ADetour.hpp
@@ -65,6 +65,17 @@ public:
 
     void setIsFollowCallOnFnAddress(bool value);
 
+
+    /**
+     * @return instructions of a routine if the provided instruction is a call instruction that calls a routine
+     * which returns an address stored SP register, which refers to the address of the next instruction following
+     * the call instruction. An example routine looks like this (eax could be any general-purpose register):
+     *
+     * 8B 04 24 | mov eax, dword ptr [esp]
+     * C3       | ret
+     */
+    std::optional<insts_t> getRoutineReturningSP(const Instruction& callInst);
+
 protected:
     uint64_t m_fnAddress;
     uint64_t m_fnCallback;

--- a/polyhook2/Detour/ILCallback.hpp
+++ b/polyhook2/Detour/ILCallback.hpp
@@ -2,7 +2,7 @@
 #define POLYHOOK_2_0_ILCALLBACK_HPP
 
 #pragma warning(push, 0)  
-#include <asmjit/asmjit.h>
+#include <asmjit/x86.h>
 #pragma warning( pop )
 
 #pragma warning( disable : 4200)

--- a/polyhook2/Detour/x64Detour.hpp
+++ b/polyhook2/Detour/x64Detour.hpp
@@ -9,10 +9,8 @@
 #include "polyhook2/Detour/ADetour.hpp"
 #include "polyhook2/Enums.hpp"
 #include "polyhook2/Instruction.hpp"
-#include "polyhook2/ZydisDisassembler.hpp"
-#include "polyhook2/ErrorLog.hpp"
 #include "polyhook2/RangeAllocator.hpp"
-#include <asmjit/asmjit.h>
+#include <asmjit/x86.h>
 
 namespace PLH {
 

--- a/polyhook2/Detour/x86Detour.hpp
+++ b/polyhook2/Detour/x86Detour.hpp
@@ -7,9 +7,6 @@
 #include "polyhook2/Detour/ADetour.hpp"
 #include "polyhook2/Enums.hpp"
 #include "polyhook2/Instruction.hpp"
-#include "polyhook2/ZydisDisassembler.hpp"
-#include "polyhook2/ErrorLog.hpp"
-#include "polyhook2/MemProtector.hpp"
 
 using namespace std::placeholders;
 
@@ -26,6 +23,8 @@ public:
     Mode getArchType() const override;
 
 protected:
+    void fixSpecialCases(insts_t& prologue);
+
     bool makeTrampoline(insts_t& prologue, insts_t& trampolineOut);
 };
 

--- a/polyhook2/Instruction.hpp
+++ b/polyhook2/Instruction.hpp
@@ -137,6 +137,10 @@ public:
 		return m_isRelative;
 	}
 
+    bool isReadingSP() const {
+	    return m_isReadingSP;
+	}
+
 	/**Check if the instruction is a type with valid displacement**/
 	bool hasDisplacement() const {
 		return m_hasDisplacement;
@@ -178,10 +182,15 @@ public:
 		return m_mnemonic + " " + m_opStr;
 	}
 
-    /** Displacement size in bytes **/
-    void setDisplacementSize(uint8_t size){
-        m_dispSize = size;
-    }
+	/**Get parameters**/
+	const std::string& getOperands() const {
+		return m_opStr;
+	}
+
+	/** Displacement size in bytes **/
+	void setDisplacementSize(uint8_t size) {
+		m_dispSize = size;
+	}
 
 	size_t getDispSize() const {
 		return m_dispSize;
@@ -219,6 +228,10 @@ public:
 
 		assert(((uint32_t)getDisplacementOffset()) + dispSz <= m_bytes.size() && dispSz <= sizeof(m_displacement.Absolute));
 		std::memcpy(&m_bytes[getDisplacementOffset()], &m_displacement.Absolute, dispSz);
+	}
+
+	void setReadingSP(const bool isReadingSP) {
+		m_isReadingSP = isReadingSP;
 	}
 
 	long getUID() const {
@@ -326,6 +339,7 @@ private:
 	bool          m_isCalling;       // Does this instruction is of a CALL type.
 	bool		  m_isBranching;     // Does this instruction jmp/call or otherwise change control flow
 	bool          m_isRelative;      // Does the displacement need to be added to the address to retrieve where it points too?
+	bool          m_isReadingSP;    // Does this instruction read *SP in its second operand?
 	bool          m_hasDisplacement; // Does this instruction have the displacement fields filled (only rip/eip relative types are filled)
     bool          m_hasImmediate;    // Does this instruction have the immediate field filled?
 	Displacement  m_displacement;    // Where an instruction points too (valid for jmp + call types, and RIP relative MEM types)
@@ -337,7 +351,8 @@ private:
 	uint8_t       m_dispSize;        // Size of the displacement, in bytes
 
 	std::vector<uint8_t> m_bytes;    // All the raw bytes of this instruction
-	std::vector<OperandType> m_operands; // Types of all instruction operands
+	std::vector<OperandType>
+	m_operands; // Types of all instruction operands
 	std::string          m_mnemonic;
 	std::string          m_opStr;
 

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -286,7 +286,6 @@ std::optional<insts_t> Detour::getRoutineReturningSP(const Instruction& callInst
     }
 
     if (
-        routine.size() == 2 &&
         routine[0].getMnemonic() == "mov" && routine[0].hasRegister() && routine[0].isReadingSP() &&
         routine[1].getMnemonic() == "ret"
     ) {

--- a/sources/ADetour.cpp
+++ b/sources/ADetour.cpp
@@ -281,11 +281,9 @@ std::optional<insts_t> Detour::getRoutineReturningSP(const Instruction& callInst
 
     const uint64_t routineAddress = callInst.getRelativeDestination();
     const insts_t routine = m_disasm.disassemble(routineAddress, routineAddress, routineAddress + 4, *this);
-    if (routine.size() != 2) {
-        return std::nullopt;
-    }
 
     if (
+        routine.size() == 2 &&
         routine[0].getMnemonic() == "mov" && routine[0].hasRegister() && routine[0].isReadingSP() &&
         routine[1].getMnemonic() == "ret"
     ) {

--- a/sources/ZydisDisassembler.cpp
+++ b/sources/ZydisDisassembler.cpp
@@ -40,7 +40,7 @@ PLH::insts_t PLH::ZydisDisassembler::disassemble(
 	insts_t insVec;
 //	m_branchMap.clear();
 
-	uint64_t size = end - start;
+	int64_t size = end - start;
 	assert(size > 0);
 	if (size <= 0) {
 		return insVec;
@@ -139,7 +139,13 @@ void PLH::ZydisDisassembler::setDisplacementFields(PLH::Instruction& inst, const
 			}
 			case ZYDIS_OPERAND_TYPE_UNUSED:
 				break;
-			case ZYDIS_OPERAND_TYPE_MEMORY: { // Relative to RIP/EIP
+			case ZYDIS_OPERAND_TYPE_MEMORY: {
+				if (i == 1 && operand->mem.base == ZYDIS_REGISTER_ESP) {
+					inst.setReadingSP(true);
+					break;
+				}
+
+				// Relative to RIP/EIP
 				inst.addOperandType(Instruction::OperandType::Displacement);
 
 				if (zydisInst->attributes & ZYDIS_ATTRIB_IS_RELATIVE) {

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -29,7 +29,7 @@ void x86Detour::fixSpecialCases(insts_t& prologue) {
     for (auto& instruction: prologue) {
         if (const auto routine = getRoutineReturningSP(instruction)) {
             Log::log(
-                "Fixing special case [call to routine reading esp ]:\n" + instsToStr(std::vector{instruction}),
+                "Fixing special case [call to routine returning ESP]:\n" + instsToStr(std::vector{instruction}),
                 ErrorLevel::INFO
             );
 

--- a/sources/x86Detour.cpp
+++ b/sources/x86Detour.cpp
@@ -28,7 +28,10 @@ uint8_t getJmpSize() {
 void x86Detour::fixSpecialCases(insts_t& prologue) {
     for (auto& instruction: prologue) {
         if (const auto routine = getRoutineReturningSP(instruction)) {
-            Log::log("Fixing special case #215:\n" + instsToStr(std::vector{instruction}), ErrorLevel::INFO);
+            Log::log(
+                "Fixing special case [call to routine reading esp ]:\n" + instsToStr(std::vector{instruction}),
+                ErrorLevel::INFO
+            );
 
             // Fix for https://github.com/stevemk14ebr/PolyHook_2_0/issues/215
             // Example routine(eax could be any register):


### PR DESCRIPTION
This PR mainly fixes #215, a small bug in the disassembler tests and asmjit warnings.

## Fix for #215

The fix consists of:
1. Recognizing the call to a routine that returns dereferenced ESP value (i.e. next instruction after call).
2. Replacing such call instructions with `mov reg, imm32` where:
   - `reg` is the destination register. In real Linux binaries I found out that it can be any GP register, not just `eax`
   - `imm32` is the original address of the instruction that follows `call` instruction.

I like this approach because it doesn't involve allocating any new global memory. In fact it even makes the hooked function code a bit more performant since instead of 3 instructions (call, mov, ret) CPU will execute just 1 (mov).

Furthermore, sometimes the first instruction we might see in a function is precisely this *call to routine reading SP*. Hence I also modified the `followJmp` function to ignore such first calls, since it would be replaced soon-after.

Thanks to this fix, the `build-and-test (ubuntu-latest, Debug, 32, clang)` CI is now passing successfully. However, the `build-and-test (ubuntu-latest, **Release**, 32, clang)` is failing due to another issue that is similar in nature, but not the exactly same. I will create another issue detailing it and submit a corresponding PR to fix it once this PR has been approved.

## Fix `TestDisassembler`

Just a minor bug in calculating byte range to disassemble.

## Fix asmjit warnings

The `asmjit/ashmjit.j` header got deprecated, and every build was print this warning. I replaced it with `asmjit/x86.h` to resolve this warning since Polyhook2 supports only x86/x86_64 architecture.

There are other constant build warnings related to implicit conversion of types, which is not ideal since such conversion might differ depending on the compiler. These warnings will need to be addressed in a future PR as well.
