### PR TITLE
Fix dynamic_cast crash caused by missing RTTI prefix in cloned vtable

### DIFF
--- a/polyhook2/Virtuals/VTableSwapHook.hpp
+++ b/polyhook2/Virtuals/VTableSwapHook.hpp
@@ -10,11 +10,23 @@ namespace PLH {
 
 typedef std::map<uint16_t, uint64_t> VFuncMap;
 
+enum class VTableRTTIMode {
+    None,       // no prefix (e.g. -fno-rtti, manually built vtable)
+    MSVC,       // 1 entry: RTTI Complete Object Locator
+    Itanium,    // 2 entries: offset-to-top + type_info* (GCC/Clang)
+
+#if defined(_MSC_VER)
+    Default = MSVC,
+#else
+    Default = Itanium,
+#endif
+};
+
 class VTableSwapHook : public PLH::IHook {
 public:
-	VTableSwapHook(const uint64_t Class, VFuncMap* origVFuncs);
-	VTableSwapHook(const uint64_t Class, const VFuncMap& redirectMap, VFuncMap* origVFuncs);
-	VTableSwapHook(const char* Class, const VFuncMap& redirectMap, VFuncMap* origVFuncs);
+	VTableSwapHook(const uint64_t Class, VFuncMap* origVFuncs, VTableRTTIMode rttiMode = VTableRTTIMode::Default);
+	VTableSwapHook(const uint64_t Class, const VFuncMap& redirectMap, VFuncMap* origVFuncs, VTableRTTIMode rttiMode = VTableRTTIMode::Default);
+	VTableSwapHook(const char* Class, const VFuncMap& redirectMap, VFuncMap* origVFuncs, VTableRTTIMode rttiMode = VTableRTTIMode::Default);
 
 	virtual ~VTableSwapHook() {
 		if (m_hooked) {
@@ -36,6 +48,7 @@ protected:
 	uint64_t  m_class;
 
 	uint16_t  m_vFuncCount;
+	VTableRTTIMode  m_rttiMode;
 
 	// index -> ptr val 
 	VFuncMap m_redirectMap;

--- a/sources/VTableSwapHook.cpp
+++ b/sources/VTableSwapHook.cpp
@@ -18,6 +18,13 @@ PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, const VFuncMap& redire
 	, m_userOrigMap(userOrigMap)
 {}
 
+// Platform prefix sizes (in pointer-width units)
+#if defined(POLYHOOK2_OS_WINDOWS)
+	static constexpr size_t VTABLE_PREFIX_ENTRIES = 1;  // RTTI Complete Object Locator
+#else
+	static constexpr size_t VTABLE_PREFIX_ENTRIES = 2;  // offset-to-top + type_info*
+#endif
+
 bool PLH::VTableSwapHook::hook() {
 	assert(m_userOrigMap != nullptr);
 	assert(!m_hooked);
@@ -36,10 +43,16 @@ bool PLH::VTableSwapHook::hook() {
 		return false;
 	}
 
-	m_newVtable.reset(new uintptr_t[m_vFuncCount]);
+	// +PREFIX_ENTRIES to include RTTI data before the function pointers
+	const size_t totalEntries = m_vFuncCount + VTABLE_PREFIX_ENTRIES;
+	m_newVtable.reset(new uintptr_t[totalEntries]);
 
-	// deep copy orig vtable into new
-	memcpy(m_newVtable.get(), m_origVtable, sizeof(uintptr_t) * m_vFuncCount);
+	// Copy including the RTTI prefix
+	uintptr_t* srcBase = m_origVtable - VTABLE_PREFIX_ENTRIES;
+	memcpy(m_newVtable.get(), srcBase, sizeof(uintptr_t) * totalEntries);
+
+	// The vtable pointer the class stores must point PAST the prefix
+	uintptr_t* newVtableStart = m_newVtable.get() + VTABLE_PREFIX_ENTRIES;
 
 	for (const auto& p : m_redirectMap) {
 		assert(p.first < m_vFuncCount);
@@ -51,11 +64,11 @@ bool PLH::VTableSwapHook::hook() {
 		}
 
 		// redirect ptr at VTable[i]
-		(*m_userOrigMap)[p.first] = (uint64_t)m_newVtable[p.first];
-		m_newVtable[p.first] = (uintptr_t)p.second;
+		(*m_userOrigMap)[p.first] = (uint64_t)newVtableStart[p.first];
+		newVtableStart[p.first] = (uintptr_t)p.second;
 	}
 
-	*(uint64_t**)m_class = (uint64_t*)m_newVtable.get();
+	*(uint64_t**)m_class = (uint64_t*)newVtableStart;
 	m_hooked = true;
 	Log::log("vtable hooked", ErrorLevel::INFO);
 	return true;

--- a/sources/VTableSwapHook.cpp
+++ b/sources/VTableSwapHook.cpp
@@ -19,10 +19,10 @@ PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, const VFuncMap& redire
 {}
 
 // Platform prefix sizes (in pointer-width units)
-#if defined(POLYHOOK2_OS_WINDOWS)
-	static constexpr size_t VTABLE_PREFIX_ENTRIES = 1;  // RTTI Complete Object Locator
+#if defined(_MSC_VER)
+	static constexpr size_t VTABLE_PREFIX_ENTRIES = 1;  // RTTI Complete Object Locator (MSVC ABI)
 #else
-	static constexpr size_t VTABLE_PREFIX_ENTRIES = 2;  // offset-to-top + type_info*
+	static constexpr size_t VTABLE_PREFIX_ENTRIES = 2;  // offset-to-top + type_info* (Itanium ABI)
 #endif
 
 bool PLH::VTableSwapHook::hook() {

--- a/sources/VTableSwapHook.cpp
+++ b/sources/VTableSwapHook.cpp
@@ -1,29 +1,23 @@
 #include "polyhook2/Virtuals/VTableSwapHook.hpp"
 #include "polyhook2/ErrorLog.hpp"
 
-PLH::VTableSwapHook::VTableSwapHook(const char* Class, const VFuncMap& redirectMap, VFuncMap* userOrigMap)
-	: VTableSwapHook((uint64_t)Class, redirectMap, userOrigMap)
+PLH::VTableSwapHook::VTableSwapHook(const char* Class, const VFuncMap& redirectMap, VFuncMap* userOrigMap, VTableRTTIMode rttiMode)
+	: VTableSwapHook((uint64_t)Class, redirectMap, userOrigMap, rttiMode)
 {}
 
-PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, VFuncMap* userOrigMap)
-	: VTableSwapHook(Class, PLH::VFuncMap{ }, userOrigMap)
+PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, VFuncMap* userOrigMap, VTableRTTIMode rttiMode)
+	: VTableSwapHook(Class, PLH::VFuncMap{ }, userOrigMap, rttiMode)
 {}
 
-PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, const VFuncMap& redirectMap, VFuncMap* userOrigMap)
+PLH::VTableSwapHook::VTableSwapHook(const uint64_t Class, const VFuncMap& redirectMap, VFuncMap* userOrigMap, VTableRTTIMode rttiMode)
 	: m_newVtable(nullptr)
 	, m_origVtable(nullptr)
 	, m_class(Class)
 	, m_vFuncCount(0)
+	, m_rttiMode(rttiMode)
 	, m_redirectMap(redirectMap)
 	, m_userOrigMap(userOrigMap)
 {}
-
-// Platform prefix sizes (in pointer-width units)
-#if defined(_MSC_VER)
-	static constexpr size_t VTABLE_PREFIX_ENTRIES = 1;  // RTTI Complete Object Locator (MSVC ABI)
-#else
-	static constexpr size_t VTABLE_PREFIX_ENTRIES = 2;  // offset-to-top + type_info* (Itanium ABI)
-#endif
 
 bool PLH::VTableSwapHook::hook() {
 	assert(m_userOrigMap != nullptr);
@@ -43,16 +37,18 @@ bool PLH::VTableSwapHook::hook() {
 		return false;
 	}
 
+    const size_t prefixEntries = static_cast<size_t>(m_rttiMode);
+
 	// +PREFIX_ENTRIES to include RTTI data before the function pointers
-	const size_t totalEntries = m_vFuncCount + VTABLE_PREFIX_ENTRIES;
+	const size_t totalEntries = m_vFuncCount + prefixEntries;
 	m_newVtable.reset(new uintptr_t[totalEntries]);
 
 	// Copy including the RTTI prefix
-	uintptr_t* srcBase = m_origVtable - VTABLE_PREFIX_ENTRIES;
+	uintptr_t* srcBase = m_origVtable - prefixEntries;
 	memcpy(m_newVtable.get(), srcBase, sizeof(uintptr_t) * totalEntries);
 
 	// The vtable pointer the class stores must point PAST the prefix
-	uintptr_t* newVtableStart = m_newVtable.get() + VTABLE_PREFIX_ENTRIES;
+	uintptr_t* newVtableStart = m_newVtable.get() + prefixEntries;
 
 	for (const auto& p : m_redirectMap) {
 		assert(p.first < m_vFuncCount);


### PR DESCRIPTION
### Problem

Using [VTableSwapHook](https://github.com/untrustedmodders/plugify-plugin-polyhook) for overriding virtual methods resulted in process crash whenever a call to dynamic_cast was made on the hook target.

The problem is that vtable pointer in class objects points to *inside* vtable structure. RTTI data, specifically offset-to-top value and/or type_info pointer (on Windows), appears *before* actual function pointers. While the old implementation cloned the pointer array of the original vtable, it didn't copy the prefix part, thus making all the information stored there invalid. This wasn't a problem before, because no calls were being made that would need access to this info. dynamic_cast did.

### Solution

Allocate VTABLE_PREFIX_ENTRIES extra entries at the beginning of the new cloned vtable and do memcpy(origVtable - VTABLE_PREFIX_ENTRIES). The pointer to write into our hook target will be offset past the prefix accordingly, so it matches the standard ABI requirements.

Prefix sizes:
- Linux (Itanium): 2 entries: offset-to-top and type_info
- Windows (MSVC): 1 entry: RTTI Complete Object Locator

### Test

Tested that both dynamic_cast and typeid worked on hooked object after fix both MSVC and GCC 14 builds on Windows and Linux (SteamRT).